### PR TITLE
Check build_lock before releasing

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -780,7 +780,8 @@ class ImageDistGitRepo(DistGitRepo):
             # threaded, we should not throw an exception; instead return False.
         finally:
             # Regardless of success, allow other images depending on this one to progress or fail.
-            self.build_lock.release()
+            if self.build_lock.locked():
+                self.build_lock.release()
 
         self.push_status = True  # if if never pushes, the status is True
         if not scratch and self.build_status and (push_to_defaults or additional_registries):


### PR DESCRIPTION
@smunilla 
@tbielawa @sosiouxme PTAL
If the `wait_for_build` is called, then `build_lock` is actually already released. Not really sure how this doesn't always fail other than threading is weird we've gotten lucky except when we don't and get failures like here -> https://buildvm.openshift.eng.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Focp4/196/consoleFull

```
Traceback (most recent call last):
  File "/bin/doozer", line 1831, in <module>
    main()
  File "/bin/doozer", line 1812, in main
    cli(obj={})
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/bin/doozer", line 842, in images_build_image
    results = results.get()
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 554, in get
    raise self._value
doozerlib.runtime.WrapException: 
Original traceback:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/doozerlib/runtime.py", line 78, in wrapper
    return func(*args, **kwargs)
  File "/bin/doozer", line 840, in <lambda>
    terminate_event=terminate_event, scratch=scratch, realtime=(threads == 1)),
  File "/usr/lib/python2.7/site-packages/doozerlib/distgit.py", line 783, in build_container
    self.build_lock.release()
ValueError: semaphore or lock released too many times
```