### PR TITLE
Do not include non-release images in release sync

### DIFF
--- a/doozer
+++ b/doozer
@@ -1541,6 +1541,7 @@ def release_mirror(runtime, src_dest, image_stream, is_base, pattern):
           tags: []
 
     """
+    runtime.exclude.extend(runtime.group_config.get('non_release.images', []))
     runtime.initialize(clone_distgits=False)
     images = [i for i in runtime.image_metas()]
 


### PR DESCRIPTION
Do not include non-release images in release sync. These are not wanted in the mirroring and release image stream.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1690189
