### PR TITLE
Get rid of unicode warnings

### DIFF
--- a/doozerlib/__init__.py
+++ b/doozerlib/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from .runtime import Runtime
 from .pushd import Dir
 

--- a/doozerlib/assertion.py
+++ b/doozerlib/assertion.py
@@ -5,7 +5,6 @@ the asserted condition is not met.
 The use of the FileNotFound exception makes this Python3 ready.
 Making them functions keeps the exception definition localized.
 """
-from __future__ import unicode_literals
 import os
 import errno
 

--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -2,7 +2,6 @@
 Utility functions for general interactions with Brew and Builds
 """
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 # stdlib
 import ast

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
-from __future__ import unicode_literals
 from doozerlib import version
 from doozerlib import Runtime, Dir
 from doozerlib import state

--- a/doozerlib/cli_opts.py
+++ b/doozerlib/cli_opts.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import yaml
 
 GLOBAL_OPT_DEFAULTS = {

--- a/doozerlib/config.py
+++ b/doozerlib/config.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import unicode_literals
 from . import metadata
 import yaml
 from pykwalify.core import Core

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 import hashlib
 import json
 import os

--- a/doozerlib/dotconfig.py
+++ b/doozerlib/dotconfig.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import yaml
 import os
 import shutil

--- a/doozerlib/exceptions.py
+++ b/doozerlib/exceptions.py
@@ -1,9 +1,6 @@
 """Common tooling exceptions. Store them in this central place to
 avoid circular imports
 """
-from __future__ import unicode_literals
-
-
 class DoozerFatalError(Exception):
     """A broad exception for errors during Brew CRUD operations"""
     pass

--- a/doozerlib/exectools.py
+++ b/doozerlib/exectools.py
@@ -6,7 +6,6 @@ ordinary subprocess behaviors.
 
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import subprocess
 import time

--- a/doozerlib/gitdata.py
+++ b/doozerlib/gitdata.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 import yaml
 import logging
 import urlparse

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 import os
 import json
 import bashlex

--- a/doozerlib/logutil.py
+++ b/doozerlib/logutil.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import logging
 
 

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 import yaml
 import os
 import urllib

--- a/doozerlib/model.py
+++ b/doozerlib/model.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-
-
 class ModelException(Exception):
 
     def __init__(self, msg, result=None, **kwargs):

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import unicode_literals
 import glob
 import json
 import os

--- a/doozerlib/pushd.py
+++ b/doozerlib/pushd.py
@@ -16,8 +16,6 @@ Example:
 
   # os.getcwd() returns /tmp/somewhere
 """
-from __future__ import unicode_literals
-
 import os
 import threading
 

--- a/doozerlib/repos.py
+++ b/doozerlib/repos.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 from .model import Model, ModelException, Missing
 import yaml
 import requests

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 import glob
 import os
 import traceback

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 from multiprocessing import Lock
 from multiprocessing.dummy import Pool as ThreadPool
 from pykwalify.core import Core

--- a/doozerlib/source_modifications.py
+++ b/doozerlib/source_modifications.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals, print_function
+from __future__ import print_function
 import os
 import io
 from future.standard_library import install_aliases

--- a/doozerlib/state.py
+++ b/doozerlib/state.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 STATE_PEND = 'pending'
 STATE_PASS = 'passed'
 STATE_FAIL = 'failed'

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import click
 import copy
 import os


### PR DESCRIPTION
```
/usr/lib/python2.7/site-packages/doozerlib/cli/__main__.py:126: Warning:
Click detected the use of the unicode_literals __future__ import.  This
is heavily discouraged because it can introduce subtle bugs in your
code.  You should instead use explicit u"" literals for your unicode
strings.  For more information see
https://click.palletsprojects.com/python3/
```