### PR TITLE
refer to metadata by distgit_key instead of name

### DIFF
--- a/doozerlib/state.py
+++ b/doozerlib/state.py
@@ -21,12 +21,12 @@ TEMPLATE_IMAGE = {
 
 def record_image_success(state, image):
     state['success'] += 1
-    state['images'][image.name] = True
+    state['images'][image.distgit_key] = True
 
 
 def record_image_fail(state, image, msg, logger=None):
     state['required_fail' if image.required else 'optional_fail'] += 1
-    state['images'][image.name] = msg
+    state['images'][image.distgit_key] = msg
     if logger:
         logger.error('[{}] {}'.format(image.qualified_key, msg))
 


### PR DESCRIPTION
In most cases, we want to distinguish between metadata that may have the
same name ("mediawiki") but come from different config files /
commandline specifications, which are captured in the
`metadata.distgit_key` ("mediawiki.apb")

We almost never want to use distgit's `self.name`. I've left a few in
there that seemed risky to change and not yet critical. We might want to
consider removing it entirely once we have better testing because it is
likely to be used unknowingly.

With this change, for `mediawiki.{apb,container}` entries are separated in:
* rebase modification diff files
* brew log files
* `state.yml` entries
* `record.log` entries (which are used to notify and retry failures)