### PR TITLE
fix broken tag_exists

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,16 +2,67 @@
 
 from __future__ import unicode_literals
 import unittest
-
+import mock
 import os
 import tempfile
 import logging
 import shutil
+from doozerlib import metadata
 
 TEST_YAML = """---
 name: 'test'
 distgit:
   namespace: 'hello'"""
+
+
+class TestMetadataModule(unittest.TestCase):
+    def test_tag_exists(self):
+        with mock.patch("requests.get") as mocked_get:
+            mocked_get.return_value = mock.MagicMock(status_code=200)
+            registry = "https://registry.example.com"
+            namespace = "fake_namespace"
+            image_name = "fake_image"
+            tag = "fake_tag"
+            expected_url = "https://registry.example.com/v1/repositories/fake_namespace/fake_image/tags/fake_tag"
+            actual = metadata.tag_exists(registry, namespace, image_name, tag)
+            mocked_get.assert_called_with(expected_url)
+            self.assertEqual(True, actual)
+            mocked_get.return_value = mock.MagicMock(status_code=404)
+            actual = metadata.tag_exists(registry, namespace, image_name, tag)
+            self.assertEqual(False, actual)
+            mocked_get.return_value = mock.MagicMock(status_code=403)
+            with self.assertRaises(IOError) as cm:
+                metadata.tag_exists(registry, namespace, image_name, tag)
+                self.assertIn("HTTP 403", str(cm.exception))
+
+
+class TestMetadataClass(unittest.TestCase):
+    def test_get_brew_image_name_short(self):
+        with mock.patch("doozerlib.metadata.Metadata.__init__", return_value=None):
+            obj = metadata.Metadata()
+            obj.image_name = "openshift3/ose-ansible"
+            expected = "openshift3-ose-ansible"
+            actual = metadata.Metadata.get_brew_image_name_short.__call__(obj)
+            self.assertEqual(expected, actual)
+
+    def test_get_brew_image_name_short(self):
+        with mock.patch("doozerlib.metadata.Metadata.__init__", return_value=None):
+            obj = metadata.Metadata()
+            obj.image_name = "openshift3/ose-ansible"
+            expected = "openshift3-ose-ansible"
+            actual = metadata.Metadata.get_brew_image_name_short.__call__(obj)
+            self.assertEqual(expected, actual)
+
+    def test_tag_exists(self):
+        with mock.patch("doozerlib.metadata.Metadata.__init__", return_value=None), mock.patch("doozerlib.metadata.tag_exists", return_value=True) as mocked_module_tag_exists:
+            obj = metadata.Metadata()
+            obj.runtime = mock.MagicMock()
+            obj.runtime.group_config.urls.brew_image_host = "registry.example.com"
+            obj.runtime.group_config.urls.brew_image_namespace = "fake_namespace"
+            obj.get_brew_image_name_short = mock.MagicMock(return_value="fake_image_name")
+            actual = obj.tag_exists("fake_tag")
+            self.assertTrue(actual)
+            mocked_module_tag_exists.assert_called_with("https://registry.example.com", "fake_namespace", "fake_image_name", "fake_tag")
 
 
 class MockRuntime(object):


### PR DESCRIPTION
The current `tag_exists` function is broken due to brew-pulp to registry-proxy migration.
It was not noticed because HTTP 403 is treated as `tag doesn't exist`.

After porting this function to Python 3, it will raise an `urllib.error.HTTPError` which prevents all image builds from being started.

Fixed this function and added unit tests.