### PR TITLE
List "koji" on requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests_kerberos
 bashlex
 pydotconfig >= 0.1.4
 pygitdata >= 0.2.2
+koji


### PR DESCRIPTION
The installation instructions mention `koji` as a dependency, that can be obtained as a `.rpm` package.
<https://github.com/openshift/doozer/blob/master/Installation.md#brew--rhpkg>

Doozer surely needs that for several purposes (including the `brew -> koji` symlink),
but I noticed that we *implicitly* rely on one of the extra packages that come when we `[dnf|yum] install koji`:

```
=================================================================================
 Package                       Arch      Version               Repository   Size
=================================================================================
Installing:
 koji                          noarch    1.15.1-1.el7.centos   extras      115 k
Installing for dependencies:
 ... (ommited) ...
 python2-koji                  noarch    1.15.1-1.el7.centos   extras      291 k
```

We currently use `python2-koji` in the following lines:

https://github.com/openshift/doozer/blob/c033f4d61225250e6fc71bd1391f02400ee14ada/doozer#L27
https://github.com/openshift/doozer/blob/c033f4d61225250e6fc71bd1391f02400ee14ada/doozerlib/brew.py#L14-L15

So my proposal is to _also_ list `koji` in `requirements.txt`, to ensure `python2-koji` will be present.
And this seems to be a required step towards using `tox` for running tests. ([ART-546](https://jira.coreos.com/browse/ART-546)).