### PR TITLE
Add use_source_version option for cpaas users

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1794,6 +1794,12 @@ class ImageDistGitRepo(DistGitRepo):
             if self.has_source():
                 self._merge_source()
 
+                # before mods, check if upstream source version should be used
+                # this will override the version fetch above
+                if self.metadata.config.get('use_source_version', False):
+                    dfp = DockerfileParser("Dockerfile")
+                    version = dfp.labels["version"]
+
             # Source or not, we should find a Dockerfile in the root at this point or something is wrong
             assertion.isfile("Dockerfile", "Unable to find Dockerfile in distgit root")
 

--- a/doozerlib/schema_image.yml
+++ b/doozerlib/schema_image.yml
@@ -7,6 +7,9 @@ mapping:
   "mode":
     type: str
 
+  "use_source_version":
+    type: bool
+
   "required":
     type: bool
 


### PR DESCRIPTION
@thiagoalessio @sosiouxme @tbielawa 
This is for cpaas compatibility. Basically many groups outside of OpenShift control their image version by including it in the github dockerfile. As it currently stands doing this is impossible as you either override the version with --version on the CLI or it uses what's in distgit.
What I added is simple: if `use_source_version: true` is in the image config it will fetch the version from the "upstream" Dockerfile after it has been copied into the distgit dir but before the modifications are made (this was the least intrusive). Since I'm just updating the `version` var in `rebase_images` the rest flows from there as normal.