### PR TITLE
improve scanning for incremental builds

### DIFF
--- a/doozer
+++ b/doozer
@@ -379,6 +379,7 @@ def config_scan_source_changes(runtime, as_yaml):
     Print a list of configs that were scanned and whether the source differs from the distgit.
     """
     _fix_runtime_mode(runtime)
+    CONFIG_RUNTIME_OPTS['disabled'] = False  # unless explicitly indicated, ignore disabled configs
     runtime.initialize(**CONFIG_RUNTIME_OPTS)
     results = dict(rpms=[], images=[])
     for meta, matches in runtime.scan_distgit_sources():

--- a/doozerlib/schema_group.yml
+++ b/doozerlib/schema_group.yml
@@ -52,6 +52,14 @@ mapping:
         sequence:
           - type: str
 
+  "scan_freshness":
+    type: map
+    mapping:
+      "release_regex":
+        type: str
+      "threshold_hours":
+        type: str
+
   "sources":
     type: map
     mapping:


### PR DESCRIPTION
Now if source has been copied into distgit but not built, it will no longer sit forever until the next source change. It will be considered stale and a candidate for incremental build after a configurable threshold (which we'll start at 24 hours).

Also, I noticed it was accidentally including disabled images... fixed.