### PR TITLE
Add some image distgit-related test cases

### DIFF
--- a/tests/test_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit.py
@@ -29,6 +29,37 @@ class TestImageDistGit(TestDistgit):
 
         repo._read_master_data.assert_called_once()
 
+    def test_image_build_method_default(self):
+        metadata = mock.Mock()
+        metadata.runtime.group_config.default_image_build_method = "default-method"
+        metadata.config = type("MyConfig", (dict,), {})()
+        metadata.config.distgit = mock.Mock()
+        metadata.config.image_build_method = distgit.Missing
+
+        repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
+        self.assertEqual("default-method", repo.image_build_method)
+
+    def test_image_build_method_imagebuilder(self):
+        metadata = mock.Mock()
+        metadata.runtime.group_config.default_image_build_method = "default-method"
+        metadata.config = type("MyConfig", (dict,), {})()
+        metadata.config["from"] = {"builder": "..."}
+        metadata.config.distgit = mock.Mock()
+        metadata.config.image_build_method = distgit.Missing
+
+        repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
+        self.assertEqual("imagebuilder", repo.image_build_method)
+
+    def test_image_build_method_from_config(self):
+        metadata = mock.Mock()
+        metadata.runtime.group_config.default_image_build_method = "default-method"
+        metadata.config = type("MyConfig", (dict,), {})()
+        metadata.config.distgit = mock.Mock()
+        metadata.config.image_build_method = "config-method"
+
+        repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
+        self.assertEqual("config-method", repo.image_build_method)
+
     def test_detect_permanent_build_failures(self):
         self.img_dg._logs_dir = lambda: self.logs_dir
         task_dir = tempfile.mkdtemp(dir=self.logs_dir)

--- a/tests/test_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 
 import flexmock
+import mock
 
 import distgit
 from model import Model
@@ -15,6 +16,18 @@ class TestImageDistGit(TestDistgit):
         super(TestImageDistGit, self).setUp()
         self.img_dg = distgit.ImageDistGitRepo(self.md, autoclone=False)
         self.img_dg.runtime.group_config = Model()
+
+    @mock.patch("distgit.DistGitRepo.clone", return_value=None)
+    def test_clone_invokes_read_master_data(self, *_):
+        """
+        Mocking `clone` method of parent class, since we are only interested
+        in validating that `_read_master_data` is called in the child class.
+        """
+        repo = distgit.ImageDistGitRepo(mock.Mock(), autoclone=False)
+        repo._read_master_data = mock.Mock()
+        repo.clone("distgits_root_dir", "distgit_branch")
+
+        repo._read_master_data.assert_called_once()
 
     def test_detect_permanent_build_failures(self):
         self.img_dg._logs_dir = lambda: self.logs_dir


### PR DESCRIPTION
Only covering smaller public methods of `ImageDistGitRepo`; a  "low-hanging fruit" pull request.

The bigger/more complex methods will require dedicated test files, due to the amount of possible variations / outcomes.

### Coverage

#### before

```
py27 run-test: commands[0] | flake8
py27 run-test: commands[1] | coverage run --branch --source doozerlib -m unittest discover
s...No handlers could be found for logger "doozer.tests.test_runtime"
..s............s.s.....................................s.s.s.s....s.s.
----------------------------------------------------------------------
Ran 64 tests in 0.263s

OK (skipped=10)
py27 run-test: commands[2] | coverage report
Name                      Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------
...
doozerlib/distgit.py        992    699    458      5    26%
...
-----------------------------------------------------------
TOTAL                      2694   1951   1105     16    23%
```

#### after

```
py27 run-test: commands[0] | flake8
py27 run-test: commands[1] | coverage run --branch --source doozerlib -m unittest discover
s...No handlers could be found for logger "doozer.tests.test_runtime"
..s................s.s.........................................s.s.s.s....s.s.
----------------------------------------------------------------------
Ran 72 tests in 0.281s

OK (skipped=10)
py27 run-test: commands[2] | coverage report
Name                      Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------
...
doozerlib/distgit.py        992    677    458      5    28%
...
-----------------------------------------------------------
TOTAL                      2694   1929   1105     16    24%
```