### PR TITLE
Fix operator metadata lookups [ART-1238] [ART-1175]

### DIFF
--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -593,11 +593,12 @@ class OperatorMetadataLatestNvrReporter:
 
     @log
     def get_latest_build(self):
-        candidate_release = 0
+        candidate_release = -1
         candidate = None
 
         for brew_build in self.get_all_builds():
             component, version, release = self.unpack_nvr(brew_build)
+            release = int(re.search(r'\d+', release).group())
             if component == self.metadata_component and version == self.metadata_version and release > candidate_release:
                 candidate_release = release
                 candidate = brew_build

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -603,12 +603,6 @@ class OperatorMetadataLatestNvrReporter:
                 candidate_release = release
                 candidate = brew_build
 
-        if not candidate:
-            # XXX: This fallback should be removed after operator metadata containers get built with
-            # the new naming scheme. https://jira.coreos.com/browse/ART-1175
-            logger.warning('Did not find a match under the new naming scheme. Falling back to the old')
-            candidate = OperatorMetadataLatestBuildReporter(self.operator_name, self.runtime).get_latest_build()
-
         return candidate
 
     @log

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -1190,6 +1190,19 @@ class TestOperatorMetadataLatestNvrReporter(unittest.TestCase):
 
         self.assertEqual(nvr_reporter.get_latest_build(), 'my-operator-metadata-container-v1.2.3.20191022.dev-2')
 
+        # test that releases are compared numerically
+        flexmock(nvr_reporter, get_all_builds=[
+            'my-operator-metadata-container-v1.2.3.20191022.dev-12',
+            'my-operator-metadata-container-v1.2.3.20191022.dev-2',
+        ])
+
+        self.assertEqual(nvr_reporter.get_latest_build(), 'my-operator-metadata-container-v1.2.3.20191022.dev-12')
+
+        # technically 0 is a valid release... but who would do that?
+        flexmock(nvr_reporter, get_all_builds=['my-operator-metadata-container-v1.2.3.20191022.dev-0'])
+
+        self.assertEqual(nvr_reporter.get_latest_build(), 'my-operator-metadata-container-v1.2.3.20191022.dev-0')
+
 
 class TestChannelVersion(unittest.TestCase):
 

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -1106,6 +1106,7 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
 class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
     def test_get_latest_build(self):
         runtime = type('TestRuntime', (object,), {
+            'brew_tag': None,
             'group_config': type('TestGroupConfig', (object,), {
                 'branch': 'my-target-branch'
             }),
@@ -1130,6 +1131,7 @@ class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
 
     def test_get_latest_build_with_custom_component_name(self):
         runtime = type('TestRuntime', (object,), {
+            'brew_tag': None,
             'group_config': type('TestGroupConfig', (object,), {
                 'branch': 'my-target-branch'
             }),
@@ -1158,7 +1160,7 @@ class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
         operator_metadata.OperatorMetadataLatestBuildReporter('my-operator', runtime).get_latest_build()
 
 
-class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
+class TestOperatorMetadataLatestNvrReporter(unittest.TestCase):
     runtime = type('TestRuntime', (object,), {
         'group_config': type('TestGroupConfig', (object,), {
             'branch': 'my-target-branch'
@@ -1172,15 +1174,19 @@ class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
 
     def test_unpack_nvr(self):
         nvr_reporter = operator_metadata.OperatorMetadataLatestNvrReporter('package-container-v1.2.3-20191022', 'dev', self.runtime)
-        self.assertEquals(nvr_reporter.unpack_nvr(nvr_reporter.operator_nvr), ('package', 'v1.2.3', '20191022'))
+        self.assertEquals(nvr_reporter.unpack_nvr(nvr_reporter.operator_nvr), ('package-container', 'v1.2.3', '20191022'))
         # Add test for metadata nvr
 
     def test_get_latest_build(self):
         nvr_reporter = operator_metadata.OperatorMetadataLatestNvrReporter('my-operator-container-v1.2.3-20191022', 'dev', self.runtime)
+        self.assertEquals(nvr_reporter.metadata_component, 'my-operator-metadata-container')
 
+        # test ignoring builds for later operators
         flexmock(nvr_reporter, get_all_builds=[
             'my-operator-metadata-container-v1.2.3.20191022.dev-1',
-            'my-operator-metadata-container-v1.2.3.20191022.dev-2'])
+            'my-operator-metadata-container-v1.2.3.20191022.dev-2',
+            'my-operator-metadata-container-v1.2.4.20191029.dev-12',
+        ])
 
         self.assertEqual(nvr_reporter.get_latest_build(), 'my-operator-metadata-container-v1.2.3.20191022.dev-2')
 


### PR DESCRIPTION
Turns out the package name was being truncated so the fallback method of lookup was always used (just get the latest in the stream).

```
$ doozer -g openshift-4.3 operator-metadata:latest-build --nvr cluster-logging-operator-container-v4.3.0-201911151317 --stream dev
...
cluster-logging-operator-metadata-container-v4.3.0.201911191807.dev-2
```

Now it correctly finds `cluster-logging-operator-container-v4.3.0-201911151317` as well as handling ptp-operator and its oddball naming correctly.

I wonder if this affected any stage pushes? It seems unlikely, but it would come into play if we ever needed to revert opmeta to refer to something earlier.

Also could not help fixing a few fiddly things along the way...