### PR TITLE
Enable public_upstreams replacement group metadata

### DIFF
--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -3,6 +3,7 @@ import click
 import copy
 import os
 import errno
+import re
 
 
 def stringify(val):
@@ -73,6 +74,23 @@ def dict_get(dct, path, default=DICT_EMPTY):
                 raise Exception('Unable to follow key path {}'.format(path))
             return default
     return dct
+
+
+def convert_remote_git_to_https(source):
+    """
+    Accepts a source git URL in ssh or https format and return is in a normalized
+    https format:
+        - https protocol
+        - no trailing /
+    :param source: Git remote
+    :return: Normalized https git URL
+    """
+    url = re.sub(
+        pattern=r'git@([^:]+):([^\.]+)',
+        repl='https://\\1/\\2',
+        string=source.strip(),
+    )
+    return re.sub(string=url, pattern=r'\.git$', repl='').rstrip('/')
 
 
 def is_in_directory(path, directory):

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -78,7 +78,7 @@ def dict_get(dct, path, default=DICT_EMPTY):
 
 def convert_remote_git_to_https(source):
     """
-    Accepts a source git URL in ssh or https format and return is in a normalized
+    Accepts a source git URL in ssh or https format and return it in a normalized
     https format:
         - https protocol
         - no trailing /

--- a/tests/test_distgit/test_convert_source_url_to_https.py
+++ b/tests/test_distgit/test_convert_source_url_to_https.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import unittest
-from doozerlib import distgit
+from doozerlib import util
 
 
 class TestDistgitConvertSourceURLToHTTPS(unittest.TestCase):
@@ -8,7 +8,7 @@ class TestDistgitConvertSourceURLToHTTPS(unittest.TestCase):
     def test_conversion_from_ssh_source(self):
         source = "git@github.com:myorg/myproject.git"
 
-        actual = distgit.convert_source_url_to_https(source)
+        actual = util.convert_remote_git_to_https(source)
         expected = "https://github.com/myorg/myproject"
 
         self.assertEqual(actual, expected)
@@ -16,7 +16,7 @@ class TestDistgitConvertSourceURLToHTTPS(unittest.TestCase):
     def test_conversion_from_already_https_source(self):
         source = "https://github.com/myorg/myproject"
 
-        actual = distgit.convert_source_url_to_https(source)
+        actual = util.convert_remote_git_to_https(source)
         expected = "https://github.com/myorg/myproject"
 
         self.assertEqual(actual, expected)
@@ -24,7 +24,7 @@ class TestDistgitConvertSourceURLToHTTPS(unittest.TestCase):
     def test_conversion_from_https_source_with_dotgit_suffix(self):
         source = "https://github.com/myorg/myproject.git"
 
-        actual = distgit.convert_source_url_to_https(source)
+        actual = util.convert_remote_git_to_https(source)
         expected = "https://github.com/myorg/myproject"
 
         self.assertEqual(actual, expected)
@@ -32,8 +32,24 @@ class TestDistgitConvertSourceURLToHTTPS(unittest.TestCase):
     def test_conversion_from_https_source_with_dotgit_elsewhere(self):
         source = "https://foo.gitlab.com/myorg/myproject"
 
-        actual = distgit.convert_source_url_to_https(source)
+        actual = util.convert_remote_git_to_https(source)
         expected = "https://foo.gitlab.com/myorg/myproject"
+
+        self.assertEqual(actual, expected)
+
+    def test_conversion_from_ssh_org_source(self):
+        source = "git@github.com:myorg/"
+
+        actual = util.convert_remote_git_to_https(source)
+        expected = "https://github.com/myorg"
+
+        self.assertEqual(actual, expected)
+
+    def test_conversion_from_https_org_source(self):
+        source = "https://github.com/myorg/"
+
+        actual = util.convert_remote_git_to_https(source)
+        expected = "https://github.com/myorg"
 
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
In the very near future, we will need to be able to replace `openshift/ose` references with `openshift/origin` in public facing information. In the somewhat near future, we will need to replace `github.com/openshift-priv` references with `github.com/openshift`. 

This PR introduces new metadata in group.yaml that allows us to perform this translation for public facing URLs.

If:
```
public_upstreams:
  "https://github.com/openshift-priv" : "https://github.com/openshift"
  "https://github.com/openshift/ose" : "https://github.com/openshift/origin"
```

then all of the following will resolve to `https://github.com/openshift/origin:
```
print(get_public_upstream('https://github.com/openshift/ose/'))
print(get_public_upstream('https://github.com/openshift/origin'))
print(get_public_upstream('git@github.com:openshift/origin/'))
print(get_public_upstream('git@github.com:openshift/ose.git'))
print(get_public_upstream('git@github.com:openshift-priv/origin.git'))
print(get_public_upstream('https://github.com/openshift-priv/origin.git'))
```

The matching is a little smarter than simple prefix matching. For example `print(get_public_upstream('git@github.com:openshift/osed'))` will result in `https://github.com/openshift/osed` which is what we would want in this case.

Turning this on for 4.5: https://github.com/openshift/ocp-build-data/pull/404