### PR TITLE
Define 'blacklist' in group schema

### DIFF
--- a/doozerlib/schema_group.yml
+++ b/doozerlib/schema_group.yml
@@ -18,6 +18,11 @@ mapping:
     sequence:
       - type: str
 
+  "blacklist":
+    type: seq
+    sequence:
+      - type: str
+
   "branch":
     type: str
 


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1690189

Accompanies a change in ocp-build-data.