### PR TITLE
fixing os.mkdir race-condition in push_image

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -583,7 +583,15 @@ class ImageDistGitRepo(DistGitRepo):
 
                     push_config_dir = os.path.join(self.runtime.working_dir, 'push')
                     if not os.path.isdir(push_config_dir):
-                        os.mkdir(push_config_dir)
+                        try:
+                            os.mkdir(push_config_dir)
+                        except OSError as e:
+                            # File exists, and it's a directory,
+                            # another thread already created this dir, that's OK.
+                            if e.errno == errno.EEXIST and os.path.isdir(push_config_dir):
+                                pass
+                            else:
+                                raise
 
                     push_config = os.path.join(push_config_dir, self.metadata.distgit_key)
 


### PR DESCRIPTION
the problem I assume happened in here: https://buildvm.openshift.eng.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Fbuildvm-maint/618/consoleFull

Not sure if it's a pythonic way, @adammhaile PTAL