### PR TITLE
Inject team ownership info into rpms/images

### DIFF
--- a/doozerlib/gitdata.py
+++ b/doozerlib/gitdata.py
@@ -143,7 +143,8 @@ class GitData(object):
                 if not os.path.isdir(data_destination):
                     set_env = os.environ.copy()
                     set_env.update(constants.GIT_NO_PROMPTS)
-                    cmd = "git clone -b {} --depth 1 {} {}".format(self.branch, self.data_path, data_destination)
+                    # Clone all branches as we must sometimes reference master /OWNERS for maintainer information
+                    cmd = "git clone --no-single-branch -b {} --depth 1 {} {}".format(self.branch, self.data_path, data_destination)
                     rc, out, err = exectools.cmd_gather(cmd, set_env=set_env)
                     if rc:
                         raise GitDataException('Error while cloning data: {}'.format(err))

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from future import standard_library
 standard_library.install_aliases
-import yaml
-import os
 import urllib.parse
 from retry import retry
 import requests
+import yaml
+from collections import OrderedDict
 
-from . import assertion
+from .pushd import Dir
 from .distgit import ImageDistGitRepo, RPMDistGitRepo
 from . import exectools
 from . import logutil
@@ -161,3 +161,55 @@ class Metadata(object):
             component_name = self.config.distgit.component
 
         return component_name
+
+    def get_maintainer_info(self):
+        """
+        :return: Returns a dict of identifying maintainer information. Dict might be empty if no maintainer information is available.
+            fields are generally [ component: '...', subcomponent: '...', and product: '...' ] if available. These
+            are coordinates for product security to figure out where to file bugs when an image or RPM has an issue.
+        """
+
+        # We are trying to discover some team information that indicates which BZ or Jira board bugs for this
+        # component should be filed against. This information can be stored in the doozer metadata OR
+        # in upstream source. Metadata overrides, as usual.
+
+        source_dir = self.runtime.resolve_source(self)
+
+        # Maintainer info can be defined in metadata, so try there first.
+        maintainer = self.config.maintainer or dict()
+
+        # This tuple will also define key ordering in the returned OrderedDict
+        known_fields = ('product', 'component', 'subcomponent')
+
+        # Fill in any missing attributes from upstream source
+        if source_dir:
+            with Dir(source_dir):
+                # Not every repo has a master branch, they may have a different default; detect it.
+                remote_info, _ = exectools.cmd_assert(f'git remote show origin')
+                head_branch_lines = [i for i in remote_info.splitlines() if i.strip().startswith('HEAD branch:')]  # e.g. [ "  HEAD branch: master" ]
+                if not head_branch_lines:
+                    raise IOError('Error trying to detect remote default branch')
+                default_branch = head_branch_lines[0].strip().split()[-1]  # [ "  HEAD branch: master" ] => "master"
+
+                _, owners_yaml, _ = exectools.cmd_gather(f'git --no-pager show origin/{default_branch}:OWNERS')
+                if owners_yaml.strip():
+                    owners = yaml.safe_load(owners_yaml)
+                    for field in known_fields:
+                        if field not in maintainer and field in owners:
+                            maintainer[field] = owners[field]
+
+        if 'product' not in maintainer:
+            maintainer['product'] = 'OpenShift Container Platform'  # Safe bet - we are ART.
+
+        # Just so we return things in a defined order (avoiding unnecessary changes in git commits)
+        sorted_maintainer = OrderedDict()
+        for k in known_fields:
+            if k in maintainer:
+                sorted_maintainer[k] = maintainer[k]
+
+        # Add anything remaining in alpha order
+        for k in sorted(maintainer.keys()):
+            if k not in sorted_maintainer:
+                sorted_maintainer[k] = maintainer[k]
+
+        return sorted_maintainer

--- a/tests/test_rpmcfg.py
+++ b/tests/test_rpmcfg.py
@@ -30,7 +30,7 @@ class MockRuntime(object):
         self.tmpdir = tmpdir
         self.logger = logger
 
-    def resolve_source(self, parent, meta):
+    def resolve_source(self, meta):
         return self.tmpdir
 
 


### PR DESCRIPTION
Help prodsec track down which team / bz_component owns issues with a component. 
Principle:

In each upstream repository, owners can define a /OWNERS in their default branch with bugzilla component information:
```
# Normal entries
reviewers:
- x
- y 
approvers:
- z

# New entries for this feature
product:  ...    # Optional, defaults to OpenShift Container Platform
component: ...    # Optional, but we may one day warn folks when it is not specified / eventually erroring
subcomponent: ...    # Optional; defaults to not being defined in builds
```
When doozer is building images / rpms from any upstream repository, it will check for the existence of an OWNERS file in the root of the repository's *default* branch (usually `master).

There is will parse the yaml and extract product, component, and subcomponent if it is present.

This information will be added to RPM's built by doozer in the `%description` directive (more reasonable fields like vendor & packager are restricted by brew). Example after a build with this PR (see the Description blurb):
```
20:41 $ rpm -qip ~/Downloads/openshift-clients-4.4.0-999.git.0.b3e3639.el7.x86_64.rpm
Name        : openshift-clients
Version     : 4.4.0
Release     : 999.git.0.b3e3639.el7
Architecture: x86_64
Install Date: (not installed)
...
Summary     : OpenShift client binaries
Description :
[Maintainer] product: OpenShift Container Platform, component: some-component, subcomponent: some-subcomponent
OpenShift client binaries
``` 

maintainer data may also be defined in ocp-build-data metadata. In each config file, a field like:
```
maintainer:
  component: ...
  product: ...
  subcomponent: ...
```

may be specified. Each of these is optional and will override anything found in the upstream repository. 

When maintainer information is found for image builds, the following labels will be set for the build (Clayton has approved their use).
```
io.openshift.maintainer.product=...
io.openshift.maintainer.component=...
io.openshift.maintainer.subcomponent=...
```

