### PR TITLE
Use only flexmock in test_generic_distgit

### DIFF
--- a/tests/test_distgit/support.py
+++ b/tests/test_distgit/support.py
@@ -18,9 +18,10 @@ class MockContent(object):
         self.branch = None
 
 
-class MockConfig(object):
+class MockConfig(dict):
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super(MockConfig, self).__init__(*args, **kwargs)
         self.distgit = MockDistgit()
         self.content = Model()
         self.content.source = Model()

--- a/tests/test_distgit/test_recursive_overwrite.py
+++ b/tests/test_distgit/test_recursive_overwrite.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+import flexmock
 import distgit
 
 
@@ -10,24 +10,30 @@ class TestDistgitRecursiveOverwrite(unittest.TestCase):
     string is being generated.
     """
 
-    @mock.patch("distgit.exectools.cmd_assert", return_value=None)
-    def test_without_ignore_set(self, cmd_assert_mock):
+    def test_without_ignore_set(self):
         expected_cmd = ("rsync -av "
                         " --exclude .git/ "
                         " my-source/ my-dest/")
 
-        distgit.recursive_overwrite("my-source", "my-dest")
-        cmd_assert_mock.assert_called_once_with(expected_cmd, retries=mock.ANY)
+        (flexmock(distgit.exectools)
+            .should_receive("cmd_assert")
+            .with_args(expected_cmd, retries=3)
+            .once())
 
-    @mock.patch("distgit.exectools.cmd_assert", return_value=None)
-    def test_with_ignore_set(self, cmd_assert_mock):
+        distgit.recursive_overwrite("my-source", "my-dest")
+
+    def test_with_ignore_set(self):
         expected_cmd = ("rsync -av "
                         " --exclude .git/ "
                         " --exclude=\"ignore\" "
                         " --exclude=\"me\" "
                         " my-source/ my-dest/")
 
+        (flexmock(distgit.exectools)
+            .should_receive("cmd_assert")
+            .with_args(expected_cmd, retries=3)
+            .once())
+
         # passing a list to ignore instead of a set, because sets are unordered,
         # making this assertion unpredictable.
         distgit.recursive_overwrite("my-source", "my-dest", ignore=["ignore", "me"])
-        cmd_assert_mock.assert_called_once_with(expected_cmd, retries=mock.ANY)

--- a/tests/test_distgit/test_rpm_distgit.py
+++ b/tests/test_distgit/test_rpm_distgit.py
@@ -1,7 +1,6 @@
 import unittest
 
 import flexmock
-import mock
 
 import distgit
 from model import Model
@@ -16,8 +15,11 @@ class TestRPMDistGit(TestDistgit):
         self.rpm_dg.runtime.group_config = Model()
 
     def test_init_with_missing_source_specfile(self):
-        metadata = mock.Mock()
-        metadata.config.content.source.specfile = distgit.Missing
+        metadata = flexmock(config=flexmock(content=flexmock(source=distgit.Missing),
+                                            distgit=flexmock(branch="_irrelevant_")),
+                            runtime=flexmock(branch="_irrelevant_"),
+                            name="_irrelevant_",
+                            logger="_irrelevant_")
 
         try:
             distgit.RPMDistGitRepo(metadata, autoclone=False)


### PR DESCRIPTION
As discussed in our arch meeting, i'm getting rid of all usages of `mock` in favor of `flexmock`.
~~This PR only covers `test_generic_distgit.py`.~~ This PR covers everything I had done previously **except** the contents of #111, because they are still not on master. But i'm already working on it ;D