### PR TITLE
[ART-1343] Add multi-arch support on OLM Operators Metadata

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -2152,12 +2152,14 @@ def config_update_required(runtime, image_list):
 @click.argument("nvr_list", nargs=-1, required=True)
 @click.option("--stream", required=True, type=click.Choice(['dev', 'stage', 'prod']),
               help="Metadata repo to apply update. Possible values: dev, stage, prod.")
+@click.option("--image-ref-mode", required=False, type=click.Choice(['by-arch', 'manifest-list']),
+              help="Build mode for image references. Possible values: by-arch, manifest-list (default: group.yml operator_image_ref_mode)")
 @click.option("--merge-branch", required=False,
               help="Branch to be updated on the metadata repo (default: rhaos-4-rhel-7)")
 @click.option("-f", "--force", required=False, is_flag=True,
               help="Perform a build even if there is nothing new on the metadata repo")
 @pass_runtime
-def update_operator_metadata(runtime, nvr_list, stream, merge_branch, force=False):
+def update_operator_metadata(runtime, nvr_list, stream, image_ref_mode, merge_branch, force=False):
     """Update the corresponding metadata repositories of the given operators
     and build "metadata containers" with nothing but a collection of manifests on them.
 
@@ -2174,6 +2176,10 @@ def update_operator_metadata(runtime, nvr_list, stream, merge_branch, force=Fals
     """
     runtime.initialize(clone_distgits=False)
     runtime.assert_mutation_is_permitted()
+
+    if not image_ref_mode:
+        image_ref_mode = runtime.group_config.operator_image_ref_mode
+
     if not merge_branch:
         merge_branch = 'rhaos-4-rhel-7'
         # @TODO: populate merge_branch from runtime once the following MRs are merged:
@@ -2183,7 +2189,7 @@ def update_operator_metadata(runtime, nvr_list, stream, merge_branch, force=Fals
 
     try:
         ok = ThreadPool(cpu_count()).map(operator_metadata.update_and_build, [
-            (nvr, stream, runtime, merge_branch, force) for nvr in nvr_list
+            (nvr, stream, runtime, image_ref_mode, merge_branch, force) for nvr in nvr_list
         ])
         # @TODO: save state.yaml (check how to do that)
     except Exception as e:

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -308,7 +308,9 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
     def test_get_file_list_from_no_art_yaml(self):
         nvr = '...irrelevant...'
         stream = 'dev'
-        runtime = '...irrelevant...'
+        runtime = type('TestRuntime', (object,), {
+            'group_config': type('', (object,), {'vars': {}}),
+        })
         op_md = flexmock(
             operator_metadata.OperatorMetadataBuilder(nvr, stream, runtime),
             operator_art_yaml={},


### PR DESCRIPTION
Going to start a PR just so I can easily comment.
@thiagoalessio 

----
[ART-1343](https://jira.coreos.com/browse/ART-1343) && [ART-839](https://jira.coreos.com/browse/ART-839): Support 2 ways of building OLM operator metadata: `by-arch` or `manifest-list`.

Either by CLI option:
```
doozer -g openshift-4.2 \
  operator-metadata:build \
  cluster-logging-operator-container-v4.2.9-201911261133 \
  --stream dev \
  --image-ref-mode [by-arch|manifest-list]
```

Or by ocp-build-data's group.yml option:
* https://github.com/openshift/ocp-build-data/pull/241
* https://github.com/openshift/ocp-build-data/pull/242
* https://github.com/openshift/ocp-build-data/pull/243
* https://github.com/openshift/ocp-build-data/pull/244

## `by-arch` mode

when mode is `by-arch`, it creates additional manifests dirs and channels per arch, for example:
```
[cluster-logging-dev-operator-metadata]$ tree
.
├── Dockerfile
└── manifests
    ├── 4.1
    │   ├── cluster-loggings.crd.yaml
    │   ├── cluster-logging.v4.1.0.clusterserviceversion.yaml
    │   └── image-references
    ├── 4.2
    │   ├── cluster-loggings.crd.yaml
    │   ├── cluster-logging.v4.2.0.clusterserviceversion.yaml
    │   └── image-references
    ├── 4.2-s390x
    │   ├── cluster-loggings.crd.yaml
    │   ├── cluster-logging.v4.2.0-s390x.clusterserviceversion.yaml
    │   └── image-references
    ├── 4.3
    │   ├── cluster-loggings.crd.yaml
    │   ├── cluster-logging.v4.3.0.clusterserviceversion.yaml
    │   ├── collectors.crd.yaml
    │   ├── image-references
    │   └── logforwardings.crd.yaml
    └── cluster-logging.package.yaml
```
And image references will point to the `SHA` of a build of that image for the specific architecture.
It also lists each additional architecture as another **channel** in `package.yml`:
```
channels:
- currentCSV: clusterlogging.4.2.9-201911261133
  name: '4.2'

- currentCSV: clusterlogging.4.1.27-201912030019
  name: preview

- currentCSV: clusterlogging.4.3.0-201912020833
  name: '4.3'

- currentCSV: clusterlogging.4.2.9-201911261133-s390x
  name: 4.2-s390x

defaultChannel: '4.3'
packageName: cluster-logging
```

## `manifest-list` mode

When mode is `manifest-list`, no additional dirs are created and image references will point to the `SHA` of a Digest, containing `SHAs` for every architecture that the image was built.

## Still TODO

* [ ] Write more tests to demonstrate both ways of building metadata repo