### PR TITLE
Adding brew_tag option

### DIFF
--- a/doozer
+++ b/doozer
@@ -119,6 +119,8 @@ def print_version(ctx, param, value):
 @click.option('--local/--osbs', default=False, is_flag=True, help='--local to run in local-only mode, --osbs to run on build cluster (default)')
 @click.option("--rhpkg-config", metavar="RHPKG_CONFIG",
               help="Path to rhpkg config file to use instead of system default")
+@click.option("--brew-tag", metavar="BREW_TAG",
+              help="Override brew tag to expect for images built")
 @click.pass_context
 def cli(ctx, **kwargs):
     global CTX_GLOBAL

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -179,9 +179,7 @@ class ImageMetadata(Metadata):
 
         component_name = self.get_component_name()
 
-        tag = "{}-candidate".format(self.branch())
-
-        rc, stdout, stderr = exectools.cmd_gather(["brew", "latest-build", tag, component_name])
+        rc, stdout, stderr = exectools.cmd_gather(["brew", "latest-build", self.brew_tag(), component_name])
 
         assertion.success(rc, "Unable to search brew builds: %s" % stderr)
 
@@ -191,7 +189,7 @@ class ImageMetadata(Metadata):
             # If no builds found, `brew latest-build` output will appear as:
             # Build                                     Tag                   Built by
             # ----------------------------------------  --------------------  ----------------
-            raise IOError("No builds detected for %s using tag: %s" % (self.qualified_name, tag))
+            raise IOError("No builds detected for %s using tag: %s" % (self.qualified_name, self.brew_tag()))
 
         # latest example: "registry-console-docker-v3.6.173.0.75-1""
         name, version, release = latest.rsplit("-", 2)  # [ "registry-console-docker", "v3.6.173.0.75", "1"]

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -105,6 +105,12 @@ class Metadata(object):
             return self.config.distgit.branch
         return self.runtime.branch
 
+    def brew_tag(self):
+        if self.runtime.brew_tag:
+            return self.runtime.brew_tag
+        else:
+            return '{}-candidate'.format(self.branch())
+
     def cgit_url(self, filename):
         rev = self.branch()
         ret = "/".join((self.runtime.group_config.urls.cgit, self.qualified_name, "plain", filename))

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -402,7 +402,7 @@ class OperatorMetadataBuilder:
 
     @property
     def target(self):
-        return '{}-candidate'.format(self.operator_branch)
+        return self.runtime.brew_tag if self.runtime.brew_tag else '{}-candidate'.format(self.operator_branch)
 
     @property
     def operator_name(self):
@@ -555,7 +555,7 @@ class OperatorMetadataLatestBuildReporter:
 
     @property
     def target(self):
-        return '{}-candidate'.format(self.operator_branch)
+        return self.runtime.brew_tag if self.runtime.brew_tag else '{}-candidate'.format(self.operator_branch)
 
     @property
     def operator_branch(self):
@@ -627,7 +627,7 @@ class OperatorMetadataLatestNvrReporter:
 
     @property
     def brew_tag(self):
-        return '{}-candidate'.format(self.operator_branch)
+        return self.runtime.brew_tag if self.runtime.brew_tag else '{}-candidate'.format(self.operator_branch)
 
     @property
     def operator_branch(self):

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -119,6 +119,7 @@ class Runtime(object):
         self.load_disabled = False
         self.data_path = None
         self.data_dir = None
+        self.brew_tag = None
 
         for key, val in kwargs.items():
             self.__dict__[key] = val
@@ -339,6 +340,11 @@ class Runtime(object):
                             .format(val, e)
                         )
                 scanner.matches = regexen
+
+            if self.group_config.brew_tag:
+                self.brew_tag = self.group_config.brew_tag
+            else:
+                self.brew_tag = '{}-candidate'.format(self.branch)
 
             # Flattens a list like like [ 'x', 'y,z' ] into [ 'x.yml', 'y.yml', 'z.yml' ]
             # for later checking we need to remove from the lists, but they are tuples. Clone to list
@@ -983,7 +989,7 @@ class Runtime(object):
         # return a dict of all the latest builds for this group, according to
         # the branch's candidate tag in brew. each entry is name => tuple(version, release).
         output, _ = exectools.cmd_assert(
-            "brew list-tagged --quiet --latest {}-candidate".format(self.branch),
+            "brew list-tagged --quiet --latest {}".format(self.brew_tag),
             retries=3,
         )
         builds = [

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -751,7 +751,9 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
     def test_property_target(self):
         nvr = '...irrelevant...'
         stream = '...irrelevant...'
-        runtime = '...irrelevant...'
+        runtime = type('TestRuntime', (object,), {
+            'brew_tag': None
+        })
         cached_attrs = {
             'operator_branch': 'my-operator-branch'
         }


### PR DESCRIPTION
@thiagoalessio @sosiouxme @tbielawa 
Adding brew_tag option 
See [RCM-69565](https://projects.engineering.redhat.com/browse/RCM-69565) for specific details.
Basically, doozer assumes (and has hard-coded) that the brew tag will always match the same pattern. This is only true for OpenShift and the rest of the company just sort of does whatever. So this allows an override.