### PR TITLE
rpmcfg.py: enable pushing release commit to origin

### DIFF
--- a/doozerlib/schema_rpm.yml
+++ b/doozerlib/schema_rpm.yml
@@ -10,6 +10,17 @@ mapping:
   "content":
     type: map
     mapping:
+      'build':
+        type: map
+        mapping:
+          "use_source_tito_config":
+            type: bool
+          "tito_target":
+            type: str
+          "tito_dist":
+            type: str
+          "push_release_commit":
+            type: bool
       'source':
         type: map
         mapping:


### PR DESCRIPTION
Ref. https://github.com/openshift/ocp-build-data/pull/74/files
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1694183

A standard doozer RPM build is less intrusive to the source repo than
the usual tito flow because the commit it uses for the build isn't
pushed back to origin; the origin commit is tagged and the tag pushed
but the release commit is discarded.

The minor problem with this is that `tito release` injects the commit
hash it releases right into the build release, and this hash will never
be present in the source repo.

It turns out that for the openshift RPM, something really cares about
that git hash being available in the source repo for validation. So this
change enables an option to push that release commit back to the source.

Also the openshift RPM has specialized tito config already. Doozer logic
already imitates it pretty well, but it seems wisest to minimize
deviations from upstream by actually using the tito config to tag and
release; so now the logic can be configured to do that.