### PR TITLE
Integrating gitdata and misc fixes

### DIFF
--- a/doozer
+++ b/doozer
@@ -10,7 +10,7 @@ from doozerlib.config import MetaDataConfig as mdc
 from doozerlib.config import valid_updates
 from doozerlib import cli_opts
 from doozerlib.exceptions import DoozerFatalError
-from doozerlib.util import green_prefix, red_prefix, green_print, red_print
+from doozerlib.util import green_prefix, red_prefix, green_print, red_print, yellow_print, yellow_prefix
 import datetime
 import click
 import os
@@ -73,6 +73,13 @@ def cli(ctx, **kwargs):
                            template=cli_opts.CLI_CONFIG_TEMPLATE,
                            envvars=cli_opts.CLI_ENV_VARS,
                            cli_args=kwargs)
+    if cli_opts.config_is_empty(cfg.full_path):
+        msg = (
+            "It appears you may be using Doozer for the first time.\n"
+            "Be sure to setup Doozer using the user config file:\n"
+            "{}\n"
+        ).format(cfg.full_path)
+        yellow_print(msg)
     ctx.obj = Runtime(cfg_obj=cfg, **cfg.to_dict())
 
 
@@ -1065,7 +1072,6 @@ def config_commit(runtime, message, push):
     _fix_runtime_mode(runtime)
     runtime.initialize(no_group=True, **CONFIG_RUNTIME_OPTS)
     config = mdc(runtime)
-    config.sanitize_new_config()
     config.commit(message)
     if push:
         config.push()
@@ -1082,6 +1088,18 @@ def config_push(runtime):
     runtime.initialize(no_group=True, **CONFIG_RUNTIME_OPTS)
     config = mdc(runtime)
     config.push()
+
+
+@cli.command("config:get", short_help="Pull latest config data into working directory")
+@pass_runtime
+def config_get(runtime):
+    """
+    Pull latest config data into working directory.
+    This function exists as a convenience for working with the
+    config manually.
+    """
+    _fix_runtime_mode(runtime)
+    runtime.initialize(no_group=False, **CONFIG_RUNTIME_OPTS)
 
 
 @cli.command("config:update-mode", short_help="Update config(s) mode. enabled|disabled|wip")
@@ -1162,38 +1180,6 @@ def config_print(runtime, key, name_only):
     runtime.initialize(**CONFIG_RUNTIME_OPTS)
     config = mdc(runtime)
     config.config_print(key, name_only)
-
-
-@cli.command("config:new", short_help="Add new config. Follow up with config:commit")
-@click.argument("new_type", nargs=1, metavar="TYPE", type=click.Choice(['image', 'rpm']))
-@click.argument("name", nargs=1, metavar="NAME")
-@pass_runtime
-def config_new(runtime, new_type, name):
-    """Copy a TYPE kind of template config (one of 'image' or 'rpm') into correct place naming the
-    new component config after NAME. Report that new config file path
-    for later editing.
-
-    Filtering of configs is based on usage of the following global options:
-    --group, --images/-i, --rpms/-r
-
-    See `oit.py --help` for more.
-
-    Examples:
-
-    Add a new 'image' TYPE of config with the NAME 'megafrobber'
-
-        $ oit.py --group=openshift-4.0 config:new image megafrobber
-
-    Commit that new change to git:
-
-        $ oit.py --group=openshift-4.0 config:commit
-    """
-
-    runtime.initialize(**CONFIG_RUNTIME_OPTS)
-    config = mdc(runtime)
-    config.new(new_type, name)
-
-    click.echo('Remember to use config:commit after the new config is complete')
 
 
 def main():

--- a/doozerlib/cli_opts.py
+++ b/doozerlib/cli_opts.py
@@ -1,7 +1,7 @@
 CLI_OPTS = {
     'data_path': {
         'env': 'DOOZER_DATA_PATH',
-        'help': 'Git URL or File Path to build data'
+        'help': 'Git URL or File Path to build data',
     },
     'group': {
         'env': 'DOOZER_GROUP',
@@ -20,3 +20,9 @@ CLI_OPTS = {
 CLI_ENV_VARS = {k: v['env'] for (k, v) in CLI_OPTS.iteritems()}
 
 CLI_CONFIG_TEMPLATE = '\n'.join(['#{}\n{}:\n'.format(v['help'], k) for (k, v) in CLI_OPTS.iteritems()])
+
+
+def config_is_empty(path):
+    with open(path, 'r') as f:
+        cfg = f.read()
+        return (cfg == CLI_CONFIG_TEMPLATE)

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -43,8 +43,8 @@ YUM_NON_FLAGS = [
 
 class ImageMetadata(Metadata):
 
-    def __init__(self, runtime, base_dir, config_filename):
-        super(ImageMetadata, self).__init__('image', runtime, base_dir, config_filename)
+    def __init__(self, runtime, data_obj):
+        super(ImageMetadata, self).__init__('image', runtime, data_obj)
         self.image_name = self.config.name
 
     @property

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -44,20 +44,18 @@ CONFIG_MODE_DEFAULT = CONFIG_MODES[0]
 
 
 class Metadata(object):
-    def __init__(self, meta_type, runtime, base_dir, config_filename):
+    def __init__(self, meta_type, runtime, data_obj):
         """
         :param: meta_type - a string. Index to the sub-class <'rpm'|'image'>.
         :param: runtime - a Runtime object.
         :param: name - a filename to load as metadata
         """
-
         self.meta_type = meta_type
         self.runtime = runtime
-        self.base_dir = base_dir
-        self.config_filename = config_filename
-        self.full_config_path = os.path.join(self.base_dir, self.config_filename)
-        base_dirs = base_dir.split('/')
-        self.in_group_config_path = base_dirs[-1] + '/' + self.config_filename
+        self.data_obj = data_obj
+        self.base_dir = data_obj.base_dir
+        self.config_filename = data_obj.filename
+        self.full_config_path = data_obj.path
 
         # Some config filenames have suffixes to avoid name collisions; strip off the suffix to find the real
         # distgit repo name (which must be combined with the distgit namespace).
@@ -65,18 +63,12 @@ class Metadata(object):
         #      distgit_key=openshift-enterprise-mediawiki.apb
         #      name (repo name)=openshift-enterprise-mediawiki
 
-        self.distgit_key = config_filename.rsplit('.', 1)[0]  # Split off .yml
+        self.distgit_key = data_obj.key
         self.name = self.distgit_key.split('.')[0]   # Split off any '.apb' style differentiator (if present)
 
-        self.runtime.logger.debug("Loading metadata from {}".format(self.config_filename))
+        self.runtime.logger.debug("Loading metadata from {}".format(self.full_config_path))
 
-        assertion.isfile(os.path.join(os.getcwd(), self.config_filename),
-                         "Unable to find configuration file")
-
-        with open(self.full_config_path, "r") as f:
-            config_yml_content = f.read()
-
-        self.config = Model(yaml.load(config_yml_content))
+        self.config = Model(data_obj.data)
 
         self.mode = self.config.get('mode', CONFIG_MODE_DEFAULT).lower()
         if self.mode not in CONFIG_MODES:
@@ -109,8 +101,7 @@ class Metadata(object):
         self._distgit_repo = None
 
     def save(self):
-        with open(self.full_config_path, "w") as f:
-            yaml.safe_dump(self.config.primitive(), f, default_flow_style=False)
+        self.data_obj.save()
 
     def distgit_repo(self):
         if self._distgit_repo is None:

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -27,8 +27,8 @@ remote_git_name = {name}
 
 class RPMMetadata(Metadata):
 
-    def __init__(self, runtime, base_dir, config_filename, clone_source=True):
-        super(RPMMetadata, self).__init__('rpm', runtime, base_dir, config_filename)
+    def __init__(self, runtime, data_obj, clone_source=True):
+        super(RPMMetadata, self).__init__('rpm', runtime, data_obj)
 
         self.source = self.config.content.source
         if self.source is Missing:

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -7,21 +7,32 @@ messages"""
     click.secho(msg, nl=False, bold=True, fg='red')
 
 
-def green_prefix(msg):
-    """Print out a message prefix in bold green letters, like for "Success: "
-messages"""
-    click.secho(msg, nl=False, bold=True, fg='green')
-
-
 def red_print(msg):
     """Print out a message in red text"
 messages"""
     click.secho(msg, nl=True, bold=False, fg='red')
 
 
+def green_prefix(msg):
+    """Print out a message prefix in bold green letters, like for "Success: "
+messages"""
+    click.secho(msg, nl=False, bold=True, fg='green')
+
+
 def green_print(msg):
     """Print out a message in green text"""
     click.secho(msg, nl=True, bold=False, fg='green')
+
+
+def yellow_prefix(msg):
+    """Print out a message prefix in bold yellow letters, like for "Success: "
+messages"""
+    click.secho(msg, nl=False, bold=True, fg='yellow')
+
+
+def yellow_print(msg):
+    """Print out a message in yellow text"""
+    click.secho(msg, nl=True, bold=False, fg='yellow')
 
 
 def cprint(msg):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests_kerberos
 koji
 bashlex
 pydotconfig
+pygitdata


### PR DESCRIPTION
@tbielawa @sosiouxme @smunilla @joeldavis84 
Another kinda hefty change.
Setting up for being able to have ocp-build-data be branched (which I've already tested works with a 2 line change, currently commented out with note).
This mainly streamlines the data loading a lot making it easier for Elliott to use the same base data load code but eventually do away with runtime entirely. (Really elliott only needs the name from the yaml)
Also made a bunch of small fixes.
And I removed `config:new` because it really was problematic as a workflow. I added `config:get` instead so that there's a one-off for "give me the latest config local", which you can then edit and use `config:push` to update.