### PR TITLE
Finish covering RPMDistGitRepo with tests

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1716,11 +1716,6 @@ class RPMDistGitRepo(DistGitRepo):
         if self.source.specfile is Missing:
             raise ValueError('Must specify spec file name for RPMs.')
 
-    def _read_master_data(self):
-        with Dir(self.distgit_dir):
-            # Read in information about the rpm we are about to build
-            pass  # placeholder for now. nothing to read
-
     def _find_in_spec(self, spec, regex, desc):
         match = re.search(regex, spec)
         if match:

--- a/tests/test_distgit/test_rpm_distgit.py
+++ b/tests/test_distgit/test_rpm_distgit.py
@@ -1,6 +1,7 @@
 import unittest
 
 import flexmock
+import mock
 
 import distgit
 from model import Model
@@ -13,6 +14,18 @@ class TestRPMDistGit(TestDistgit):
         super(TestRPMDistGit, self).setUp()
         self.rpm_dg = distgit.RPMDistGitRepo(self.md, autoclone=False)
         self.rpm_dg.runtime.group_config = Model()
+
+    def test_init_with_missing_source_specfile(self):
+        metadata = mock.Mock()
+        metadata.config.content.source.specfile = distgit.Missing
+
+        try:
+            distgit.RPMDistGitRepo(metadata, autoclone=False)
+            self.fail("Should have raised a ValueError")
+        except ValueError as e:
+            expected = "Must specify spec file name for RPMs."
+            actual = e.message
+            self.assertEqual(expected, actual)
 
     def test_pkg_find_in_spec(self):
         """ Test RPMDistGitRepo._find_in_spec """

--- a/tests/test_distgit/test_rpm_distgit.py
+++ b/tests/test_distgit/test_rpm_distgit.py
@@ -67,6 +67,12 @@ class TestRPMDistGit(TestDistgit):
         self.assertTrue(self.rpm_dg._built_or_recent("v1", "r1%{?dist}", builds))
         self.assertIsNone(self.rpm_dg._built_or_recent("v2", "r1", builds))
 
+    def test_pkg_build_or_recent_with_no_builds(self):
+        flexmock(self.rpm_dg).should_receive("release_is_recent").and_return(None)
+
+        builds = dict()
+        self.assertIsNone(self.rpm_dg._built_or_recent("v1", "r1", builds))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
There were only two uncovered branches in the whole class:
* The constructor `__init__` raises a `ValueError` if there is no spec file;
* `_build_or_recent` returns `None` if no builds were passed as argument;