### PR TITLE
Adding reposync command

### DIFF
--- a/doozer
+++ b/doozer
@@ -21,6 +21,7 @@ import yaml
 import sys
 import subprocess
 import urllib
+import tempfile
 import traceback
 import koji
 from numbers import Number
@@ -1483,13 +1484,80 @@ def release_mirror(runtime, src_dest, image_stream, is_base, pattern):
 
     yellow_prefix("Images skipped due to invalid naming:\n")
     for img in sorted(invalid_name_items):
-	click.echo(" {}".format(img))
-	click.echo()
+        click.echo(" {}".format(img))
+        click.echo()
 
     yellow_prefix("Images skipped due to missing source:\n")
     for img in sorted(missing_source_items):
-	click.echo(" {}".format(img))
-	click.echo()
+        click.echo(" {}".format(img))
+        click.echo()
+
+
+@cli.command("beta:reposync", short_help="Generate .repo file from group data")
+@click.option("-o", "--output", help="Output directory to sync to", required=True)
+@click.option("--repo-type", metavar="REPO_TYPE", envvar="OIT_IMAGES_REPO_TYPE",
+              default="unsigned",
+              help="Repo group type to use for repo file generation (e.g. signed, unsigned).")
+@pass_runtime
+def beta_reposync(runtime, output, repo_type):
+    """Generate a yum.conf compatible file from group data
+    All repos will be disabled in the file.
+
+    See `doozer --help` for more.
+
+    Examples:
+
+    Write unsigned.repo:
+
+        $ doozer --group=openshift-4.0 beta:reposync -o yum.conf --repo-type unsigned
+
+    """
+    runtime.initialize(clone_distgits=False)
+    repos = runtime.repos
+
+    yum_conf = """
+[main]
+cachedir=/tmp/cache/yum/$basearch/$releasever
+keepcache=0
+debuglevel=2
+logfile=/tmp/yum.log
+exactarch=1
+obsoletes=1
+gpgcheck=1
+plugins=1
+installonly_limit=3
+"""
+    optional_fails = []
+
+    try:
+        yc_file = tempfile.NamedTemporaryFile()
+
+        yc_file.write(yum_conf)
+        yc_file.write('\n\n')
+        content = repos.repo_file(repo_type, enabled_repos=None, use_config_name=True)
+        yc_file.write(content)
+
+        # must flush so it can be read
+        yc_file.flush()
+        cmd_base = 'reposync -c {} -p {} --delete -n -r {}'
+
+        for repo in repos.itervalues():
+            color_print('Syncing repo {}'.format(repo.name), 'blue')
+            cmd = cmd_base.format(yc_file.name, output, repo.name)
+            rc, out, err = exectools.cmd_gather(cmd, realtime=True)
+            if rc != 0:
+                if not repo.cs_optional:
+                    raise DoozerFatalError(err)
+                else:
+                    runtime.logger.warning('Failed to sync repo {} but marked as optional: {}'.format(repo.name, err))
+                    optional_fails.append(repo.name)
+    finally:
+        yc_file.close()
+
+    if optional_fails:
+        yellow_print('Completed with the following optional repos skipped due to failure, see log.:\n{}'.format('\n'.join(optional_fails)))
+    else:
+        green_print('All repos synced to {}'.format(output))
 
 
 def main():


### PR DESCRIPTION
@tbielawa @jupierce This is one half of the task of syncing repos. It will sync the entire repo set used by any OCP version to a given local directory. From there the rest of the tasks should be all jenkins-side to sync that up to `use-mirror`.

Note:

- I used the `-n` option which only syncs the newest version of a package in the repo
- I used `--delete` so that it should clear out old packages when resynced
- The above are meant to be used such that the local sync dir is never deleted between syncs to speed up subsequent sync tasks.
- Currently, for 4.0, this results in 24GB and 19,000 packages.