### PR TITLE
record rebase failures; fix reconciliation blame

### DIFF
--- a/doozer
+++ b/doozer
@@ -530,11 +530,21 @@ def images_rebase(runtime, stream, version, release, repo_type, message, push):
             dgr.tag(real_version, real_release)
             runtime.add_record(
                 "distgit_commit",
-                distgit=dgr.metadata.qualified_name,
-                image=dgr.config.name,
-                sha=sha)
+                distgit=image.qualified_name,
+                image=image.config.name,
+                sha=sha,
+            )
             state.record_image_success(lstate, image)
         except Exception as ex:
+            owners = image.config.owners
+            owners = ",".join(list(owners) if owners is not Missing else [])
+            runtime.add_record(
+                "distgit_commit_failure",
+                distgit=image.qualified_name,
+                image=image.config.name,
+                owners=owners,
+                message=ex.message.replace("|", ""),
+            )
             state.record_image_fail(lstate, image, ex.message, runtime.logger)
 
     try:

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1413,7 +1413,12 @@ class ImageDistGitRepo(DistGitRepo):
             with Dir(self.source_path()):
                 author_email = None
                 err = None
-                rc, sha, err = exectools.cmd_gather('git log -n 1 --pretty=format:%H {}'.format(dockerfile_name))
+                rc, sha, err = exectools.cmd_gather(
+                    # --no-merges because the merge bot is not the real author
+                    # --diff-filter=a to omit the "first" commit in a shallow clone which may not be the author
+                    #   (though this means when the only commit is the initial add, that is omitted)
+                    'git log --no-merges --diff-filter=a -n 1 --pretty=format:%H {}'.format(dockerfile_name)
+                )
                 if rc == 0:
                     rc, ae, err = exectools.cmd_gather('git show -s --pretty=format:%ae {}'.format(sha))
                     if rc == 0:

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -672,7 +672,8 @@ class Runtime(object):
         try:
             self.logger.info("Attempting to checkout source '%s' branch %s in: %s" % (url, clone_branch, source_dir))
             exectools.cmd_assert(
-                "git clone -b {} --single-branch {} --depth 1 {}".format(clone_branch, url, source_dir),
+                # get a little history to enable finding a recent Dockerfile change, but not too much.
+                "git clone -b {} --single-branch {} --depth 50 {}".format(clone_branch, url, source_dir),
                 retries=3,
                 on_retry=["rm", "-rf", source_dir],
             )


### PR DESCRIPTION
Kind of unrelated commits. My main purpose was to put a record in record.log when there's a rebase failure, and include the owners so that our jobs can inform them of the failure like we now do for build failures.

Then I noticed the bit about last committer and had to understand and fix that...