### PR TITLE
ART-1536: scan-sources should not count disabled images as changed

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -405,10 +405,11 @@ def config_scan_source_changes(runtime, as_yaml):
     Print a list of configs that were scanned and whether the source differs from the distgit.
     """
     _fix_runtime_mode(runtime)
-    CONFIG_RUNTIME_OPTS['disabled'] = False  # unless explicitly indicated, ignore disabled configs
     runtime.initialize(**CONFIG_RUNTIME_OPTS)
     results = dict(rpms=[], images=[])
     for meta, matches in runtime.scan_distgit_sources():
+        if not (meta.enabled or meta.mode == "disabled" and runtime.load_disabled):
+            continue  # An enabled image's dependents are always loaded. Ignore disabled configs unless explicitly indicated
         results['rpms' if meta.meta_type == 'rpm' else 'images'].append(
             dict(name=meta.distgit_key, changed=not matches)
         )


### PR DESCRIPTION
This bug happens because `mode: disabled` and `mode: wip` only disable autoloading that image.yml when `--images` is not specified, but it will be loaded anyway if another image defines the disabled image as a dependent.

This PR https://github.com/openshift/ocp-build-data/pull/304 has removed `openshift-enterprise-template-service-broker-operator` from the dependent list of `template-service-broker`.

To prevent this issue from happening again, we can skip disabled images when scanning sources unless `--load-disabled` is specified.

Signed-off-by: Yuxiang Zhu <yuxzhu@redhat.com>