### PR TITLE
make dotconfig respect unicode templates

### DIFF
--- a/doozerlib/dotconfig.py
+++ b/doozerlib/dotconfig.py
@@ -71,7 +71,7 @@ class Config(object):
                 else:
                     with open(self.full_path, 'w') as f:
                         if template:
-                            if isinstance(template, str):
+                            if isinstance(template, (str, unicode)):
                                 f.write(template)
                             elif isinstance(template, dict):
                                 yaml.dump(template, f, default_flow_style=False)


### PR DESCRIPTION
@thiagoalessio This is pretty urgent as CPaaS is dead in the water on doozer support until it's fixed and pushed to PyPi
Because the template was now `unicode` the type check was failing and and empty template was written.