### PR TITLE
distgit builds: analyze logs ART-392 ART-366

### DIFF
--- a/doozerlib/distgit_test.py
+++ b/doozerlib/distgit_test.py
@@ -6,6 +6,9 @@ import unittest
 
 import StringIO
 import logging
+import tempfile
+import shutil
+import re
 
 import distgit
 
@@ -30,9 +33,16 @@ class MockMetadata(object):
     def __init__(self, runtime):
         self.config = MockConfig()
         self.runtime = runtime
+        self.logger = runtime.logger
         self.name = "test"
         self.namespace = "namespace"
         self.distgit_key = "distgit_key"
+        
+class MockScanner(object):
+
+    def __init__(self):
+        self.matches = []
+        self.files = []
 
 
 class TestDistgit(unittest.TestCase):
@@ -47,6 +57,7 @@ class TestDistgit(unittest.TestCase):
         self.stream = StringIO.StringIO()
         logging.basicConfig(level=logging.DEBUG, stream=self.stream)
         self.logger = logging.getLogger()
+        self.logs_dir = tempfile.mkdtemp()
 
     def tearDown(self):
         """
@@ -54,10 +65,11 @@ class TestDistgit(unittest.TestCase):
         """
         logging.shutdown()
         reload(logging)
+        shutil.rmtree(self.logs_dir)
 
     def test_init(self):
         """
-        Ensure that pull_image logs properly
+        Ensure that init creates the object expected
         """
         md = MockMetadata(MockRuntime(self.logger))
         d = distgit.DistGitRepo(md, autoclone=False)
@@ -66,24 +78,65 @@ class TestDistgit(unittest.TestCase):
 
     def test_logging(self):
         """
-        Ensure that pull_image logs properly
+        Ensure that logs work
         """
         md = MockMetadata(MockRuntime(self.logger))
         d = distgit.DistGitRepo(md, autoclone=False)
 
-        d.logger.info("Hey there!")
+        msg = "Hey there!"
+        d.logger.info(msg)
 
-        expected = "INFO:[namespace/distgit_key]:Hey there!\n"
         actual = self.stream.getvalue()
 
-        self.assertEquals(actual, expected)
+        self.assertIn(msg, actual)
 
-    
-    def test_pull_image_logging(self):
-        """
-        Ensure that pull_image logs properly
-        """
-        self.skipTest("test not implemented")
+    def test_detect_permanent_build_failures(self):
+        md = MockMetadata(MockRuntime(self.logger))
+        d = distgit.ImageDistGitRepo(md, autoclone=False)
+
+        d._logs_dir = lambda: self.logs_dir
+        task_dir = tempfile.mkdtemp(dir=self.logs_dir)
+        with open(task_dir + "/x86_64.log", "w") as file:
+            msg1 = "No package fubar available"
+            file.write(msg1)
+        with open(task_dir + "/task_failed.log", "w") as file:
+            msg2 = "Failed component comparison for components: fubar"
+            file.write(msg2)
+
+        scanner = MockScanner()
+        scanner.matches = [
+            # note: we read log lines, so these can only match in a single line
+            re.compile("No package .* available"),
+            re.compile("Failed component comparison for components:.*"),
+        ]
+        scanner.files = [ "x86_64.log", "task_failed.log" ]
+        fails = d._detect_permanent_build_failures(scanner)
+        self.assertIn(msg1, fails)
+        self.assertIn(msg2, fails)
+
+    def test_detect_permanent_build_failures_borkage(self):
+        md = MockMetadata(MockRuntime(self.logger))
+        d = distgit.ImageDistGitRepo(md, autoclone=False)
+
+        scanner = MockScanner()
+        scanner.matches = []
+        scanner.files = [ "x86_64.log", "task_failed.log" ]
+
+        self.assertIsNone(d._detect_permanent_build_failures(scanner))
+        output = self.stream.getvalue()
+        self.assertIn("Log file scanning not specified", output)
+
+        scanner.matches.append(None)
+
+        d._logs_dir = lambda: self.logs_dir  # search an empty log dir
+        self.assertIsNone(d._detect_permanent_build_failures(scanner))
+        output = self.stream.getvalue()
+        self.assertIn("No task logs found under", output)
+
+        d._logs_dir = lambda: str(tempfile.TemporaryFile())  # search a dir that won't be there
+        self.assertIsNone(d._detect_permanent_build_failures(scanner))
+        output = self.stream.getvalue()
+        self.assertIn("Exception while trying to analyze build logs", output)
 
         
 if __name__ == "__main__":

--- a/doozerlib/model.py
+++ b/doozerlib/model.py
@@ -47,6 +47,9 @@ class MissingModel(dict):
     def __delitem__(self, key):
         raise ModelException("Invalid attempt to delete key(%s) in missing branch of model" % key)
 
+    def __bool__(self):
+        return False
+
     def __str__(self):
         return "(MissingModel)"
 

--- a/doozerlib/schema_group.yml
+++ b/doozerlib/schema_group.yml
@@ -99,3 +99,18 @@ mapping:
               "=":
                 type: str
 
+  "image_build_log_scanner":
+    type: map
+    mapping:
+      "matches":
+        # regexen to detect problems in log lines
+        required: true
+        type: seq
+        sequence:
+          - type: str
+      "files":
+        # names of log files to examine
+        required: true
+        type: seq
+        sequence:
+          - type: str


### PR DESCRIPTION
check build logs for package install failures and multiarch component
mismatches.

ART-392 Fail faster on known build problems
When build logs indicate failures that we recognize and don't expect to
be solved by retries, the build is not retried.

ART-366 Detect missing RPMs in build logs
Even for successful builds, the logs are checked for problems. At this
time, that's just packages that didn't actually install, but could
expand.

Here these checks look for the same problems. If it becomes
necessary then there could easily be two separate problem lists.