### PR TITLE
Add `--dry-run` option to images:build and rpms:build

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -226,8 +226,9 @@ def rpms_clone_sources(runtime, output_yml):
 @click.option("--release", metavar='RELEASE', default=None,
               help="Release label to populate in specfile.", required=True)
 @click.option('--scratch', default=False, is_flag=True, help='Perform a scratch build.')
+@click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @pass_runtime
-def rpms_build(runtime, version, release, scratch):
+def rpms_build(runtime, version, release, scratch, dry_run):
     """
     Attempts to build rpms for all of the defined rpms
     in a group. If an rpm has already been built, it will be treated as
@@ -247,7 +248,7 @@ def rpms_build(runtime, version, release, scratch):
 
     results = runtime.parallel_exec(
         lambda rpm, terminate_event: rpm.build_rpm(
-            version, release, terminate_event, scratch),
+            version, release, terminate_event, scratch, local=runtime.local, dry_run=dry_run),
         items)
     results = results.get()
     failed = [name for name, r in results if not r]
@@ -806,8 +807,9 @@ def print_build_metrics(runtime):
 @click.option('--scratch', default=False, is_flag=True, help='Perform a scratch build.')
 @click.option("--threads", default=1, metavar="NUM_THREADS",
               help="Number of concurrent builds to execute. Only valid for --local builds.")
+@click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @pass_runtime
-def images_build_image(runtime, odcs, repo_type, repo, push_to_defaults, push_to, scratch, threads):
+def images_build_image(runtime, odcs, repo_type, repo, push_to_defaults, push_to, scratch, threads, dry_run):
     """
     Attempts to build container images for all of the distgit repositories
     in a group. If an image has already been built, it will be treated as
@@ -888,7 +890,7 @@ def images_build_image(runtime, odcs, repo_type, repo, push_to_defaults, push_to
     results = runtime.parallel_exec(
         lambda dgr, terminate_event: dgr.build_container(
             odcs, repo_type, repo, push_to_defaults, additional_registries=push_to,
-            terminate_event=terminate_event, scratch=scratch, realtime=(threads == 1)),
+            terminate_event=terminate_event, scratch=scratch, realtime=(threads == 1), dry_run=dry_run),
         items, n_threads=threads)
     results = results.get()
 

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -263,7 +263,7 @@ class RPMMetadata(Metadata):
                 # write back new lines
                 sf.writelines(lines)
 
-    def _build_rpm(self, scratch, record, terminate_event):
+    def _build_rpm(self, scratch, record, terminate_event, dry_run=False):
         """
         The part of `build_container` which actually starts the build,
         separated for clarity.
@@ -274,6 +274,8 @@ class RPMMetadata(Metadata):
             cmd_list = ['tito', 'release', '--debug', '--yes', '--test']
             if scratch:
                 cmd_list.append('--scratch')
+            if dry_run:
+                cmd_list.append('--dry-run')
             tito_target = self.config.content.build.tito_target
             cmd_list.append(tito_target if tito_target else 'aos')
 
@@ -285,6 +287,10 @@ class RPMMetadata(Metadata):
                 self.logger.info("Unable to create brew task: out={}  ; err={}".format(out, err))
                 return False
 
+            if dry_run:
+                self.logger.info("[Dry Run] Successfully built rpm: {}".format(self.rpm_name))
+                self.logger.warning("Checking build output and downloading logs are skipped due to --dry-run.")
+                return True
             # Otherwise, we should have a brew task we can monitor listed in the stdout.
             out_lines = out.splitlines()
 
@@ -321,7 +327,7 @@ class RPMMetadata(Metadata):
             self.logger.info("Successfully built rpm: {} ; {}".format(self.rpm_name, task_url))
         return True
 
-    def build_rpm(self, version, release, terminate_event, scratch=False, retries=3):
+    def build_rpm(self, version, release, terminate_event, scratch=False, retries=3, local=False, dry_run=False):
         """
         Builds a package using tito release.
 
@@ -338,6 +344,8 @@ class RPMMetadata(Metadata):
         By default, the tag is pushed, then it and the commit are removed locally after the build.
         But optionally the commit can be pushed before the build, so that the actual commit released is in the source.
         """
+        if local:
+            raise DoozerFatalError("Local RPM build is not currently supported.")
         self.set_nvr(version, release)
         self.tito_setup()
         self.update_spec()
@@ -366,7 +374,7 @@ class RPMMetadata(Metadata):
                 exectools.retry(
                     retries=3, wait_f=wait,
                     task_f=lambda: self._build_rpm(
-                        scratch, record, terminate_event))
+                        scratch, record, terminate_event, dry_run))
             except exectools.RetryException as err:
                 self.logger.error(str(err))
                 return (self.distgit_key, False)


### PR DESCRIPTION
This is used by integration test (https://github.com/openshift/doozer/pull/160) to exercise the build logic
but not really build anything.

This also makes `rpms:build` to suspect `--local` (only raise an exception as local RPM build is not currently supported).