### PR TITLE
opmeta: don't build opmetas multi-arch

### DIFF
--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -89,6 +89,7 @@ class OperatorMetadataBuilder:
         self.update_current_csv_shasums()
         self.merge_streams_on_top_level_package_yaml()
         self.create_metadata_dockerfile()
+        self.create_container_yaml()
         return self.commit_and_push_metadata_repo()
 
     @log
@@ -266,6 +267,18 @@ class OperatorMetadataBuilder:
             operator_dockerfile.labels['release'],
             self.stream)
         del(metadata_dockerfile.labels['release'])
+
+    def create_container_yaml(self):
+        """Use container.yaml to disable unnecessary multiarch"""
+        filename = "{}/{}/container.yaml".format(self.working_dir, self.metadata_repo)
+        with open(filename, "w") as cyml:
+            cyml.write("""
+# metadata containers are not functional and do not need to be multiarch
+---
+platforms:
+  only:
+  - x86_64
+            """)
 
     @log
     def commit_and_push_metadata_repo(self):

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -587,6 +587,24 @@ class TestOperatorMetadataBuilder(unittest.TestCase):
         shutil.rmtree('/tmp/my-operator')
         shutil.rmtree('/tmp/my-dev-operator-metadata')
 
+    def test_create_container_yaml(self):
+        container_yaml_filename = '/my/working/dir/my-operator-metadata/container.yaml'
+        writer = flexmock(write=None)
+
+        mock = flexmock(get_builtin_module())
+        (mock.should_receive('open')
+            .with_args(container_yaml_filename)
+            .and_return(writer))
+        mock.should_call('open')
+
+        cached_attrs = {
+            'working_dir': '/my/working/dir',
+            'operator_name': 'my-operator',
+            'metadata_repo': 'my-operator-metadata',
+        }
+        (operator_metadata.OperatorMetadataBuilder(nvr="...", stream="...", runtime="...", **cached_attrs)
+            .create_container_yaml())
+
     def test_commit_and_push_metadata_repo(self):
         sample_dir_obj = operator_metadata.pushd.Dir('/tmp')
         (flexmock(operator_metadata.pushd)


### PR DESCRIPTION
Operator metadata containers will never be executed. They are just
glorified tarballs; there is no need to build all of the available
architectures and risk something going wrong with one randomly.