### PR TITLE
Improve command executions

### DIFF
--- a/doozerlib/constants.py
+++ b/doozerlib/constants.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+
+# Environment variables to disable Git stdin prompts for username, password, etc
+GIT_NO_PROMPTS = {
+    "GIT_SSH_COMMAND": "ssh -oBatchMode=yes",
+    "GIT_TERMINAL_PROMPT": "0",
+}

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -27,6 +27,7 @@ from doozerlib.exceptions import DoozerFatalError
 from doozerlib.util import yellow_print
 from doozerlib import state
 from doozerlib.source_modifications import SourceModifierFactory
+from doozerlib import constants
 
 # doozer used to be part of OIT
 OIT_COMMENT_PREFIX = '#oit##'
@@ -165,7 +166,9 @@ class DistGitRepo(object):
                     self.logger.info("Cloning distgit repository [branch:%s] into: %s" % (distgit_branch, self.distgit_dir))
 
                     # Clone the distgit repository. Occasional flakes in clone, so use retry.
-                    exectools.cmd_assert(cmd_list, retries=3)
+                    set_env = os.environ.copy()
+                    set_env.update(constants.GIT_NO_PROMPTS)
+                    exectools.cmd_assert(cmd_list, retries=3, set_env=set_env)
 
     def merge_branch(self, target, allow_overwrite=False):
         self.logger.info('Switching to branch: {}'.format(target))

--- a/doozerlib/gitdata.py
+++ b/doozerlib/gitdata.py
@@ -12,6 +12,7 @@ import shutil
 import io
 from . import exectools
 from .pushd import Dir
+from doozerlib import constants
 
 
 SCHEMES = ['ssh', 'ssh+git', "http", "https"]
@@ -140,8 +141,10 @@ class GitData(object):
                     shutil.rmtree(data_destination)
                 self.logger.info('Cloning config data from {}'.format(self.data_path))
                 if not os.path.isdir(data_destination):
+                    set_env = os.environ.copy()
+                    set_env.update(constants.GIT_NO_PROMPTS)
                     cmd = "git clone -b {} --depth 1 {} {}".format(self.branch, self.data_path, data_destination)
-                    rc, out, err = exectools.cmd_gather(cmd)
+                    rc, out, err = exectools.cmd_gather(cmd, set_env=set_env)
                     if rc:
                         raise GitDataException('Error while cloning data: {}'.format(err))
 

--- a/tests/test_distgit/test_generic_distgit.py
+++ b/tests/test_distgit/test_generic_distgit.py
@@ -149,7 +149,7 @@ class TestGenericDistGit(TestDistgit):
 
         (flexmock(distgit.exectools)
             .should_receive("cmd_assert")
-            .with_args(expected_cmd, retries=3)
+            .with_args(expected_cmd, retries=3, set_env=object)
             .once()
             .and_return(None))
 
@@ -195,7 +195,7 @@ class TestGenericDistGit(TestDistgit):
 
         (flexmock(distgit.exectools)
             .should_receive("cmd_assert")
-            .with_args(expected_cmd, retries=3)
+            .with_args(expected_cmd, retries=3, set_env=object)
             .once()
             .and_return(None))
 

--- a/tests/test_distgit/test_rpm_distgit.py
+++ b/tests/test_distgit/test_rpm_distgit.py
@@ -42,7 +42,7 @@ class TestRPMDistGit(TestDistgit):
         flexmock(self.md).should_receive("fetch_cgit_file").once().and_raise(Exception(""))
         self.assertFalse(self.rpm_dg._matches_commit("anything", {}))
 
-        test_file = u"""
+        test_file = b"""
             Version: 42
             Release: 201901020304.git.1.12spam7%{?dist}
             %global commit 5p4mm17y5p4m
@@ -54,7 +54,7 @@ class TestRPMDistGit(TestDistgit):
         self.assertFalse(self.rpm_dg._matches_commit("11eggs11", {}))  # doesn't match, returns
 
         self.assertNotIn("No Release: field found", self.stream.getvalue())
-        flexmock(self.md).should_receive("fetch_cgit_file").once().and_return("nothing")
+        flexmock(self.md).should_receive("fetch_cgit_file").once().and_return(b"nothing")
         self.assertFalse(self.rpm_dg._matches_commit("nothing", {}))
         self.assertIn("No Release: field found", self.stream.getvalue())
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -20,7 +20,7 @@ def stub_runtime():
 class RuntimeTestCase(unittest.TestCase):
     def test_parallel_exec(self):
         ret = runtime.Runtime._parallel_exec(lambda x: x * 2, range(5), n_threads=20)
-        self.assertEqual(ret.get(), [0, 2, 4, 6, 8])
+        self.assertEqual(ret, [0, 2, 4, 6, 8])
 
     def test_parallel_exec2(self):
         items = [1, 2, 3]


### PR DESCRIPTION
1. Make `Runtime._parallel_exec` interruptible so it won't hang forever if it expects user input.
2. When cloning a git repo but user input is required, fail the command rather than hang forever.

Also fix broken unit test.