### PR TITLE
Fix dev container build

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:31
 RUN dnf install -y \
     # runtime dependencies
     krb5-workstation git rsync koji skopeo podman docker tito \
-    python2 python2-certifi python2-rpm python2-koji \
+    python2 python2-certifi python2-rpm \
     python3 python3-certifi python3-rpm \
     # development dependencies
     gcc krb5-devel openssl-devel \
@@ -24,7 +24,7 @@ RUN wget -O /etc/yum.repos.d/rcm-tools-fedora.repo https://download.devel.redhat
   && dnf install -y rhpkg \
   && dnf clean all
 
-ARG OC_VERSION=4.2.16
+ARG OC_VERSION=4.3.0
 # include oc client
 RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux-"$OC_VERSION".tar.gz \
   && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \


### PR DESCRIPTION
- `python2-koji` has been removed from Fedora 31 official repo. Drop this package.
- Upgrade `oc` to 4.3.0.