### PR TITLE
Moving sources to object files

### DIFF
--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -53,7 +53,7 @@ def watch_task(log_f, task_id, terminate_event):
     end = time.time() + 4 * 60 * 60
     watcher = koji_cli.lib.TaskWatcher(
         task_id,
-        koji.ClientSession(constants.BREW_HUB),
+        koji.ClientSession(constants.BREW_HUB, opts={'serverca': '/etc/pki/brew/legacy.crt'}),
         quiet=True)
     error = None
     except_count = 0
@@ -114,6 +114,7 @@ def get_brew_build(nvr, product_version='', session=None):
                           auth=HTTPKerberosAuth())
     else:
         res = requests.get(constants.errata_get_build_url.format(id=nvr),
+                           verify=ssl.get_default_verify_paths().openssl_cafile,
                            auth=HTTPKerberosAuth())
     if res.status_code == 200:
         return Build(nvr=nvr, body=res.json(), product_version=product_version)

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -154,12 +154,8 @@ class DistGitRepo(object):
         """
         :return: Returns the directory containing the source which should be used to populate distgit.
         """
-        alias = self.config.content.source.alias
 
-        if alias is Missing:
-            raise IOError("Can't find any source alias in config: %s" % self.metadata.config_filename)
-
-        source_root = self.runtime.resolve_source(alias)
+        source_root = self.runtime.resolve_source(self.name, self.config.content.source)
         sub_path = self.config.content.source.path
 
         path = source_root

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -42,8 +42,8 @@ class RPMMetadata(Metadata):
         self.build_status = False
 
         if clone_source:
-            self.source_path = self.runtime.resolve_source(self.source.alias)
-            self.source_head = self.runtime.resolve_source_head(self.source.alias)
+            self.source_path = self.runtime.resolve_source('rpm_{}'.format(self.rpm_name), self.source)
+            self.source_head = self.runtime.resolve_source_head('rpm_{}'.format(self.rpm_name), self.source)
             if self.source.specfile:
                 self.specfile = os.path.join(self.source_path, self.source.specfile)
                 if not os.path.isfile(self.specfile):

--- a/doozerlib/rpmcfg_test.py
+++ b/doozerlib/rpmcfg_test.py
@@ -28,7 +28,7 @@ class MockRuntime(object):
         self.tmpdir = tmpdir
         self.logger = logger
 
-    def resolve_source(self, alias):
+    def resolve_source(self, parent, source):
         return self.tmpdir
 
 

--- a/doozerlib/schema_image.yml
+++ b/doozerlib/schema_image.yml
@@ -54,8 +54,25 @@ mapping:
         type: map
         mapping:
           "alias":
-            required: true
+            required: false
             type: str
+          "git":
+            type: map
+            mapping:
+              "url":
+                required: true
+                type: str
+              "branch":
+                required: true
+                type: map
+                mapping:
+                  "target":
+                    required: true
+                    type: str
+                  "fallback":
+                    type: str
+                  "stage":
+                    type: str
           "dockerfile":
             type: str
           "path":

--- a/doozerlib/schema_rpm.yml
+++ b/doozerlib/schema_rpm.yml
@@ -16,6 +16,23 @@ mapping:
           "alias":
             required: true
             type: str
+          "git":
+            type: map
+            mapping:
+              "url":
+                required: true
+                type: str
+              "branch":
+                required: true
+                type: map
+                mapping:
+                  "target":
+                    required: true
+                    type: str
+                  "fallback":
+                    type: str
+                  "stage":
+                    type: str
           "specfile":
             type: str
           "path":


### PR DESCRIPTION
Note: This will not work until ocp-build-data has been updated!

Source info is now in the image/rpm config yaml files instead of group.yml, *however* this is fully backward compatible with the old way. I tested with current ocp-build-data and a private fork with modified yaml files.
The breaking change though is that this now requires ocp-build-data to use branches instead of sub-dirs. I already have this move scripted out 100% and have tested it multiple times.

This also means that sources are now cloned on a per-image basis. Meaning there could be one repo cloned more than once. All images that build from ose still use the alias given with `--source ose <foo>` (that backward compatibility working it's magic).