### PR TITLE
Python 3 porting: Run `futurize --stage1`

### DIFF
--- a/doozerlib/__init__.py
+++ b/doozerlib/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from .runtime import Runtime
 from .pushd import Dir
 

--- a/doozerlib/assertion.py
+++ b/doozerlib/assertion.py
@@ -5,6 +5,7 @@ the asserted condition is not met.
 The use of the FileNotFound exception makes this Python3 ready.
 Making them functions keeps the exception definition localized.
 """
+from __future__ import unicode_literals
 import os
 import errno
 

--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -1,6 +1,8 @@
 """
 Utility functions for general interactions with Brew and Builds
 """
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 # stdlib
 import ast
@@ -13,9 +15,9 @@ from multiprocessing import Lock
 import shlex
 import traceback
 
-import exceptions
-import exectools
-import logutil
+from . import exceptions
+from . import exectools
+from . import logutil
 
 # 3rd party
 import click

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -245,8 +245,8 @@ def rpms_build(runtime, version, release, scratch):
         exit(0)
 
     results = runtime.parallel_exec(
-        lambda rpm_terminate_event: rpm_terminate_event[0].build_rpm(
-            version, release, rpm_terminate_event[1], scratch),
+        lambda rpm, terminate_event: rpm.build_rpm(
+            version, release, terminate_event, scratch),
         items)
     results = results.get()
     failed = [name for name, r in results if not r]
@@ -885,9 +885,9 @@ def images_build_image(runtime, odcs, repo_type, repo, push_to_defaults, push_to
         threads = None
 
     results = runtime.parallel_exec(
-        lambda dgr_terminate_event: dgr_terminate_event[0].build_container(
+        lambda dgr, terminate_event: dgr.build_container(
             odcs, repo_type, repo, push_to_defaults, additional_registries=push_to,
-            dgr_terminate_event[1]=dgr_terminate_event[1], scratch=scratch, realtime=(threads == 1)),
+            terminate_event=terminate_event, scratch=scratch, realtime=(threads == 1)),
         items, n_threads=threads)
     results = results.get()
 
@@ -1001,8 +1001,8 @@ def images_push(runtime, tag, version_release, to_defaults, late_only, to, dry_r
         # Push early images
 
         results = runtime.parallel_exec(
-            lambda img_terminate_event:
-                img_terminate_event[0].distgit_repo().push_image(tag, to_defaults, additional_registries,
+            lambda img, terminate_event:
+                img.distgit_repo().push_image(tag, to_defaults, additional_registries,
                                               version_release_tuple=version_release_tuple, dry_run=dry_run),
             items,
             n_threads=4

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+from __future__ import unicode_literals
 from doozerlib import version
 from doozerlib import Runtime, Dir
 from doozerlib import state
@@ -243,8 +245,8 @@ def rpms_build(runtime, version, release, scratch):
         exit(0)
 
     results = runtime.parallel_exec(
-        lambda (rpm, terminate_event): rpm.build_rpm(
-            version, release, terminate_event, scratch),
+        lambda rpm_terminate_event: rpm_terminate_event[0].build_rpm(
+            version, release, rpm_terminate_event[1], scratch),
         items)
     results = results.get()
     failed = [name for name, r in results if not r]
@@ -883,9 +885,9 @@ def images_build_image(runtime, odcs, repo_type, repo, push_to_defaults, push_to
         threads = None
 
     results = runtime.parallel_exec(
-        lambda (dgr, terminate_event): dgr.build_container(
+        lambda dgr_terminate_event: dgr_terminate_event[0].build_container(
             odcs, repo_type, repo, push_to_defaults, additional_registries=push_to,
-            terminate_event=terminate_event, scratch=scratch, realtime=(threads == 1)),
+            dgr_terminate_event[1]=dgr_terminate_event[1], scratch=scratch, realtime=(threads == 1)),
         items, n_threads=threads)
     results = results.get()
 
@@ -999,8 +1001,8 @@ def images_push(runtime, tag, version_release, to_defaults, late_only, to, dry_r
         # Push early images
 
         results = runtime.parallel_exec(
-            lambda (img, terminate_event):
-                img.distgit_repo().push_image(tag, to_defaults, additional_registries,
+            lambda img_terminate_event:
+                img_terminate_event[0].distgit_repo().push_image(tag, to_defaults, additional_registries,
                                               version_release_tuple=version_release_tuple, dry_run=dry_run),
             items,
             n_threads=4
@@ -1756,7 +1758,7 @@ quay registry:
 
             # End 'for image in images' loop
             #############################################################
-        except state.DoozerStateError, serr:
+        except state.DoozerStateError as serr:
             red_print(serr.message)
             state.record_image_fail(lstate, image, serr.message, runtime.logger)
 
@@ -2017,7 +2019,7 @@ def release_gen_payload(runtime, src_dest, image_stream, is_base, pattern):
 
             # End 'for image in images' loop
             #############################################################
-        except state.DoozerStateError, serr:
+        except state.DoozerStateError as serr:
             red_print(serr.message)
             state.record_image_fail(lstate, image, serr.message, runtime.logger)
 

--- a/doozerlib/cli_opts.py
+++ b/doozerlib/cli_opts.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import yaml
 
 GLOBAL_OPT_DEFAULTS = {

--- a/doozerlib/config.py
+++ b/doozerlib/config.py
@@ -1,10 +1,13 @@
-import metadata
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from . import metadata
 import yaml
 from pykwalify.core import Core
 import os
 import shutil
-from pushd import Dir
-import exectools
+from .pushd import Dir
+from . import exectools
 import sys
 import csv
 

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import hashlib
 import json
 import os
@@ -15,12 +17,12 @@ from datetime import datetime, timedelta
 
 from dockerfile_parse import DockerfileParser
 
-import logutil
-import assertion
-import exectools
-from pushd import Dir
-from brew import watch_task, check_rpm_buildroot
-from model import Model, Missing
+from . import logutil
+from . import assertion
+from . import exectools
+from .pushd import Dir
+from .brew import watch_task, check_rpm_buildroot
+from .model import Model, Missing
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.util import yellow_print
 from doozerlib import state

--- a/doozerlib/dotconfig.py
+++ b/doozerlib/dotconfig.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import yaml
 import os
 import shutil

--- a/doozerlib/exceptions.py
+++ b/doozerlib/exceptions.py
@@ -1,6 +1,7 @@
 """Common tooling exceptions. Store them in this central place to
 avoid circular imports
 """
+from __future__ import unicode_literals
 
 
 class DoozerFatalError(Exception):

--- a/doozerlib/exectools.py
+++ b/doozerlib/exectools.py
@@ -5,6 +5,8 @@ ordinary subprocess behaviors.
 """
 
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import subprocess
 import time
@@ -14,10 +16,10 @@ import os
 from fcntl import fcntl, F_GETFL, F_SETFL
 from os import O_NONBLOCK, read
 
-import logutil
-import pushd
-import assertion
-from util import red_print, green_print, yellow_print
+from . import logutil
+from . import pushd
+from . import assertion
+from .util import red_print, green_print, yellow_print
 
 SUCCESS = 0
 

--- a/doozerlib/gitdata.py
+++ b/doozerlib/gitdata.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import yaml
 import logging
 import urlparse
 import os
 import shutil
-import exectools
-from pushd import Dir
+from . import exectools
+from .pushd import Dir
 
 
 SCHEMES = ['ssh', 'ssh+git', "http", "https"]

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -1,17 +1,19 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import json
 import bashlex
 from dockerfile_parse import DockerfileParser
-from distgit import pull_image
-from metadata import Metadata
-from model import Missing
-from pushd import Dir
+from .distgit import pull_image
+from .metadata import Metadata
+from .model import Missing
+from .pushd import Dir
 from doozerlib.exceptions import DoozerFatalError
 
-import assertion
-import logutil
-import exectools
-import logutil
+from . import assertion
+from . import logutil
+from . import exectools
+from . import logutil
 
 logger = logutil.getLogger(__name__)
 

--- a/doozerlib/logutil.py
+++ b/doozerlib/logutil.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import logging
 
 

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -1,13 +1,15 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import yaml
 import os
 import urllib
 
-import assertion
-from distgit import ImageDistGitRepo, RPMDistGitRepo
-import exectools
-import logutil
+from . import assertion
+from .distgit import ImageDistGitRepo, RPMDistGitRepo
+from . import exectools
+from . import logutil
 
-from model import Model, Missing
+from .model import Model, Missing
 
 #
 # These are used as labels to index selection of a subclass.

--- a/doozerlib/model.py
+++ b/doozerlib/model.py
@@ -1,5 +1,6 @@
+from __future__ import unicode_literals
 
-class ModelException(StandardError):
+class ModelException(Exception):
 
     def __init__(self, msg, result=None, **kwargs):
         super(self.__class__, self).__init__(msg)

--- a/doozerlib/model.py
+++ b/doozerlib/model.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+
 class ModelException(Exception):
 
     def __init__(self, msg, result=None, **kwargs):

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import unicode_literals
 import glob
 import json
 import re

--- a/doozerlib/pushd.py
+++ b/doozerlib/pushd.py
@@ -16,6 +16,7 @@ Example:
 
   # os.getcwd() returns /tmp/somewhere
 """
+from __future__ import unicode_literals
 
 import os
 import threading

--- a/doozerlib/repos.py
+++ b/doozerlib/repos.py
@@ -1,4 +1,6 @@
-from model import Model, ModelException, Missing
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from .model import Model, ModelException, Missing
 import yaml
 import requests
 import json

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -1,14 +1,16 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import glob
 import os
 import traceback
 import re
 
-import exectools
-from pushd import Dir
-from brew import watch_task
+from . import exectools
+from .pushd import Dir
+from .brew import watch_task
 
-from metadata import Metadata
-from model import Missing
+from .metadata import Metadata
+from .model import Missing
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.source_modifications import SourceModifierFactory
 

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from multiprocessing import Lock
 from multiprocessing.dummy import Pool as ThreadPool
 from pykwalify.core import Core
@@ -18,18 +20,18 @@ import urlparse
 import signal
 
 from doozerlib import gitdata
-import logutil
-import assertion
-import exectools
-from pushd import Dir
+from . import logutil
+from . import assertion
+from . import exectools
+from .pushd import Dir
 
-from image import ImageMetadata
-from rpmcfg import RPMMetadata
+from .image import ImageMetadata
+from .rpmcfg import RPMMetadata
 from doozerlib import state
-from model import Model, Missing
+from .model import Model, Missing
 from multiprocessing import Lock
-from repos import Repos
-import brew
+from .repos import Repos
+from . import brew
 from doozerlib.exceptions import DoozerFatalError
 
 

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -101,6 +101,16 @@ def wrap_exception(func):
             raise WrapException()
     return wrapper
 
+
+def _unpack_tuple_args(func):
+    """ Decorate a function for unpacking the tuple argument `args`
+        This is used to workaround Python 3 lambda not unpacking tuple arguments (PEP-3113)
+    """
+    @functools.wraps(func)
+    def wrapper(args):
+        return func(*args)
+    return wrapper
+
 # ============================================================================
 # Runtime object definition
 # ============================================================================
@@ -122,6 +132,7 @@ class Runtime(object):
         self.data_path = None
         self.data_dir = None
         self.brew_tag = None
+        self.latest_parent_version = False
 
         for key, val in kwargs.items():
             self.__dict__[key] = val
@@ -973,8 +984,11 @@ class Runtime(object):
         n_threads = n_threads if n_threads is not None else len(args)
         terminate_event = threading.Event()
         pool = ThreadPool(n_threads)
+        # Python 3 doesn't allow to unpack tuple argument in a lambdas or functions (PEP-3113).
+        # `_unpack_tuple_args` is a workaround that unpacks the tuple as arguments for the function passed to `ThreadPool.map_async`.
+        # `starmap_async` can be used in the future when we don't keep compatibility with Python 2.
         ret = pool.map_async(
-            wrap_exception(f),
+            wrap_exception(_unpack_tuple_args(f)),
             [(a, terminate_event) for a in args])
         pool.close()
         try:
@@ -1005,7 +1019,7 @@ class Runtime(object):
     def scan_distgit_sources(self):
         builds = self.builds_for_group_branch()  # query for builds only once
         return self.parallel_exec(
-            lambda m: (m[0], m[0].distgit_repo(autoclone=False).matches_source_commit(builds)),
+            lambda meta, _: (meta, meta.distgit_repo(autoclone=False).matches_source_commit(builds)),
             self.image_metas() + self.rpm_metas(),
             n_threads=100,
         ).get()

--- a/doozerlib/state.py
+++ b/doozerlib/state.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 STATE_PEND = 'pending'
 STATE_PASS = 'passed'
 STATE_FAIL = 'failed'

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import click
 import copy
 import os

--- a/rundoozer/setup.py
+++ b/rundoozer/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from setuptools import setup
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from setuptools import setup
 
 with open('./requirements.txt') as f:

--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -1,6 +1,7 @@
 """
 Test the task related functions for the OpenShift Image/RPM Build Tool
 """
+from __future__ import unicode_literals
 import unittest
 
 from doozerlib import assertion

--- a/tests/test_distgit/support.py
+++ b/tests/test_distgit/support.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import StringIO

--- a/tests/test_distgit/test_build_image_ref_name.py
+++ b/tests/test_distgit/test_build_image_ref_name.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 from doozerlib import distgit
 

--- a/tests/test_distgit/test_convert_source_url_to_https.py
+++ b/tests/test_distgit/test_convert_source_url_to_https.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 from doozerlib import distgit
 

--- a/tests/test_distgit/test_generic_distgit.py
+++ b/tests/test_distgit/test_generic_distgit.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import errno
 import os
 import unittest

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import re
 import tempfile
 import unittest

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -163,7 +163,7 @@ class TestImageDistGit(TestDistgit):
                             name="_irrelevant_",
                             logger=flexmock(info=lambda *_: None))
 
-        expected = (metadata, "IOError('io-error',)")
+        expected = (metadata, repr(IOError("io-error")))
         actual = distgit.ImageDistGitRepo(metadata, autoclone=False).push()
 
         self.assertEqual(expected, actual)

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import errno
 import os
 import sys

--- a/tests/test_distgit/test_pull_image.py
+++ b/tests/test_distgit/test_pull_image.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 import flexmock
 from doozerlib import distgit

--- a/tests/test_distgit/test_recursive_overwrite.py
+++ b/tests/test_distgit/test_recursive_overwrite.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 import flexmock
 from doozerlib import distgit

--- a/tests/test_distgit/test_rpm_distgit.py
+++ b/tests/test_distgit/test_rpm_distgit.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import flexmock

--- a/tests/test_exectools.py
+++ b/tests/test_exectools.py
@@ -4,6 +4,7 @@ Test functions related to controlled command execution
 """
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import unittest
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -2,6 +2,7 @@
 """
 Test the ImageMetadata class
 """
+from __future__ import unicode_literals
 import unittest
 
 import os

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
 import unittest
 
 import os

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import flexmock
 import io
 import shutil

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import flexmock
 import io
 import shutil
@@ -1170,6 +1169,12 @@ class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
             })
         }
     })
+    # runtime = MagicMock(
+    #     group_config=MagicMock(branch='my-target-branch'),
+    #     image_map={
+    #         'my-operator': MagicMock(config={})
+    #     },
+    # )
 
     def test_unpack_nvr(self):
         nvr_reporter = operator_metadata.OperatorMetadataLatestNvrReporter('package-container-v1.2.3-20191022', 'dev', self.runtime)

--- a/tests/test_pushd.py
+++ b/tests/test_pushd.py
@@ -1,6 +1,7 @@
 """
 Test the Dir() class.  Verify that it works as a context_manager.
 """
+from __future__ import unicode_literals
 
 import unittest
 

--- a/tests/test_rpmcfg.py
+++ b/tests/test_rpmcfg.py
@@ -2,6 +2,7 @@
 """
 Test the ImageMetadata class
 """
+from __future__ import unicode_literals
 import unittest
 
 import os

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -22,6 +22,14 @@ class RuntimeTestCase(unittest.TestCase):
         ret = runtime.Runtime._parallel_exec(lambda x: x * 2, xrange(5), n_threads=20)
         self.assertEqual(ret.get(), [0, 2, 4, 6, 8])
 
+    def test_parallel_exec2(self):
+        items = [1, 2, 3]
+        results = stub_runtime().parallel_exec(
+            lambda k, v: k,
+            items, n_threads=4)
+        results = results.get()
+        self.assertEqual(results, items)
+
     def test_get_remote_branch_ref(self):
         rt = stub_runtime()
         flexmock(exectools).should_receive("cmd_assert").once().and_return("spam", "")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import unicode_literals
 import unittest
 import flexmock
 from doozerlib import runtime, exectools, logutil, model


### PR DESCRIPTION
I am trying [Futurize][] for porting Python 2 code to Python 3.
The tool is one of recommended tools listed on the official Python HOWTOs documentation [Porting Python 2 Code to Python 3][].

Futurize can divide the porting into two stages. Stage 1 is for “safe” changes that modernize the code but do not break Python 2.6 compatibility or introduce a depdendency on the future package. Stage 2 is to complete the process.

The PR is generated with the following command:

```bash
futurize --stage1 --unicode-literals --nobackups --write .
```

[Porting Python 2 Code to Python 3]: https://docs.python.org/3/howto/pyporting.html
[Futurize]: http://python-future.org/automatic_conversion.html

## NOTE
1. Only stage 1 of the Futurize porting process is run so that we are expecting this will not break our existing Python 2 compatibility but it will still not run on Python 3.

2. Python 3 doesn't allow to unpack tuple argument in a lambdas or functions (PEP-3113). e.g.

```python
results = runtime.parallel_exec(
        lambda (rpm, terminate_event): rpm.build_rpm(
            version, release, terminate_event, scratch),
        items)
```

This could be change to use multiple arguments:

``` python
results = runtime.parallel_exec(
        lambda rpm, terminate_event: rpm.build_rpm(
            version, release, terminate_event, scratch),
        items)
```

However, `ThreadPool.map_async` only accept functions with a single argument.

To workaround this, I added a wrapper function `_unpack_tuple_args` to unpack tuple as arguments for the function passed to `ThreadPool.map_async`.

NOTE: In the future when we don't keep compatibility with Python 2, `starmap_async` can be used instead.