### PR TITLE
images:print: don't crash if no builds found for an image

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1181,7 +1181,15 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
         version = ''
         release = ''
         if release_query_needed or version_query_needed:
-            _, version, release = image.get_latest_build_info()
+            try:
+                _, version, release = image.get_latest_build_info()
+            except IOError as err:
+                err_msg = str(err)
+                if err_msg.find("No builds detected") >= 0:
+                    # ignore "No builds detected" error
+                    runtime.logger.warning("No builds delected for {}: {}".format(image.name, err_msg))
+                else:
+                    raise err
 
         s = s.replace("{version}", version)
         s = s.replace("{release}", release)


### PR DESCRIPTION
In 4.4 we have some new images. `images:print` crashes when there is an image without any builds.
This breaks our appregistry job.

This PR will catch the `no builds detected` error to make `images:print` proceed. Note NVR will be `name--` when this happens but I don't know how to handle that better.

See https://issues.redhat.com/browse/ART-1532