### PR TITLE
distgit.py: search builds for component not dg name

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1595,8 +1595,9 @@ class ImageDistGitRepo(DistGitRepo):
         )
 
     def _built_or_recent(self, dg_version, dg_release, builds):
-        if self.name in builds:
-            b_version, b_release = builds[self.name]
+        component = self.metadata.get_component_name()
+        if component in builds:
+            b_version, b_release = builds[component]
             self.logger.debug(
                 'Looking for VR "{}-{}" in distgit dockerfile to match build VR "{}-{}"'
                 .format(dg_version, dg_release, b_version, b_release)
@@ -1604,7 +1605,7 @@ class ImageDistGitRepo(DistGitRepo):
             if b_version == dg_version and b_release == dg_release:
                 self.logger.debug("Latest source has been built; no need to rebuild")
                 return True
-        self.logger.debug('No build matches distgit NVR "{}-{}-{}"'.format(self.name, dg_version, dg_release))
+        self.logger.debug('No build matches distgit NVR "{}-{}-{}"'.format(component, dg_version, dg_release))
 
         # it hasn't been built; but has it been long enough since the distgit commit was made?
         # we want neither to spam owners about still-broken builds nor to ignore them forever.

--- a/doozerlib/distgit_test.py
+++ b/doozerlib/distgit_test.py
@@ -71,6 +71,9 @@ class MockMetadata(object):
     def fetch_cgit_file(self, file):
         pass
 
+    def get_component_name(self):
+        pass
+
 class MockScanner(object):
 
     def __init__(self):
@@ -283,9 +286,10 @@ class TestImageDistGit(TestDistgit):
 
     def test_img_build_or_recent(self):
         flexmock(self.img_dg).should_receive("release_is_recent").and_return(None)
-        self.img_dg.name = "my-container"
+        self.img_dg.name = "spam-a-lot"
+        flexmock(self.img_dg.metadata).should_receive("get_component_name").and_return("spam-a-lot-container")
 
-        builds = {"my-container": ("v1", "r1")}
+        builds = {"spam-a-lot-container": ("v1", "r1")}
         self.assertTrue(self.img_dg._built_or_recent("v1", "r1", builds))
         self.assertIsNone(self.img_dg._built_or_recent("v2", "r1", builds))
 


### PR DESCRIPTION
When doing a scan for changed sources, the test for whether the distgit
copy of the source has been built looks for brew builds. But it was
looking for the distgit name instead of the component. For RPMs they are
the same but images generally add -container or -apb or explicitly
specify a component.