### PR TITLE
Allow build arches to be overridden on the command line

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -379,18 +379,7 @@ class ImageDistGitRepo(DistGitRepo):
         """
 
         # list of platform (architecture) names to build this image for
-        arches = []  # type: list
-        global_arches = set(self.metadata.runtime.arches)
-        image_specific_arches = set(self.metadata.config.arches)
-        if not image_specific_arches:
-            # assume all global arches if no image specific arches are defined
-            arches = list(global_arches)
-        else:
-            # only include arches from metadata that are valid globally
-            missing_arches = image_specific_arches - global_arches
-            if missing_arches:
-                raise ValueError("Image specific arches ({}) are not enabled in group.yml.".format(", ".join(missing_arches)))
-            arches = list(image_specific_arches)
+        arches = self.metadata.get_arches()
 
         # override image config with this dict
         config_overrides = {}

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -123,6 +123,22 @@ class Metadata(object):
         else:
             return '{}-candidate'.format(self.branch())
 
+    def get_arches(self):
+        """
+        :return: Returns the list of architecture this image/rpm should build for. This is an intersection
+        of config specific arches & globally enabled arches in group.yml
+        """
+        if self.config.arches:
+            ca = self.config.arches
+            intersection = list(set(self.runtime.get_global_arches()) & set(ca))
+            if len(intersection) != len(ca):
+                self.logger.info(f'Arches are being pruned by group.yml. Using computed {intersection} vs config list {ca}')
+            if not intersection:
+                raise ValueError(f'No arches remained enabled in {self.qualified_key}')
+            return intersection
+        else:
+            return list(self.runtime.get_global_arches())
+
     def cgit_url(self, filename):
         rev = self.branch()
         ret = "/".join((self.runtime.group_config.urls.cgit, self.qualified_name, "plain", filename))

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -661,14 +661,9 @@ class OperatorMetadataBuilder(object):
 
     @property
     def additional_arches(self):
-        if 'arches' in self.operator.data_obj.data:
-            arches = self.operator.data_obj.data['arches']
-        else:
-            arches = self.runtime.group_config.arches
-
+        arches = self.operator.get_arches()
         if 'x86_64' in arches:
             arches.remove('x86_64')
-
         return arches
 
     def get_working_dir(self):

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -496,6 +496,7 @@ other:
             'csv': 'updated-value',
             'operator': type('', (object,), {
                 'config': {'update-csv': {}},
+                'get_arches': lambda: ['s390x'],
                 'data_obj': type('', (object,), {'data': {'arches': ['s390x']}})
             })
         }
@@ -563,6 +564,7 @@ other:
             'csv': 'updated-value',
             'operator': type('', (object,), {
                 'config': {'update-csv': {}},
+                'get_arches': lambda: ['s390x'],
                 'data_obj': type('', (object,), {'data': {'arches': ['s390x']}})
             })
         }


### PR DESCRIPTION
We need group.yml to be a source of truth for arches when opening Cincinnati PRs in order to make the determination of whether to add a `+amd64` suffix for images. For example:
1. We are building 4.2.99 for arches [x86_64, s390x]
2. 4.3 is still GA only for a single arch [x86_64]
3. When we open a Cincinnati PR to put 4.2.99 in the 4.3 channels, we need to detect that 4.3 is not yet shipping for s390x and add `4.2.99+amd64` 

The OTA team has asked us to do this out of an abundance of caution. If we do not, then when a 4.3.z ships _with_ s390x support, it will immediately allow 4.2.99 s390x installations to upgrade to the new 4.3.z. This isn't necessarily a bad thing, but if we prevent it with by only adding `4.2.99+amd64` to the channels, it decreases the test surface that OTA needs to concern itself with.

So, on to the purpose of this PR. For various reasons, ART has been asked in the past to temporarily turn on CPU architectures in the builds. This means that we have to, for example, alter the arches field in the 4.3 group.yml temporarily to get a 4.3 s390x nightly out to our test groups. 

During this interval, 4.3's group.yml cannot be used as a source of truth for opening 4.2 Cincinnati PRs (again, we need to know what arches are shipping for 4.3 in order to determine which +arch CPU suffix to use, if any). This PR allows us to maintain truth in group.yml while still building test builds for other arches.

You can accomplish this two different ways. 
1. First, you can now provide a set of architectures on the doozer command line via `--arches` . Jobs can be altered to allow this from Jenkins parameters.
2. `arches` can be left to reflect GA status in group.yml  while `arches_override` (also in group.yml) can be used to temporarily override the GA arches for test purposes. 