### PR TITLE
Update dev container configuration

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,17 +1,16 @@
 FROM fedora:30
 
+ENV PYCURL_SSL_LIBRARY=openssl
+
 RUN dnf install -y \
     # runtime dependencies
-    krb5-workstation rsync \
-    python2 python2-certifi python2-click python2-dockerfile-parse python2-koji \
-    python2-pykwalify python2-pyyaml python2-requests \
-    python2-requests-kerberos python2-pygit2 python2-future \
-    python3-certifi python3-click python3-dockerfile-parse python3-koji \
-    python3-pykwalify python3-pyyaml python3-requests \
-    python3-requests-kerberos python3-pygit2 python3-future \
+    krb5-workstation git rsync skopeo podman docker \
+    python2 python2-certifi python2-rpm \
+    python3 python3-certifi python3-rpm \
     # development dependencies
-    gcc python2-devel python2-pip python2-typing pylint krb5-devel git \
-    python3-devel python3-autopep8 python3-typing-extensions \
+    gcc krb5-devel openssl-devel \
+    python2-devel python2-pip \
+    python3-devel python3-pip \
     # other tools
     bash-completion vim tmux procps-ng psmisc wget curl net-tools iproute \
   # Red Hat IT Root CA
@@ -26,6 +25,12 @@ RUN wget -O /etc/yum.repos.d/rcm-tools-fedora.repo https://download.devel.redhat
   && dnf install -y koji brewkoji \
   && dnf install -y rhpkg \
   && dnf clean all
+
+ARG OC_VERSION=4.2.8
+# include oc client
+RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux-"$OC_VERSION".tar.gz \
+  && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \
+  && rm /tmp/openshift-client-linux-"$OC_VERSION".tar.gz
 
 # Create a non-root user - see https://aka.ms/vscode-remote/containers/non-root-user.
 ARG USERNAME=dev
@@ -44,9 +49,5 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
 
 # Configure Kerberos
 COPY .devcontainer/krb5-redhat.conf /etc/krb5.conf.d/
-# Workaround for running `kinit` in an unprivileged container
-# by storing krb5 credential cache into a file rather than kernel keyring.
-# See https://blog.tomecek.net/post/kerberos-in-a-container/
-ENV KRB5CCNAME=FILE:/tmp/krb5cache
 
 USER "$USER_UID"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	// The optional 'runArgs' property can be used to specify additional runtime arguments.
 	"runArgs": [
 		// Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker for details.
-		// "-v","/var/run/docker.sock:/var/run/docker.sock",
+		"-v","/var/run/docker.sock:/var/run/docker.sock",
 		// Uncomment the next line if you will be using a ptrace-based debugger like C++, Go, and Rust.
 		// "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
 
@@ -49,6 +49,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
-		"ms-python.python"
+		"ms-python.python",
+		"eamodio.gitlens"
 	]
 }

--- a/.devcontainer/krb5-redhat.conf
+++ b/.devcontainer/krb5-redhat.conf
@@ -5,6 +5,11 @@ REDHAT.COM = {
 }
 [domain_realm]
 .redhat.com = REDHAT.COM
+redhat.com = REDHAT.COM
 [libdefaults]
+# Workaround for running `kinit` in an unprivileged container
+# by storing krb5 credential cache into a file rather than kernel keyring.
+# See https://blog.tomecek.net/post/kerberos-in-a-container/
+default_ccache_name = FILE:/tmp/krb5cc_%{uid}
 rdns = false
 default_realm = REDHAT.COM

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,8 @@ coverage
 flake8
 flexmock
 mock
+pylint
 pytest
 tox
+typing
+typing-extensions


### PR DESCRIPTION
1. Install oc, podman, and docker.
2. Remove most RPM based Python packages and use `pip` versions instead (to be consistent with How OpenShift ART team actually installs dependencies).
3. Move Kerberos ccache configuration from environment variable to configuration file, so that the configuration will not lost after switching user with `sudo`.
4. Install GitLens plugin for VSCode on dev container start.