### PR TITLE
Fixing image error name bug

### DIFF
--- a/doozer
+++ b/doozer
@@ -197,7 +197,7 @@ def rpms_build(runtime, version, release, scratch):
             version, release, terminate_event, scratch),
         items)
     results = results.get()
-    failed = [m.distgit_key for m, r in zip(runtime.rpm_metas(), results) if not r]
+    failed = [name for name, r in results if not r]
     if failed:
         runtime.logger.error("\n".join(["Build/push failures:"] + sorted(failed)))
         exit(1)
@@ -812,7 +812,7 @@ def images_build_image(runtime, odcs, repo_type, repo, push_to_defaults, push_to
             traceback.print_exc()
             runtime.logger.error("Error trying to show build metrics")
 
-    failed = [m.distgit_key for m, r in zip(runtime.image_metas(), results) if not r]
+    failed = [name for name, r in results if not r]
     if failed:
         runtime.logger.error("\n".join(["Build/push failures:"] + sorted(failed)))
         exit(1)
@@ -881,7 +881,7 @@ def images_push(runtime, tag, version_release, to_defaults, late_only, to, dry_r
                 )
         results = results.get()
 
-        failed = [m.distgit_key for m, r in zip(items, results) if not r]
+        failed = [name for name, r in results if not r]
         if failed:
             runtime.logger.error("\n".join(["Push failures:"] + sorted(failed)))
             exit(1)

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -471,7 +471,7 @@ class ImageDistGitRepo(DistGitRepo):
             is_late_push = self.config.push.late
 
         if push_late != is_late_push:
-            return True
+            return (self.metadata.distgit_key, True)
 
         push_names = []
 
@@ -482,7 +482,7 @@ class ImageDistGitRepo(DistGitRepo):
 
         # Nothing to push to? We are done.
         if not push_names:
-            return True
+            return (self.metadata.distgit_key, True)
 
         with Dir(self.distgit_dir):
 
@@ -574,7 +574,7 @@ class ImageDistGitRepo(DistGitRepo):
                                 rc, out, err = exectools.cmd_gather(["docker", "push", push_url])
                                 if rc == 0:
                                     break
-                                self.logger.info("Error pushing image -- retrying in 60 seconds")
+                                self.logger.info("Error pushing image -- retrying in 60 seconds.\n{}".format(err))
                                 time.sleep(60)
 
                         if rc != 0:
@@ -592,7 +592,7 @@ class ImageDistGitRepo(DistGitRepo):
                 finally:
                     self.runtime.add_record(action, **record)
 
-            return True
+            return (self.metadata.distgit_key, True)
 
     def wait_for_build(self, who_is_waiting):
         """
@@ -750,7 +750,7 @@ class ImageDistGitRepo(DistGitRepo):
         record['push_status'] = '0' if self.push_status else '-1'
 
         self.runtime.add_record(action, **record)
-        return self.build_status and self.push_status
+        return (self.metadata.distgit_key, self.build_status and self.push_status)
 
     def _build_container_local(self, target_image, repo_type, realtime=False):
         """

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -206,7 +206,7 @@ class RPMMetadata(Metadata):
             if rc != 0:
                 # Probably no point in continuing.. can't contact brew?
                 self.logger.info("Unable to create brew task: out={}  ; err={}".format(out, err))
-                return False
+                return (self.metadata.distgit_key, False)
 
             # Otherwise, we should have a brew task we can monitor listed in the stdout.
             out_lines = out.splitlines()
@@ -239,10 +239,10 @@ class RPMMetadata(Metadata):
             if error is not None:
                 # An error occurred. We don't have a viable build.
                 self.logger.info("Error building rpm: {}, {}".format(task_url, error))
-                return False
+                return (self.metadata.distgit_key, False)
 
             self.logger.info("Successfully built rpm: {} ; {}".format(self.rpm_name, task_url))
-        return True
+        return (self.metadata.distgit_key, True)
 
     def build_rpm(
             self, version, release, terminate_event, scratch=False, retries=3):


### PR DESCRIPTION
When we moved to building the images in a family tree defined order it broke the failure name reporting because it was 100% dependent on everything building AND returning in the order the builds were kicked off in. Which worked most of the time I would guess and the only time you would've seen an issue is when there were fails... where the list of failed images reported by doozer could be completely different names than what is reported by jenkins (which it got from record.log). By changing up how we order the builds this was completely broken. So I updated it to return from parallel_exec with not just a list of True/False but a list of tuples with name AND status for each. So we don't have to match things up by a non-deterministic order later.

@tbielawa @smunilla @sosiouxme 