### PR TITLE
[ART-1432] Add relatedImages spec to CSV

### DIFF
--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -314,10 +314,11 @@ class OperatorMetadataBuilder(object):
             related_images.append('    {}: {}'.format(name, image))
         related_images.sort()
 
-        return contents.replace(
-            'spec:\n',
+        return re.sub(
+            r'^spec:\n',
             'spec:\n  relatedImages:\n{}\n'.format('\n'.join(related_images)),
-            1
+            contents,
+            flags=re.MULTILINE
         )
 
     @log

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -264,19 +264,23 @@ class OperatorMetadataBuilder(object):
             with open(file, 'r') as reader:
                 contents = reader.read()
 
-            new_contents = re.sub(
-                r'{}/([^:]+):([^\'"\s]+)'.format(self.operator_csv_registry),
-                lambda i: '{}/{}@{}'.format(
-                    self.operator_csv_registry,
-                    i.group(1),
-                    self.fetch_image_sha('{}:{}'.format(i.group(1), i.group(2)), arch)
-                ),
-                contents,
-                flags=re.MULTILINE
-            )
+            new_contents = self.find_and_replace_image_versions_by_sha(contents, arch)
 
             with open(file, 'w') as writer:
                 writer.write(new_contents)
+
+    @log
+    def find_and_replace_image_versions_by_sha(self, contents, arch):
+        return re.sub(
+            r'{}/([^:]+):([^\'"\s]+)'.format(self.operator_csv_registry),
+            lambda i: '{}/{}@{}'.format(
+                self.operator_csv_registry,
+                i.group(1),
+                self.fetch_image_sha('{}:{}'.format(i.group(1), i.group(2)), arch)
+            ),
+            contents,
+            flags=re.MULTILINE
+        )
 
     @log
     def merge_streams_on_top_level_package_yaml(self):

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -204,41 +204,46 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
 
     def test_find_and_replace_image_versions_by_sha(self):
         initial = """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ClusterServiceVersion
-        metadata:
-          name: clusterlogging.4.1.16-201901010000
-          namespace: placeholder
-        spec:
-          version: 4.1.16-201901010000
-          displayName: Cluster Logging
-          image: image-registry.svc:5000/openshift/ose-cluster-logging-operator:v4.1.6-201901010000
-          some:
-            key:
-            - item: "image-registry.svc:5000/openshift/dependency-b:v1.1.1-1111"
-            - item: "image-registry.svc:5000/openshift/dependency-c:v1.1.1-1111"
-            - item: "image-registry.svc:5000/openshift/dependency-d:v1.1.1-1111"
-        other:
-        - reference: image-registry.svc:5000/openshift/dependency-b:v1.1.1-1111
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: clusterlogging.4.1.16-201901010000
+  namespace: placeholder
+spec:
+  version: 4.1.16-201901010000
+  displayName: Cluster Logging
+  image: image-registry.svc:5000/openshift/ose-cluster-logging-operator:v4.1.6-201901010000
+  some:
+  key:
+    - item: "image-registry.svc:5000/openshift/dependency-b:v1.1.1-1111"
+    - item: "image-registry.svc:5000/openshift/dependency-c:v1.1.1-1111"
+    - item: "image-registry.svc:5000/openshift/dependency-d:v1.1.1-1111"
+other:
+  - reference: image-registry.svc:5000/openshift/dependency-b:v1.1.1-1111
         """
 
         expected = """
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ClusterServiceVersion
-        metadata:
-          name: clusterlogging.4.1.16-201901010000
-          namespace: placeholder
-        spec:
-          version: 4.1.16-201901010000
-          displayName: Cluster Logging
-          image: image-registry.svc:5000/openshift/ose-cluster-logging-operator@sha256:aaaaaaaaaaaaaa
-          some:
-            key:
-            - item: "image-registry.svc:5000/openshift/dependency-b@sha256:bbbbbbbbbbbbbb"
-            - item: "image-registry.svc:5000/openshift/dependency-c@sha256:cccccccccccccc"
-            - item: "image-registry.svc:5000/openshift/dependency-d@sha256:dddddddddddddd"
-        other:
-        - reference: image-registry.svc:5000/openshift/dependency-b@sha256:bbbbbbbbbbbbbb
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: clusterlogging.4.1.16-201901010000
+  namespace: placeholder
+spec:
+  relatedImages:
+    dependency-b: image-registry.svc:5000/openshift/dependency-b@sha256:bbbbbbbbbbbbbb
+    dependency-c: image-registry.svc:5000/openshift/dependency-c@sha256:cccccccccccccc
+    dependency-d: image-registry.svc:5000/openshift/dependency-d@sha256:dddddddddddddd
+    ose-cluster-logging-operator: image-registry.svc:5000/openshift/ose-cluster-logging-operator@sha256:aaaaaaaaaaaaaa
+  version: 4.1.16-201901010000
+  displayName: Cluster Logging
+  image: image-registry.svc:5000/openshift/ose-cluster-logging-operator@sha256:aaaaaaaaaaaaaa
+  some:
+  key:
+    - item: "image-registry.svc:5000/openshift/dependency-b@sha256:bbbbbbbbbbbbbb"
+    - item: "image-registry.svc:5000/openshift/dependency-c@sha256:cccccccccccccc"
+    - item: "image-registry.svc:5000/openshift/dependency-d@sha256:dddddddddddddd"
+other:
+  - reference: image-registry.svc:5000/openshift/dependency-b@sha256:bbbbbbbbbbbbbb
         """
 
         flexmock(operator_metadata.OperatorMetadataBuilder).should_receive('fetch_image_sha').with_args('openshift/ose-cluster-logging-operator:v4.1.6-201901010000', 'manifest-list').and_return('sha256:aaaaaaaaaaaaaa')

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -202,7 +202,7 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
         }
         operator_metadata.OperatorMetadataBuilder(nvr, stream, runtime, image_ref_mode, **cached_attrs).update_metadata_manifests_dir()
 
-    def skip_test_replace_version_by_sha_on_image_references(self):  # broken for now, i changed the method's API
+    def test_find_and_replace_image_versions_by_sha(self):
         initial = """
         apiVersion: operators.coreos.com/v1alpha1
         kind: ClusterServiceVersion
@@ -221,9 +221,6 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
         other:
         - reference: image-registry.svc:5000/openshift/dependency-b:v1.1.1-1111
         """
-        mock = flexmock(get_builtin_module())
-        mock.should_call('open')
-        mock.should_receive('open').and_return(initial)
 
         expected = """
         apiVersion: operators.coreos.com/v1alpha1
@@ -266,7 +263,7 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
             })
         }
         op_md = operator_metadata.OperatorMetadataBuilder(nvr, stream, runtime, image_ref_mode, **cached_attrs)
-        actual = op_md.replace_version_by_sha_on_image_references('manifest-list')
+        actual = op_md.find_and_replace_image_versions_by_sha(initial, 'manifest-list')
         self.assertMultiLineEqual(actual, expected)
 
     def test_get_file_list_from_operator_art_yaml(self):


### PR DESCRIPTION
JIRA: [ART-1432](https://issues.redhat.com/browse/ART-1432)

Add a new spec called `relatedImages` to OLM Operator Metadata CSV while replacing image references by SHAs.

#### Example

```diff
  apiVersion: operators.coreos.com/v1alpha1
  kind: ClusterServiceVersion
  metadata:
    name: clusterlogging.4.1.16-201901010000
    namespace: placeholder
  spec:
+    relatedImages:
+      dependency-b: image-registry.svc:5000/openshift/dependency-b@sha256:bbbbbbbbbbbbbb
+      dependency-c: image-registry.svc:5000/openshift/dependency-c@sha256:cccccccccccccc
+      dependency-d: image-registry.svc:5000/openshift/dependency-d@sha256:dddddddddddddd
+      ose-cluster-logging-operator: image-registry.svc:5000/openshift/ose-cluster-logging-operator@sha256:aaaaaaaaaaaaaa
    version: 4.1.16-201901010000
    displayName: Cluster Logging
    image: image-registry.svc:5000/openshift/ose-cluster-logging-operator@sha256:aaaaaaaaaaaaaa
    some:
    key:
      - item: "image-registry.svc:5000/openshift/dependency-b@sha256:bbbbbbbbbbbbbb"
      - item: "image-registry.svc:5000/openshift/dependency-c@sha256:cccccccccccccc"
      - item: "image-registry.svc:5000/openshift/dependency-d@sha256:dddddddddddddd"
  other:
    - reference: image-registry.svc:5000/openshift/dependency-b@sha256:bbbbbbbbbbbbbb
```

#### Tests on a real operator

##### manifest-list
```
$ doozer \
    -g openshift-4.2 \
    operator-metadata:build \
    cluster-logging-operator-container-v4.2.0-201908070219 \
    --stream dev \
    --image-ref-mode manifest-list
```
* [distgit diff](http://dist-git.host.prod.eng.bos.redhat.com/cgit/containers/cluster-logging-dev-operator-metadata/commit/?h=rhaos-4-rhel-7&id=5aaf3e42832f3c7751972cb4596f28e76795ae80)
* [brew build](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=25760120)

##### by-arch
```
$ ./doozer \
    -g openshift-4.2 \
    operator-metadata:build \
    cluster-logging-operator-container-v4.2.15-202001140748 \
    --stream dev \
    --image-ref-mode by-arch
```
* [distgit diff](http://dist-git.host.prod.eng.bos.redhat.com/cgit/containers/cluster-logging-dev-operator-metadata/commit/?h=rhaos-4-rhel-7&id=452c6a6e4228996e4bf80c1cafb376386b30abad)
* [brew build](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=25760202)