### PR TITLE
[ART-1005] operator-metadata: work with NVR

### DIFF
--- a/doozer
+++ b/doozer
@@ -2187,9 +2187,9 @@ def update_operator_metadata(runtime, nvr_list, stream, merge_branch, force=Fals
 
 
 @cli.command("operator-metadata:latest-build", short_help="Print latest metadata build of a given operator")
-@click.option("--nvr", "-n", help="Specify Name-Version-Release", default=None, required=False)
+@click.option("--nvr", "-n", help="Specify Name-Version-Release. Needs --stream", multiple=True)
 @click.option("--stream", "-s", type=click.Choice(['dev', 'stage', 'prod']),
-    help="Metadata stream to select. Possible values: dev, stage, prod.")
+    help="Metadata stream to select. Possible values: dev, stage, prod. Needs --nvr")
 @click.argument("operator_list", nargs=-1)
 @pass_runtime
 def operator_metadata_latest_build(runtime, nvr, stream, operator_list):
@@ -2207,7 +2207,7 @@ def operator_metadata_latest_build(runtime, nvr, stream, operator_list):
 
     Usage example when feeding NVR and stream:
 
-    $ doozer -g openshift-4.2 operator-metadata:latest-build --nvr cluster-logging-operator-container-v4.2.1-201910221723 --stream stage
+    $ doozer -g openshift-4.2 operator-metadata:latest-build --stream stage --nvr cluster-logging-operator-container-v4.2.1-201910221723 --nvr sriov-network-operator-container-v4.2.0-201909131819
     """
 
     if operator_list and (stream or nvr):
@@ -2219,14 +2219,18 @@ def operator_metadata_latest_build(runtime, nvr, stream, operator_list):
     if nvr and not stream:
         click.echo('--nvr needs to be accompanied by --stream. Exiting.', err=True)
         sys.exit(1)
+    if not nvr and not operator_list:
+        click.echo("Missing arguments: Need nvr's or operators to work with")
+        sys.exit(1)
 
     runtime.initialize(clone_distgits=False)
 
     if operator_list:
         for operator in operator_list:
-            print(operator_metadata.OperatorMetadataLatestBuildReporter(operator, runtime).get_latest_build())
+            click.echo(operator_metadata.OperatorMetadataLatestBuildReporter(operator, runtime).get_latest_build())
     else:
-        print(operator_metadata.OperatorMetadataLatestNvrReporter(nvr, stream, runtime).get_latest_build())
+        for build in nvr:
+            click.echo(operator_metadata.OperatorMetadataLatestNvrReporter(build, stream, runtime).get_latest_build())
 
 
 def main():

--- a/doozer
+++ b/doozer
@@ -2187,9 +2187,12 @@ def update_operator_metadata(runtime, nvr_list, stream, merge_branch, force=Fals
 
 
 @cli.command("operator-metadata:latest-build", short_help="Print latest metadata build of a given operator")
-@click.argument("operator_list", nargs=-1, required=True)
+@click.option("--nvr", "-n", help="Specify Name-Version-Release", default=None, required=False)
+@click.option("--stream", "-s", type=click.Choice(['dev', 'stage', 'prod']),
+    help="Metadata stream to select. Possible values: dev, stage, prod.")
+@click.argument("operator_list", nargs=-1)
 @pass_runtime
-def operator_metadata_latest_build(runtime, operator_list):
+def operator_metadata_latest_build(runtime, nvr, stream, operator_list):
     """Print the latest metadata build of a given operator
 
     operator_list: One or more operator names
@@ -2198,14 +2201,32 @@ def operator_metadata_latest_build(runtime, operator_list):
 
     $ doozer -g openshift-4.2 operator-metadata:latest-build cluster-logging-operator
 
-    Usage example with multiple operators
+    Usage example with multiple operators:
 
     $ doozer -g openshift-4.2 operator-metadata:latest-build cluster-logging-operator elasticsearch-operator
+
+    Usage example when feeding NVR and stream:
+
+    $ doozer -g openshift-4.2 operator-metadata:latest-build --nvr cluster-logging-operator-container-v4.2.1-201910221723 --stream stage
     """
+
+    if operator_list and (stream or nvr):
+        click.echo('Need either a list of operators, or specified by NVR and stream. Exiting.', err=True)
+        sys.exit(1)
+    if stream and not nvr:
+        click.echo('--stream needs to be accompanied by --nvr. Exiting.', err=True)
+        sys.exit(1)
+    if nvr and not stream:
+        click.echo('--nvr needs to be accompanied by --stream. Exiting.', err=True)
+        sys.exit(1)
+
     runtime.initialize(clone_distgits=False)
 
-    for operator in operator_list:
-        print(operator_metadata.OperatorMetadataLatestBuildReporter(operator, runtime).get_latest_build())
+    if operator_list:
+        for operator in operator_list:
+            print(operator_metadata.OperatorMetadataLatestBuildReporter(operator, runtime).get_latest_build())
+    else:
+        print(operator_metadata.OperatorMetadataLatestNvrReporter(nvr, stream, runtime).get_latest_build())
 
 
 def main():

--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -11,8 +11,6 @@ from multiprocessing.dummy import Pool as ThreadPool
 from multiprocessing import cpu_count
 from multiprocessing import Lock
 import shlex
-import koji
-import koji_cli.lib
 import traceback
 
 import exceptions
@@ -21,6 +19,8 @@ import logutil
 
 # 3rd party
 import click
+import koji
+import koji_cli.lib
 import requests
 from requests_kerberos import HTTPKerberosAuth
 

--- a/tests/test_distgit/test_build_image_ref_name.py
+++ b/tests/test_distgit/test_build_image_ref_name.py
@@ -15,3 +15,7 @@ class TestDistgitBuildImageRefName(unittest.TestCase):
         expected = "openshift/ose-kubefed-operator"
 
         self.assertEqual(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_distgit/test_convert_source_url_to_https.py
+++ b/tests/test_distgit/test_convert_source_url_to_https.py
@@ -35,3 +35,7 @@ class TestDistgitConvertSourceURLToHTTPS(unittest.TestCase):
         expected = "https://foo.gitlab.com/myorg/myproject"
 
         self.assertEqual(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -525,3 +525,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  push_to_defaults,
                                  version_release_tuple=("version", "release"))
         self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_distgit/test_pull_image.py
+++ b/tests/test_distgit/test_pull_image.py
@@ -44,3 +44,7 @@ class TestDistgitPullImage(unittest.TestCase):
         logger.should_receive("info").with_args("Error pulling image my-image -- retrying in 60 seconds").twice()
 
         distgit.pull_image("my-image")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_distgit/test_recursive_overwrite.py
+++ b/tests/test_distgit/test_recursive_overwrite.py
@@ -37,3 +37,7 @@ class TestDistgitRecursiveOverwrite(unittest.TestCase):
         # passing a list to ignore instead of a set, because sets are unordered,
         # making this assertion unpredictable.
         distgit.recursive_overwrite("my-source", "my-dest", ignore=["ignore", "me"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -1181,7 +1181,6 @@ class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
             'my-operator-metadata-container-v1.2.3.20191022.dev-1',
             'my-operator-metadata-container-v1.2.3.20191022.dev-2'])
 
-        #import code; code.interact(local=dict(globals(), **locals()))
         self.assertEqual(nvr_reporter.get_latest_build(), 'my-operator-metadata-container-v1.2.3.20191022.dev-2')
 
 

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -544,7 +544,6 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
             .merge_streams_on_top_level_package_yaml())
 
     def test_create_metadata_dockerfile(self):
-        self.assertEqual(1,0)
         # using the real filesystem, because DockerfileParser library keeps
         # opening and closing files at every operation, really hard to mock
         exectools.cmd_assert('mkdir -p /tmp/my-operator')
@@ -575,7 +574,7 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
             self.assertItemsEqual([l.strip() for l in f.readlines()], [
                 'FROM scratch',
                 'COPY ./manifests /manifests',
-                'LABEL version=vX.Y.Z',
+                'LABEL version=vX.Y.Z-201908261419.dev',
                 'LABEL com.redhat.delivery.appregistry=true',
                 'LABEL name=openshift/ose-my-operator-metadata',
                 'LABEL com.redhat.component=my-operator-metadata-container',
@@ -1179,6 +1178,7 @@ class TestChannelVersion(unittest.TestCase):
 
 def get_builtin_module():
     return sys.modules.get('__builtin__', sys.modules.get('builtins'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -574,7 +574,7 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
             self.assertItemsEqual([l.strip() for l in f.readlines()], [
                 'FROM scratch',
                 'COPY ./manifests /manifests',
-                'LABEL version=vX.Y.Z-201908261419.dev',
+                'LABEL version=vX.Y.Z.201908261419.dev',
                 'LABEL com.redhat.delivery.appregistry=true',
                 'LABEL name=openshift/ose-my-operator-metadata',
                 'LABEL com.redhat.component=my-operator-metadata-container',
@@ -1169,18 +1169,20 @@ class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
         }
     })
 
-    def test_unpack_operator_nvr(self):
+    def test_unpack_nvr(self):
         nvr_reporter = operator_metadata.OperatorMetadataLatestNvrReporter('package-container-v1.2.3-20191022', 'dev', self.runtime)
-        self.assertEquals(nvr_reporter.unpack_operator_nvr(), ('package', 'v1.2.3-20191022'))
+        self.assertEquals(nvr_reporter.unpack_nvr(nvr_reporter.operator_nvr), ('package', 'v1.2.3', '20191022'))
+        # Add test for metadata nvr
 
     def test_get_latest_build(self):
         nvr_reporter = operator_metadata.OperatorMetadataLatestNvrReporter('my-operator-container-v1.2.3-20191022', 'dev', self.runtime)
 
         flexmock(nvr_reporter, get_all_builds=[
-            'my-operator-metadata-container-v1.2.3-20191022.dev-1',
-            'my-operator-metadata-container-v1.2.3-20191022.dev-2'])
+            'my-operator-metadata-container-v1.2.3.20191022.dev-1',
+            'my-operator-metadata-container-v1.2.3.20191022.dev-2'])
 
-        self.assertEqual(nvr_reporter.get_latest_build(), 'my-operator-metadata-container-v1.2.3-20191022.dev-2')
+        #import code; code.interact(local=dict(globals(), **locals()))
+        self.assertEqual(nvr_reporter.get_latest_build(), 'my-operator-metadata-container-v1.2.3.20191022.dev-2')
 
 
 class TestChannelVersion(unittest.TestCase):

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -1151,9 +1151,36 @@ class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
         (flexmock(operator_metadata.exectools)
             .should_receive('cmd_gather')
             .with_args(expected_cmd)
+            .once()
             .and_return(('..', 'irrelevant', '..')))
 
         operator_metadata.OperatorMetadataLatestBuildReporter('my-operator', runtime).get_latest_build()
+
+
+class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
+    runtime = type('TestRuntime', (object,), {
+        'group_config': type('TestGroupConfig', (object,), {
+            'branch': 'my-target-branch'
+        }),
+        'image_map': {
+            'my-operator': type('TestImageMetadata', (object,), {
+                'config': {}
+            })
+        }
+    })
+
+    def test_unpack_operator_nvr(self):
+        nvr_reporter = operator_metadata.OperatorMetadataLatestNvrReporter('package-container-v1.2.3-20191022', 'dev', self.runtime)
+        self.assertEquals(nvr_reporter.unpack_operator_nvr(), ('package', 'v1.2.3-20191022'))
+
+    def test_get_latest_build(self):
+        nvr_reporter = operator_metadata.OperatorMetadataLatestNvrReporter('my-operator-container-v1.2.3-20191022', 'dev', self.runtime)
+
+        flexmock(nvr_reporter, get_all_builds=[
+            'my-operator-metadata-container-v1.2.3-20191022.dev-1',
+            'my-operator-metadata-container-v1.2.3-20191022.dev-2'])
+
+        self.assertEqual(nvr_reporter.get_latest_build(), 'my-operator-metadata-container-v1.2.3-20191022.dev-2')
 
 
 class TestChannelVersion(unittest.TestCase):

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -544,6 +544,7 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
             .merge_streams_on_top_level_package_yaml())
 
     def test_create_metadata_dockerfile(self):
+        self.assertEqual(1,0)
         # using the real filesystem, because DockerfileParser library keeps
         # opening and closing files at every operation, really hard to mock
         exectools.cmd_assert('mkdir -p /tmp/my-operator')
@@ -1178,3 +1179,6 @@ class TestChannelVersion(unittest.TestCase):
 
 def get_builtin_module():
     return sys.modules.get('__builtin__', sys.modules.get('builtins'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
With the advent of ART-874 the process of actually shipping these new metadata containers is fairly cumbersome and error-prone. With every release slightly overlapping with the ones before and after, it's easy to include metadata for the wrong operator containers.

This PR is for improvements to make it easier to include the right metadata and verify it afterward:

- `doozer operator-metadata:build` takes an NVR and a stream; currently it creates a container with the same V and auto-incrementing R starting at 1. With several operator builds at the same version it's tedious to determine which is intended. Let's make them easily identifiable. The metadata container still needs the R to auto-increment, but we can put whatever we want in the V, so let's put the original R and the stream in there:
  `elasticsearch-operator-container-v4.1.16-201909131234`
  gets metadata container:
  `elasticsearch-operator-metadata-container-v4.1.16.201909131234.dev-1`
- `doozer operator-metadata:latest-build` takes a distgit and looks up the latest metadata container on the current openshift version. It needs to be able to look up the latest metadata container for a specific operator NVR and stream.
  `doozer operator-metadata:latest-build --nvr elasticsearch-operator-container-v4.1.16-201909131234 --stream stage`
  gets metadata container:
  `elasticsearch-operator-metadata-container-v4.1.16.201909131234.stage-<1,2,3...>`