### PR TITLE
distgit.py: make scan-sources work with aliases

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -220,9 +220,12 @@ class DistGitRepo(object):
         Returns: bool
         """
         source_details = self.config.content.source.git
-        if source_details is Missing:
+        alias = self.config.content.source.alias
+        if source_details is Missing and alias is Missing:
             # no git source configured, so distgit always matches itself
             return True
+        if source_details is Missing:
+            source_details = self.runtime.group_config.sources[alias]
         _, commit_hash = self.runtime.detect_remote_source_branch(dict(source_details))
         return self._matches_commit(commit_hash) if commit_hash else False
 


### PR DESCRIPTION
I noticed that incremental builds were not picking up changes to the ose repo. This is because it's configured as an alias; scan-sources was only looking for direct git repos, and not finding any, assumed that it builds out of dist-git (thus by definition is in sync with dist-git).

Now handles an alias correctly.