### PR TITLE
runtime and schema: group option to ignore source branch fallbacks

### DIFF
--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -692,6 +692,12 @@ class Runtime(object):
 
         branch = branches["target"]
         fallback_branch = branches.get("fallback", None)
+        if self.group_config.use_source_fallback_branch == "always" and fallback_branch:
+            # only use the fallback (unless none is given)
+            branch, fallback_branch = fallback_branch, None
+        elif self.group_config.use_source_fallback_branch == "never":
+            # ignore the fallback
+            fallback_branch = None
         stage_branch = branches.get("stage", None) if self.stage else None
 
         if stage_branch:

--- a/doozerlib/schema_group.yml
+++ b/doozerlib/schema_group.yml
@@ -73,6 +73,10 @@ mapping:
               "stage":
                 type: str
 
+  "use_source_fallback_branch":
+    type: enum
+    enum: [always, never, fallback]
+
   "default_image_build_method":
     type: enum
     enum: [docker_api, imagebuilder]


### PR DESCRIPTION
Fallbacks are used to pick up release branches as soon as they are
created; however for the future we would like to create the branches in
advance and switch to using them only when we declare master has moved
on to the next release.

For the time when the branches are created but not to be used, this
gives doozer a group.yaml option to ignore the prematurely-created
"target" branches (e.g. "release-4.1") and just use specified fallbacks
(typically "master").  Conversely it can ignore the existence of
fallbacks if that ever becomes useful.