### PR TITLE
Add image build profile support for custom Brew target and so on

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -36,9 +36,12 @@ class TestMetadataModule(unittest.TestCase):
             actual = metadata.tag_exists(registry, namespace, image_name, tag)
             self.assertEqual(False, actual)
             mocked_get.return_value = mock.MagicMock(status_code=403)
+            actual = metadata.tag_exists(registry, namespace, image_name, tag)
+            self.assertEqual(False, actual)
+            mocked_get.return_value = mock.MagicMock(status_code=500)
             with self.assertRaises(IOError) as cm:
                 metadata.tag_exists(registry, namespace, image_name, tag)
-                self.assertIn("HTTP 403", str(cm.exception))
+                self.assertIn("HTTP 500", str(cm.exception))
 
     def test_backoff(self):
         m = flexmock(metadata)


### PR DESCRIPTION
A build profile is set of configuration values which allows us to build our project using different configurations.
This feature is added to Doozer to support custom Brew target (especially for image build with ODCS) and build RPMs for RHEL versions using a single build command.

To define build profiles, we should add the following section to ocp-build-data group.yml:

```yaml
build_profiles:
  image:
    unsigned:
      targets:
      - rhaos-{MAJOR}.{MINOR}-rhel-7-containers-candidate
      signing_intent: unsigned
      repo_type: unsigned
      repo_list: []
    signed:
      targets:
      - rhaos-{MAJOR}.{MINOR}-rhel-7-signed-containers-candidate
      signing_intent: release
      repo_type: signed
      repo_list: []
  rpm:
    default:
      targets:
      - rhaos-{MAJOR}.{MINOR}-rhel-7
      - rhaos-{MAJOR}.{MINOR}-rhel-8

default_image_build_profile: unsigned
default_rpm_build_profile: default
```

This PR only covers the image portion.

When building an image, use the `--profile` to specify the build profile you want to use:

``` bash
doozer --debug -g openshift-3.11 --latest-parent-version --images logging-kibana5 --profile=signed images:build
```

The above command will use the profile `signed`. If `--profile` is not given, it will use the `default_image_build_profile` value in group.yml. If `default_image_build_profile` is not defined as well, this feature will be disabled to keep compatibility with the old behavior.

The `--repo-type` option and `repo_list` option will always override the build profile values. This is also to maintain backward compatibility.

Signed-off-by: Yuxiang Zhu <yuxzhu@redhat.com>