### PR TITLE
Fix UnicodeDecodeError when building 3.11 openshift-ansible RPM

### DIFF
--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import glob
+import io
 import os
 import traceback
 import re
@@ -237,7 +238,7 @@ class RPMMetadata(Metadata):
                 self._run_modifications()
 
             # second, update with NVR
-            with open(self.specfile, 'r+') as sf:
+            with io.open(self.specfile, 'r+', encoding='utf-8') as sf:
                 lines = sf.readlines()
                 for i in range(len(lines)):
 


### PR DESCRIPTION
Fixes https://github.com/openshift/doozer/issues/162.

openshift-ansible.spec contains non-ascii character which breaks doozer with Python 2.7.

During our daily release routine, openshift-ansible is built by build/ocp3 job rather than Doozer. This error will happen if you use the build/custom job to build openshift-ansible which uses Doozer.

Use `io.open` with UTF-8 encoding in Python 2.7, which is basically a back port from Python 3, will solve this issue.