### PR TITLE
add ability to scan sources for updates

### DIFF
--- a/doozer
+++ b/doozer
@@ -392,6 +392,36 @@ def images_verify(runtime, image, no_pull, repo_type, **kwargs):
     exit(failed_images_count)
 
 
+@cli.command("config:scan-sources", short_help="Determine if source repo differs from distgit content")
+@click.option("--yaml", "as_yaml", default=False, is_flag=True, help='Print results in a yaml block')
+@pass_runtime
+def config_scan_source_changes(runtime, as_yaml):
+    """
+    Determine if source repo differs from distgit content, according to source git hash.
+    May be used for images and/or rpms.
+    Print a list of configs that were scanned and whether the source differs from the distgit.
+    """
+    _fix_runtime_mode(runtime)
+    runtime.initialize(**CONFIG_RUNTIME_OPTS)
+    results = dict(rpms=[], images=[])
+    for meta, matches in runtime.scan_distgit_sources():
+        results['rpms' if meta.meta_type == 'rpm' else 'images'].append(
+            dict(name=meta.distgit_key, changed=not matches)
+        )
+
+    if as_yaml:
+        print '---'
+        print yaml.safe_dump(results, indent=4)
+        return
+
+    for kind, items in results.items():
+        if not items:
+            continue
+        print kind.upper() + ":"
+        for item in items:
+            print '  {} is {}'.format(item['name'], 'changed' if item['changed'] else 'the same')
+
+
 @cli.command("images:rebase", short_help="Refresh a group's distgit content from source content.")
 @click.option("--stream", metavar="ALIAS REPO/NAME:TAG", nargs=2, multiple=True,
               help="Associate an image name with a given stream alias.  [multiple]")

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -20,8 +20,8 @@ import exectools
 from pushd import Dir
 from brew import watch_task, check_rpm_buildroot
 from model import Model, Missing
-from . exceptions import DoozerFatalError
-from . util import yellow_print
+from doozerlib.exceptions import DoozerFatalError
+from doozerlib.util import yellow_print
 
 OIT_COMMENT_PREFIX = '#oit##'
 OIT_BEGIN = '##OIT_BEGIN'

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -219,8 +219,36 @@ class DistGitRepo(object):
             self.logger.info("Adding tag to local repo: {}".format(tag))
             exectools.cmd_gather(["git", "tag", "-f", tag, "-m", tag])
 
+    def matches_source_commit(self):
+        """
+        Check whether the commit that we recorded in the distgit content (according to cgit)
+        matches the commit of the source (according to git ls-remote). Nothing is cloned
+        and no local clones are consulted.
+        Returns: bool
+        """
+        source_details = self.config.content.source.git
+        if source_details is Missing:
+            # no git source configured, so distgit always matches itself
+            return True
+        _, commit_hash = self.runtime.detect_remote_source_branch(dict(source_details))
+        return self._matches_commit(commit_hash) if commit_hash else False
+
 
 class ImageDistGitRepo(DistGitRepo):
+
+    source_labels = dict(
+        old=dict(
+            sha='io.openshift.source-repo-commit',
+            source='io.openshift.source-repo-url',
+            source_commit='io.openshift.source-commit-url',
+        ),
+        now=dict(
+            sha='io.openshift.build.commit.id',
+            source='io.openshift.build.source-location',
+            source_commit='io.openshift.build.commit.url',
+        ),
+    )
+
     def __init__(self, metadata, autoclone=True):
         super(ImageDistGitRepo, self).__init__(metadata, autoclone)
         self.build_lock = Lock()
@@ -1163,26 +1191,19 @@ class ImageDistGitRepo(DistGitRepo):
                     df.write("%s %s\n" % (OIT_COMMENT_PREFIX, comment))
                 df.write(df_content)
 
-            old_sha_label = 'io.openshift.source-repo-commit'
-            old_source_label = 'io.openshift.source-repo-url'
-            old_source_commit_label = 'io.openshift.source-commit-url'
 
-            sha_label = 'io.openshift.build.commit.id'
-            source_label = 'io.openshift.build.source-location'
-            source_commit_label = 'io.openshift.build.commit.url'
-
-            # just always delete so it's either correct or not available
-            for label in (old_sha_label, old_source_label, old_source_commit_label,
-                          sha_label, source_label, source_commit_label):
+            # remove old labels from dist-git
+            for label in self.source_labels['old']:
                 if label in dfp.labels:
                     del dfp.labels[label]
 
+            # set with new source if known, otherwise leave alone for a refresh
+            srclab = self.source_labels['now']
             if self.full_source_sha:
-                dfp.labels[sha_label] = self.full_source_sha
-            if self.source_url:
-                dfp.labels[source_label] = self.source_url
-                if self.full_source_sha:
-                    dfp.labels[source_commit_label] = '{}/commit/{}'.format(self.source_url, self.full_source_sha)
+                dfp.labels[srclab['sha']] = self.full_source_sha
+                if self.source_url:
+                    dfp.labels[srclab['source']] = self.source_url
+                    dfp.labels[srclab['source_commit']] = '{}/commit/{}'.format(self.source_url, self.full_source_sha)
 
             self._reflow_labels()
 
@@ -1425,10 +1446,29 @@ class ImageDistGitRepo(DistGitRepo):
 
         return (real_version, real_release)
 
+    def _matches_commit(self, commit_hash):
+        """
+        Given a source repo git hash, checks to see if the most recent Dockerfile
+        claims that hash as its source via the label.
+        Returns: bool
+        """
+        dfp = DockerfileParser()
+        dfp.cache_content = True  # set after init, or it tries to preload content
+        try:
+            content = self.metadata.fetch_cgit_file("Dockerfile")
+            dfp.cached_content = content.decode('utf-8') if content else None
+        except Exception as e:
+            self.logger.error("failed to retrieve valid Dockerfile to compare: {}".format(e))
+            return False
+
+        df_hash = dfp.labels.get(self.source_labels['now']['sha'])
+        self.logger.debug('Comparing distgit Dockerfile label "%s" to source hash "%s"', df_hash, commit_hash)
+        return commit_hash == df_hash
+
 
 class RPMDistGitRepo(DistGitRepo):
-    def __init__(self, metadata):
-        super(RPMDistGitRepo, self).__init__(metadata)
+    def __init__(self, metadata, autoclone=True):
+        super(RPMDistGitRepo, self).__init__(metadata, autoclone)
         self.source = self.config.content.source
         if self.source.specfile is Missing:
             raise ValueError('Must specify spec file name for RPMs.')
@@ -1437,3 +1477,26 @@ class RPMDistGitRepo(DistGitRepo):
         with Dir(self.distgit_dir):
             # Read in information about the rpm we are about to build
             pass  # placeholder for now. nothing to read
+
+    def _matches_commit(self, commit_hash):
+        """
+        Given a source repo git hash, checks to see if the most recent distgit specfile
+        includes that hash in its Source0
+        Returns: bool
+        """
+        commit_hash = commit_hash[:7]  # we only store the short hash
+        try:
+            specfile = self.source.specfile
+            content = self.metadata.fetch_cgit_file(self.source.specfile)
+        except Exception as e:
+            self.logger.error("failed to retrieve valid specfile '{}' to compare: {}".format(specfile, e))
+            return False
+
+        match = re.search(r'^%global.*OS_GIT_COMMIT=(\w+)', content, re.MULTILINE)
+        if not match:
+            self.logger.error("No OS_GIT_COMMIT found in specfile '{}'".format(specfile))
+            return False
+        srcname = match.group(1)
+
+        self.logger.debug('Looking for source hash %s in distgit source "%s"', commit_hash, srcname)
+        return commit_hash in srcname

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -95,9 +95,9 @@ class Metadata(object):
     def save(self):
         self.data_obj.save()
 
-    def distgit_repo(self):
+    def distgit_repo(self, autoclone=True):
         if self._distgit_repo is None:
-            self._distgit_repo = DISTGIT_TYPES[self.meta_type](self)
+            self._distgit_repo = DISTGIT_TYPES[self.meta_type](self, autoclone=autoclone)
         return self._distgit_repo
 
     def branch(self):

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -8,7 +8,7 @@ from brew import watch_task
 
 from metadata import Metadata
 from model import Missing
-from . exceptions import DoozerFatalError
+from doozerlib.exceptions import DoozerFatalError
 
 RELEASERS_CONF = """
 [aos]

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -828,6 +828,13 @@ class Runtime(object):
         pool.join()
         return ret
 
+    def scan_distgit_sources(self):
+        return self.parallel_exec(
+            lambda m: (m[0], m[0].distgit_repo(autoclone=False).matches_source_commit()),
+            self.image_metas() + self.rpm_metas(),
+            n_threads=100,
+        ).get()
+
     def resolve_metadata(self):
         """
         The group control data can be on a local filesystem, in a git

--- a/doozerlib/runtime_test.py
+++ b/doozerlib/runtime_test.py
@@ -1,12 +1,79 @@
 #!/usr/bin/env python
 import unittest
-from runtime import Runtime
+import flexmock
+import runtime
+import exectools
+import logutil
+
+
+def stub_runtime():
+    return runtime.Runtime(
+        latest_parent_version=False,
+        logger=logutil.getLogger(__name__),
+        stage=False,
+    )
+
+def stub_exectools(assert_response = None):
+
+    def cmd_assert(self, cmd, *_):
+        return assert_response or (None, None)
 
 
 class RuntimeTestCase(unittest.TestCase):
     def test_parallel_exec(self):
-        ret = Runtime._parallel_exec(lambda x: x * 2, xrange(5), n_threads=20)
+        ret = runtime.Runtime._parallel_exec(lambda x: x * 2, xrange(5), n_threads=20)
         self.assertEqual(ret.get(), [0, 2, 4, 6, 8])
+
+    def test_get_remote_branch_ref(self):
+        rt = stub_runtime()
+        flexmock(exectools).should_receive("cmd_assert").once().and_return("spam", "")
+        res = rt._get_remote_branch_ref("giturl", "branch")
+        self.assertEqual(res, "spam")
+
+        flexmock(exectools).should_receive("cmd_assert").once().and_return("", "")
+        self.assertIsNone(rt._get_remote_branch_ref("giturl", "branch"))
+
+        flexmock(exectools).should_receive("cmd_assert").once().and_raise(Exception("whatever"))
+        self.assertIsNone(rt._get_remote_branch_ref("giturl", "branch"))
+
+    def test_detect_remote_source_branch(self):
+        rt = stub_runtime()
+        source_details = dict(
+            url='some_git_repo',
+            branch=dict(
+                target='main_branch',
+                fallback='fallback_branch',
+                stage='stage_branch',
+            ),
+        )
+
+        # got a hit on the first branch
+        flexmock(rt).should_receive("_get_remote_branch_ref").once().and_return("spam")
+        self.assertEqual(("main_branch", "spam"), rt.detect_remote_source_branch(source_details))
+
+        # got a hit on the fallback branch
+        (flexmock(rt).
+            should_receive("_get_remote_branch_ref").
+            and_return(None).
+            and_return("eggs")
+        )
+        self.assertEqual(("fallback_branch", "eggs"), rt.detect_remote_source_branch(source_details))
+
+        # no target or fallback branch
+        flexmock(rt).should_receive("_get_remote_branch_ref").and_return(None)
+        with self.assertRaises(runtime.DoozerFatalError):
+            rt.detect_remote_source_branch(source_details)
+
+        # request stage branch, get it
+        rt.stage = True
+        flexmock(rt).should_receive("_get_remote_branch_ref").once().and_return("spam")
+        self.assertEqual(("stage_branch", "spam"), rt.detect_remote_source_branch(source_details))
+
+        # request stage branch, not there
+        rt.stage = True
+        flexmock(rt).should_receive("_get_remote_branch_ref").once().and_return(None)
+        with self.assertRaises(runtime.DoozerFatalError):
+            rt.detect_remote_source_branch(source_details)
 
 
 if __name__ == "__main__":

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+flexmock


### PR DESCRIPTION
This allows us to determine when upstream sources have a different commit than the one we recorded in distgit, without cloning either. It works on both RPMs and images, and can spit out yaml for our jenkins job to grok. Examples:

```
🐚 doozer -r '' config:scan-sources 
2019-01-29 23:06:33,907 INFO Using branch from group.yml: rhaos-4.0-rhel-7
2019-01-29 23:06:34,233 INFO Checking if target branch release-4.0 exists in git@github.com:openshift/service-catalog.git
2019-01-29 23:06:34,233 INFO Checking if target branch release-4.0 exists in git@github.com:openshift/service-idler.git
2019-01-29 23:06:34,233 INFO Checking if target branch openshift-4.0 exists in git@github.com:openshift/autoheal.git
2019-01-29 23:06:34,740 INFO Target branch does not exist in git@github.com:openshift/autoheal.git, checking fallback branch master
2019-01-29 23:06:34,740 INFO Target branch does not exist in git@github.com:openshift/service-idler.git, checking fallback branch master
2019-01-29 23:06:34,741 INFO Checking if target branch master exists in git@github.com:openshift/autoheal.git
2019-01-29 23:06:34,742 INFO Target branch does not exist in git@github.com:openshift/service-catalog.git, checking fallback branch master
2019-01-29 23:06:34,742 INFO Checking if target branch master exists in git@github.com:openshift/service-idler.git
2019-01-29 23:06:34,744 INFO Checking if target branch master exists in git@github.com:openshift/service-catalog.git
2019-01-29 23:06:35,742 ERROR [rpms/openshift-enterprise-service-idler] No OS_GIT_COMMIT found in specfile 'service-idler.spec'
RPMS:
  openshift-enterprise-service-idler is changed
  openshift-enterprise-service-catalog is the same
  openshift-enterprise-autoheal is the same

🐚 doozer -i openshift-enterprise-console,ose-installer,ose-etcd,logging-fluentd -r '' config:scan-sources --yaml
2019-01-29 23:07:14,528 INFO Using branch from group.yml: rhaos-4.0-rhel-7
[...]
---
images:
- {changed: true, name: openshift-enterprise-console}
- {changed: false, name: ose-etcd}
- {changed: true, name: ose-installer}
- {changed: false, name: logging-fluentd}
rpms:
- {changed: true, name: openshift-enterprise-service-idler}
- {changed: false, name: openshift-enterprise-service-catalog}
- {changed: false, name: openshift-enterprise-autoheal}
```

Some notes:
* Does not pay any attention at all to local checkouts of sources or distgits.
* I considered just naming it something top-level, but it works somewhat similarly to other `config:` commands. Open to suggestions here.
* I thought it might be helpful to have the atomic-openshift RPM definition here, but disabled, so that we could run `doozer -r atomic-openshift config:scan-sources` and know whether we actually needed to rebuild that. I'm not sure if it has value though since we do the merge. Maybe once the merge job is separate?...
* Not all RPM specfiles have the necessary bits to capture the source commit. This is why the ERROR above and results in the source always being counted as "changed".