### PR TITLE
Set PYTHONDONTWRITEBYTECODE in tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     mock
 setenv =
     PYTHONPATH={toxinidir}/doozerlib
+    PYTHONDONTWRITEBYTECODE=1
 commands =
     flake8
     python -m unittest discover


### PR DESCRIPTION
@sosiouxme suggested https://github.com/openshift/doozer/pull/97#discussion_r288453030, but `tox` seems to disregard this env var.