### PR TITLE
Fixing push state messages

### DIFF
--- a/doozer
+++ b/doozer
@@ -307,12 +307,16 @@ def images_update_dockerfile(runtime, stream, version, release, repo_type, messa
 
     try:
         if push:
-            runtime.push_distgits()
+            res = runtime.push_distgits()
 
-        state.record_image_finish(lstate)
+            for name, r in res:
+                if r is not True:
+                    state.record_image_fail(lstate, name, r)
     except Exception as ex:
         lstate['status'] = state.STATE_FAIL
-        raise DoozerFatalError(ex.message)
+        raise DoozerFatalError(getattr(ex, 'message', repr(ex)))
+
+    state.record_image_finish(lstate)
 
     failed = []
     for img, status in lstate['images'].iteritems():
@@ -327,6 +331,7 @@ def images_update_dockerfile(runtime, stream, version, release, repo_type, messa
     if failed:
         msg = "The following non-critical images failed to update:\n{}".format('\n'.join(failed))
         yellow_print(msg)
+
 
 @cli.command("images:verify", short_help="Run some smoke tests to verify produced images")
 @click.option("--image", "-i", metavar="REPO/NAME:TAG", multiple=True,
@@ -534,12 +539,16 @@ def images_rebase(runtime, stream, version, release, repo_type, message, push):
 
     try:
         if push:
-            runtime.push_distgits()
+            res = runtime.push_distgits()
 
-        state.record_image_finish(lstate)
+            for name, r in res:
+                if r is not True:
+                    state.record_image_fail(lstate, name, r)
     except Exception as ex:
         lstate['status'] = state.STATE_FAIL
-        raise DoozerFatalError(ex.message)
+        raise DoozerFatalError(repr(ex))
+
+    state.record_image_finish(lstate)
 
     failed = []
     for img, status in lstate['images'].iteritems():

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -981,11 +981,15 @@ class ImageDistGitRepo(DistGitRepo):
     def push(self):
         with Dir(self.distgit_dir):
             self.logger.info("Pushing repository")
-            exectools.cmd_assert("timeout 1200 rhpkg push", retries=3)
-            # rhpkg will create but not push tags :(
-            # Not asserting this exec since this is non-fatal if a tag already exists,
-            # and tags in dist-git can't be --force overwritten
-            exectools.cmd_gather(['timeout', '60', 'git', 'push', '--tags'])
+            try:
+                exectools.cmd_assert("timeout 1200 rhpkg push", retries=3)
+                # rhpkg will create but not push tags :(
+                # Not asserting this exec since this is non-fatal if a tag already exists,
+                # and tags in dist-git can't be --force overwritten
+                exectools.cmd_gather(['timeout', '60', 'git', 'push', '--tags'])
+            except IOError as e:
+                return (self.metadata, repr(e))
+            return (self.metadata, True)
 
     @staticmethod
     def _mangle_yum(cmd):

--- a/doozerlib/state.py
+++ b/doozerlib/state.py
@@ -24,7 +24,7 @@ def record_image_success(state, image):
     state['images'][image.name] = True
 
 
-def record_image_fail(state, image, msg, logger):
+def record_image_fail(state, image, msg, logger=None):
     state['required_fail' if image.required else 'optional_fail'] += 1
     state['images'][image.name] = msg
     if logger:


### PR DESCRIPTION
@sosiouxme noted that failed pushes didn't make it into state.yaml which should be fixed by this.
Annoyingly the assert/exec/parallel_exec stuff makes it a royal pain... I'm open to thoughts on if there's a better way to do it.
Also... TIL that not all Exception objects have a `message` attribute... which is freaking dumb. That's why there's a couple `repr(ex)` calls in there. No other way to get the message out of the exceptions thrown in the `assertion.success()` call.
@tbielawa 