### PR TITLE
fix for non_release images

### DIFF
--- a/doozer
+++ b/doozer
@@ -1468,8 +1468,7 @@ def release_mirror(runtime, src_dest, image_stream, is_base, pattern):
           tags: []
 
     """
-    runtime.exclude.extend(runtime.group_config.get('non_release.images', []))
-    runtime.initialize(clone_distgits=False)
+    runtime.initialize(clone_distgits=False, config_excludes='non_release')
     images = [i for i in runtime.image_metas()]
 
     # Load the ImageStream stub file

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -183,7 +183,8 @@ class Runtime(object):
 
     def initialize(self, mode='images', clone_distgits=True,
                    validate_content_sets=False,
-                   no_group=False, clone_source=True, disabled=None):
+                   no_group=False, clone_source=True, disabled=None,
+                   config_excludes=None):
 
         if self.initialized:
             return
@@ -320,6 +321,8 @@ class Runtime(object):
                 return d.get('mode', 'enabled') in ['enabled', 'disabled']
 
             exclude_keys = flatten_list(self.exclude)
+            image_ex = list(exclude_keys)
+            rpm_ex = list(exclude_keys)
             image_keys = flatten_list(self.images)
             rpm_keys = flatten_list(self.rpms)
 
@@ -337,14 +340,20 @@ class Runtime(object):
             if self.group_config.vars:
                 replace_vars = self.group_config.vars.primitive()
 
+            if config_excludes:
+                excludes = self.group_config.get(config_excludes, {})
+                image_ex.extend(excludes.get('images', []))
+                rpm_ex.extend(excludes.get('rpms', []))
+
+            print(image_ex)
             image_data = self.gitdata.load_data(path='images', keys=image_keys,
-                                                exclude=exclude_keys,
+                                                exclude=image_ex,
                                                 replace_vars=replace_vars,
                                                 filter_funcs=None if len(image_keys) else filter_func)
 
             try:
                 rpm_data = self.gitdata.load_data(path='rpms', keys=rpm_keys,
-                                                  exclude=exclude_keys,
+                                                  exclude=rpm_ex,
                                                   replace_vars=replace_vars,
                                                   filter_funcs=None if len(rpm_keys) else filter_func)
             except gitdata.GitDataPathException:


### PR DESCRIPTION
Supersedes #64 
@tbielawa @sosiouxme - this should do the trick and is meant to be flexible. Instead of hardcoding a specific exclude list name, you can pass `config_excludes='non_release'` and it will look for `non_release` in the group config and if it contains an `images` or `rpms` section it will add those to the exclusions. This way we could have other exclusions in the config with different names but not have to change the code, just the call to `initialize()`.