### PR TITLE
Adding global options to settings.yaml

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -19,10 +19,23 @@ data_path: https://github.com/openshift/ocp-build-data.git
 
 #Sub-group directory or branch to pull build data
 group: openshift-4.0
+
+#Username for running rhpkg / brew / tito
+user: ahaile
+
+#Global option overrides that can only be set from settings.yaml
+global_opts:
+  # num of concurrent distgit pull/pushes
+  distgit_threads: 20
+  # timeout for `rhpkg clone` operation
+  rhpkg_clone_timeout: 900
+  # timeout for `rhpkg push` operation
+  rhpkg_push_timeout: 1200
 ```
 
-Note, all three options above can be set at the CLI with `doozer --working-dir <path> --data-path <url> --group <group>` but we highly recommend setting them in `settings.yaml` to save typing every time you run.
-Also, please note that `group` in `settings.yaml` only makes sense if you only ever work on that one version, otherwise specify it on the CLI at runtime.
+Note, the options `working_dir`, `data_path`, `group`, and `user` above can be set at the CLI with `doozer --working-dir <path> --data-path <url> --group <group> --user <user>` but we highly recommend setting at least `working_dir` and `data_path` in `settings.yaml` to save typing every time you run.
+Setting `group` in `settings.yaml` only makes sense if you only ever work on that one version, otherwise specify it on the CLI at runtime.
+Finally, `global_opts` is used to set some internal options and can only be configured from `settings.yaml`. This is intentional as they are meant to be global to the system running doozer.
 
 # Image Configuration
 

--- a/doozer
+++ b/doozer
@@ -118,6 +118,8 @@ def print_version(ctx, param, value):
 @click.pass_context
 def cli(ctx, **kwargs):
     global CTX_GLOBAL
+    kwargs['global_opts'] = None  # can only be set in settings.yaml, add manually
+
     cfg = dotconfig.Config('doozer', 'settings',
                            template=cli_opts.CLI_CONFIG_TEMPLATE,
                            envvars=cli_opts.CLI_ENV_VARS,
@@ -131,7 +133,17 @@ def cli(ctx, **kwargs):
         ).format(cfg.full_path)
         yellow_print(msg)
 
-    ctx.obj = Runtime(cfg_obj=cfg, command=ctx.invoked_subcommand, **cfg.to_dict())
+    # set global option defaults
+    runtime_args = cfg.to_dict()
+    global_opts = runtime_args['global_opts']
+    if global_opts is None:
+        global_opts = {}
+    for k, v in cli_opts.GLOBAL_OPT_DEFAULTS.iteritems():
+        if k not in global_opts or global_opts[k] is None:
+            global_opts[k] = v
+    runtime_args['global_opts'] = global_opts
+
+    ctx.obj = Runtime(cfg_obj=cfg, command=ctx.invoked_subcommand, **runtime_args)
     CTX_GLOBAL = ctx
     return ctx
 

--- a/doozerlib/cli_opts.py
+++ b/doozerlib/cli_opts.py
@@ -1,3 +1,19 @@
+import yaml
+
+GLOBAL_OPT_DEFAULTS = {
+    'distgit_threads': 20,
+    'rhpkg_clone_timeout': 900,
+    'rhpkg_push_timeout': 1200
+}
+
+
+def global_opt_default_string():
+    res = '\n'
+    for k in GLOBAL_OPT_DEFAULTS.iterkeys():
+        res += '  {}:\n'.format(k)
+    return res
+
+
 CLI_OPTS = {
     'data_path': {
         'env': 'DOOZER_DATA_PATH',
@@ -14,12 +30,17 @@ CLI_OPTS = {
     'user': {
         'env': 'DOOZER_USER',
         'help': 'Username for running rhpkg / brew / tito'
+    },
+    'global_opts': {
+        'help': 'Global option overrides that can only be set from settings.yaml',
+        'default': global_opt_default_string()
     }
 }
 
-CLI_ENV_VARS = {k: v['env'] for (k, v) in CLI_OPTS.iteritems()}
 
-CLI_CONFIG_TEMPLATE = '\n'.join(['#{}\n{}:\n'.format(v['help'], k) for (k, v) in CLI_OPTS.iteritems()])
+CLI_ENV_VARS = {k: v['env'] for (k, v) in CLI_OPTS.iteritems() if 'env' in v}
+
+CLI_CONFIG_TEMPLATE = '\n'.join(['#{}\n{}:{}\n'.format(v['help'], k, v['default'] if 'default' in v else '') for (k, v) in CLI_OPTS.iteritems()])
 
 
 def config_is_empty(path):

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -131,7 +131,7 @@ class DistGitRepo(object):
                                      'local build will be sourced from the current dist-git '
                                      'contents and not the typical GitHub source. '
                                      )
-                    cmd_list = ["timeout", "900", "rhpkg"]
+                    cmd_list = ["timeout", str(self.runtime.global_opts['rhpkg_clone_timeout']), "rhpkg"]
 
                     if self.runtime.user is not None:
                         cmd_list.append("--user=%s" % self.runtime.user)
@@ -976,7 +976,8 @@ class ImageDistGitRepo(DistGitRepo):
         with Dir(self.distgit_dir):
             self.logger.info("Pushing repository")
             try:
-                exectools.cmd_assert("timeout 1200 rhpkg push", retries=3)
+                timeout = str(self.runtime.global_opts['rhpkg_push_timeout'])
+                exectools.cmd_assert("timeout {} rhpkg push".format(timeout), retries=3)
                 # rhpkg will create but not push tags :(
                 # Not asserting this exec since this is non-fatal if a tag already exists,
                 # and tags in dist-git can't be --force overwritten

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -829,13 +829,17 @@ class Runtime(object):
         pool.join()
         return ret
 
-    def clone_distgits(self, n_threads=20):
+    def clone_distgits(self, n_threads=None):
+        if n_threads is None:
+            n_threads = self.global_opts['distgit_threads']
         return self._parallel_exec(
             lambda m: m.distgit_repo(),
             self.all_metas(),
             n_threads=n_threads).get()
 
-    def push_distgits(self, n_threads=20):
+    def push_distgits(self, n_threads=None):
+        if n_threads is None:
+            n_threads = self.global_opts['distgit_threads']
         return self._parallel_exec(
             lambda m: m.distgit_repo().push(),
             self.all_metas(),


### PR DESCRIPTION
@sosiouxme @tbielawa 

Can now add these to settings.yaml
```
global_opts:
  rhpkg_push_timeout:
  distgit_threads:
  rhpkg_clone_timeout:

```

Has these defaults:
```
GLOBAL_OPT_DEFAULTS = {
    'distgit_threads': 20,
    'rhpkg_clone_timeout': 900,
    'rhpkg_push_timeout': 1200
}
```
Anything in settings.yaml will override.