### PR TITLE
hack day: doozer bucket list

### DIFF
--- a/doozerlib/assertion.py
+++ b/doozerlib/assertion.py
@@ -31,6 +31,7 @@ def isdir(path, message):
 
     :raises: FileNotFoundError
     """
+    path = str(path)  # Convert from pathlib.Path if necessary
     if not os.path.isdir(path):
         raise FileNotFoundError(
             errno.ENOENT,
@@ -41,11 +42,12 @@ def isfile(path, message):
     """
     Raise an exception if the given file does not exist.
 
-    :param path: The path to a file to be tested
+    :param path: The str or pathlib path to a file to be tested
     :param message: A custom message to report in the exception
 
     :raises: FileNotFoundError
     """
+    path = str(path)  # Convert from pathlib.Path if necessary
     if not os.path.isfile(path):
         raise FileNotFoundError(
             errno.ENOENT,

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -392,12 +392,7 @@ def images_update_dockerfile(runtime, stream, version, release, repo_type, messa
                 if success is not True:
                     state.record_image_fail(lstate, meta, success)
         except Exception as ex:
-            msg = None
-            try:
-                msg = ex.strerror
-            except:
-                msg = str(ex)
-
+            msg = str(ex)
             state.record_image_fail(lstate, image_meta, msg, runtime.logger)
             return False
         return True
@@ -407,6 +402,7 @@ def images_update_dockerfile(runtime, stream, version, release, repo_type, messa
         metas,
     )
     jobs.get()
+    state.record_image_finish(lstate)
 
     failed = []
     for img, status in lstate['images'].items():
@@ -548,13 +544,7 @@ def images_rebase(runtime, stream, version, release, repo_type, message, push):
                 owners=owners,
                 message=str(ex).replace("|", ""),
             )
-
-            msg = None
-            try:
-                msg = ex.strerror
-            except:
-                msg = str(ex)
-
+            msg = str(ex)
             state.record_image_fail(lstate, image_meta, msg, runtime.logger)
             return False
         return True

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -13,7 +13,7 @@ from doozerlib.config import MetaDataConfig as mdc
 from doozerlib.cli import cli_opts
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib import exectools
-from doozerlib.util import green_prefix, red_prefix, green_print, red_print, yellow_print, yellow_prefix, color_print, dict_get
+from doozerlib.util import green_prefix, red_prefix, green_print, red_print, yellow_print, yellow_prefix, color_print, dict_get, mkdirs
 from doozerlib import operator_metadata
 import click
 import os
@@ -128,6 +128,8 @@ def print_version(ctx, param, value):
               help="Path to rhpkg config file to use instead of system default")
 @click.option("--brew-tag", metavar="BREW_TAG",
               help="Override brew tag to expect for images built")
+@click.option("--cache-dir", metavar="DIR", required=False, default=None,
+              help="A directory in which reference git repos can be stored for caching purposes")
 @click.option("--profile", metavar="NAME", default="", help="Name of build profile")
 @click.pass_context
 def cli(ctx, **kwargs):
@@ -222,7 +224,6 @@ option_push = click.option('--push/--no-push', default=False, is_flag=True,
 # CLI Commands
 #
 # =============================================================================
-
 
 @cli.command("images:clone", help="Clone a group's image distgit repos locally.")
 @pass_runtime

--- a/doozerlib/cli/cli_opts.py
+++ b/doozerlib/cli/cli_opts.py
@@ -6,7 +6,9 @@ GLOBAL_OPT_DEFAULTS = {
     'distgit_threads': 20,
     'rhpkg_clone_timeout': 900,
     'rhpkg_push_timeout': 1200,
-    'rhpkg_clone_depth': 1,  # 0 for unlimited
+
+    # 0 for unlimited. At present, distgit doesn't support shallow push. So leave this unlimited for now.
+    'rhpkg_clone_depth': 0,
 }
 
 

--- a/doozerlib/cli/cli_opts.py
+++ b/doozerlib/cli/cli_opts.py
@@ -5,7 +5,8 @@ import io
 GLOBAL_OPT_DEFAULTS = {
     'distgit_threads': 20,
     'rhpkg_clone_timeout': 900,
-    'rhpkg_push_timeout': 1200
+    'rhpkg_push_timeout': 1200,
+    'rhpkg_clone_depth': 1,  # 0 for unlimited
 }
 
 

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -161,6 +161,9 @@ class DistGitRepo(object):
 
                     cmd_list.extend(["clone", self.metadata.qualified_name, self.distgit_dir])
                     cmd_list.extend(["--branch", distgit_branch])
+                    rhpkg_clone_depth = int(self.runtime.global_opts.get('rhpkg_clone_depth', '1'))
+                    if rhpkg_clone_depth > 0:
+                        cmd_list.extend(["--depth", str(rhpkg_clone_depth)])
 
                     self.logger.info("Cloning distgit repository [branch:%s] into: %s" % (distgit_branch, self.distgit_dir))
 

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -156,8 +156,6 @@ class DistGitRepo(object):
 
                     timeout = str(self.runtime.global_opts['rhpkg_clone_timeout'])
                     rhpkg_clone_depth = int(self.runtime.global_opts.get('rhpkg_clone_depth', '1'))
-                    set_env = os.environ.copy()
-                    set_env.update(constants.GIT_NO_PROMPTS)
 
                     print(f'here {self.metadata.namespace} {self.runtime.cache_dir}')
                     if self.metadata.namespace == 'containers' and self.runtime.cache_dir:
@@ -169,7 +167,7 @@ class DistGitRepo(object):
                             gitargs.extend(["--depth", str(rhpkg_clone_depth)])
 
                         self.runtime.git_clone(self.metadata.distgit_remote_url(), self.distgit_dir, gitargs=gitargs,
-                                               set_env=set_env, timeout=timeout)
+                                               set_env=constants.GIT_NO_PROMPTS, timeout=timeout)
                     else:
                         # Use rhpkg -- presently no idea how to cache.
                         cmd_list = ["timeout", timeout]
@@ -188,7 +186,7 @@ class DistGitRepo(object):
                             cmd_list.extend(["--depth", str(rhpkg_clone_depth)])
 
                         # Clone the distgit repository. Occasional flakes in clone, so use retry.
-                        exectools.cmd_assert(cmd_list, retries=3, set_env=set_env)
+                        exectools.cmd_assert(cmd_list, retries=3, set_env=constants.GIT_NO_PROMPTS)
 
     def merge_branch(self, target, allow_overwrite=False):
         self.logger.info('Switching to branch: {}'.format(target))

--- a/doozerlib/exectools.py
+++ b/doozerlib/exectools.py
@@ -10,6 +10,9 @@ import subprocess
 import time
 import shlex
 import os
+import threading
+import platform
+import sys
 
 from fcntl import fcntl, F_GETFL, F_SETFL
 from os import O_NONBLOCK, read
@@ -17,7 +20,7 @@ from os import O_NONBLOCK, read
 from . import logutil
 from . import pushd
 from . import assertion
-from .util import red_print, green_print, yellow_print
+from .util import red_print, green_print, yellow_print, timer
 
 SUCCESS = 0
 
@@ -87,6 +90,10 @@ def cmd_assert(cmd, retries=1, pollrate=60, on_retry=None, set_env=None):
     return stdout, stderr
 
 
+cmd_counter_lock = threading.Lock()
+cmd_counter = 0  # Increments atomically to help search logs for command start/stop
+
+
 def cmd_gather(cmd, set_env=None, realtime=False):
     """
     Runs a command and returns rc,stdout,stderr as a tuple.
@@ -96,79 +103,118 @@ def cmd_gather(cmd, set_env=None, realtime=False):
     directory of the process (i.e. it is thread-safe).
 
     :param cmd: The command and arguments to execute
-    :param set_env: Dict of env vars to set for command (overriding existing)
+    :param set_env: Dict of env vars to override in the current doozer environment.
     :param realtime: If True, output stdout and stderr in realtime instead of all at once.
     :return: (rc,stdout,stderr)
     """
+    global cmd_counter, cmd_counter_lock
+
+    with cmd_counter_lock:
+        my_id = cmd_counter
+        cmd_counter = cmd_counter + 1
 
     if not isinstance(cmd, list):
         cmd_list = shlex.split(cmd)
     else:
-        cmd_list = cmd
+        # convert any non-str into str
+        cmd_list = [str(c) for c in cmd]
 
     cwd = pushd.Dir.getcwd()
-    cmd_info = '[cwd={}]: {}'.format(cwd, cmd_list)
+    cmd_info_base = f'${my_id}: {cmd_list} - [cwd={cwd}]'
+    cmd_info = cmd_info_base
 
     env = os.environ.copy()
     if set_env:
-        cmd_info = '[env={}] {}'.format(set_env, cmd_info)
+        cmd_info = '{} [env={}]'.format(cmd_info, set_env)
         env.update(set_env)
 
     # Make sure output of launched commands is utf-8
     env['LC_ALL'] = 'en_US.UTF-8'
 
-    logger.debug("Executing:cmd_gather {}".format(cmd_info))
-    try:
-        proc = subprocess.Popen(
-            cmd_list, cwd=cwd, env=env,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    except OSError as exc:
-        logger.error("Subprocess errored running:\n{}\nWith error:\n{}\nIs {} installed?".format(
-            cmd_info, exc, cmd_list[0]
-        ))
-        return exc.errno, "", "See previous error description."
+    with timer(logger.info, f'{cmd_info}: Executed:cmd_gather'):
+        logger.info(f'{cmd_info}: Executing:cmd_gather')
+        try:
+            proc = subprocess.Popen(
+                cmd_list, cwd=cwd, env=env,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except OSError as exc:
+            logger.error("{}: Errored:\nException:\n{}\nIs {} installed?".format(
+                cmd_info, exc, cmd_list[0]
+            ))
+            return exc.errno, "", "See previous error description."
 
-    if not realtime:
-        out, err = proc.communicate()
-        rc = proc.returncode
-    else:
-        out = b''
-        err = b''
+        if not realtime:
+            out, err = proc.communicate()
+            rc = proc.returncode
+        else:
+            out = b''
+            err = b''
 
-        # Many thanks to http://eyalarubas.com/python-subproc-nonblock.html
-        # setup non-blocking read
-        # set the O_NONBLOCK flag of proc.stdout file descriptor:
-        flags = fcntl(proc.stdout, F_GETFL)  # get current proc.stdout flags
-        fcntl(proc.stdout, F_SETFL, flags | O_NONBLOCK)
-        # set the O_NONBLOCK flag of proc.stderr file descriptor:
-        flags = fcntl(proc.stderr, F_GETFL)  # get current proc.stderr flags
-        fcntl(proc.stderr, F_SETFL, flags | O_NONBLOCK)
+            # Many thanks to http://eyalarubas.com/python-subproc-nonblock.html
+            # setup non-blocking read
+            # set the O_NONBLOCK flag of proc.stdout file descriptor:
+            flags = fcntl(proc.stdout, F_GETFL)  # get current proc.stdout flags
+            fcntl(proc.stdout, F_SETFL, flags | O_NONBLOCK)
+            # set the O_NONBLOCK flag of proc.stderr file descriptor:
+            flags = fcntl(proc.stderr, F_GETFL)  # get current proc.stderr flags
+            fcntl(proc.stderr, F_SETFL, flags | O_NONBLOCK)
 
-        rc = None
-        while rc is None:
-            output = None
-            try:
-                output = read(proc.stdout.fileno(), 256)
-                green_print(output.rstrip())
-                out += output
-            except OSError:
-                pass
+            rc = None
+            while rc is None:
+                output = None
+                try:
+                    output = read(proc.stdout.fileno(), 256)
+                    green_print(output.rstrip())
+                    out += output
+                except OSError:
+                    pass
 
-            error = None
-            try:
-                error = read(proc.stderr.fileno(), 256)
-                yellow_print(error.rstrip())
-                out += error
-            except OSError:
-                pass
+                error = None
+                try:
+                    error = read(proc.stderr.fileno(), 256)
+                    yellow_print(error.rstrip())
+                    out += error
+                except OSError:
+                    pass
 
-            rc = proc.poll()
-            time.sleep(0.0001)  # reduce busy-wait
+                rc = proc.poll()
+                time.sleep(0.0001)  # reduce busy-wait
 
-    # We read in bytes representing utf-8 output; decode so that python recognizes them as unicode strings
-    out = out.decode('utf-8')
-    err = err.decode('utf-8')
-    logger.debug(
-        "Process {}: exited with: {}\nstdout>>{}<<\nstderr>>{}<<\n".
-        format(cmd_info, rc, out, err))
+        # We read in bytes representing utf-8 output; decode so that python recognizes them as unicode strings
+        out = out.decode('utf-8')
+        err = err.decode('utf-8')
+        logger.debug(
+            "{}: Exited with: {}\nstdout>>{}<<\nstderr>>{}<<\n".
+            format(cmd_info, rc, out, err))
+
     return rc, out, err
+
+
+def fire_and_forget(cwd, shell_cmd, quiet=True):
+    """
+    Executes a command in a separate process that can continue to do its work
+    even after doozer terminates.
+    :param cwd: Path in which to launch the command
+    :param shell_cmd: A string to send to the shell
+    :param quiet: Whether to sink stdout & stderr to /dev/null
+    :return: N/A
+    """
+
+    if quiet:
+        shell_cmd = f'{shell_cmd} > /dev/null 2>/dev/null'
+
+    # https://stackoverflow.com/a/13256908
+    kwargs = {}
+    if platform.system() == 'Windows':
+        # from msdn [1]
+        CREATE_NEW_PROCESS_GROUP = 0x00000200  # note: could get it from subprocess
+        DETACHED_PROCESS = 0x00000008  # 0x8 | 0x200 == 0x208
+        kwargs.update(creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
+    elif sys.version_info < (3, 2):  # assume posix
+        kwargs.update(preexec_fn=os.setsid)
+    else:  # Python 3.2+ and Unix
+        kwargs.update(start_new_session=True)
+
+    p = subprocess.Popen(f'{shell_cmd}', env=os.environ.copy(), shell=True, stdin=None, stdout=None, stderr=None,
+                         cwd=cwd, close_fds=True, **kwargs)
+    assert not p.poll()

--- a/doozerlib/gitdata.py
+++ b/doozerlib/gitdata.py
@@ -141,11 +141,9 @@ class GitData(object):
                     shutil.rmtree(data_destination)
                 self.logger.info('Cloning config data from {}'.format(self.data_path))
                 if not os.path.isdir(data_destination):
-                    set_env = os.environ.copy()
-                    set_env.update(constants.GIT_NO_PROMPTS)
                     # Clone all branches as we must sometimes reference master /OWNERS for maintainer information
                     cmd = "git clone --no-single-branch -b {} --depth 1 {} {}".format(self.branch, self.data_path, data_destination)
-                    rc, out, err = exectools.cmd_gather(cmd, set_env=set_env)
+                    rc, out, err = exectools.cmd_gather(cmd, set_env=constants.GIT_NO_PROMPTS)
                     if rc:
                         raise GitDataException('Error while cloning data: {}'.format(err))
 

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -107,6 +107,11 @@ class Metadata(object):
         self.data_obj.data = self.config.primitive()
         self.data_obj.save()
 
+    def distgit_remote_url(self):
+        pkgs_host = self.runtime.group_config.urls.get('pkgs_host', 'pkgs.devel.redhat.com')
+        # rhpkg uses a remote named like this to pull content from distgit
+        return f'ssh://{self.runtime.user}@{pkgs_host}/{self.qualified_name}'
+
     def distgit_repo(self, autoclone=True):
         if self._distgit_repo is None:
             self._distgit_repo = DISTGIT_TYPES[self.meta_type](self, autoclone=autoclone)

--- a/doozerlib/pushd.py
+++ b/doozerlib/pushd.py
@@ -39,7 +39,7 @@ class Dir(object):
     _tl = threading.local()
 
     def __init__(self, newdir):
-        self.dir = newdir
+        self.dir = str(newdir)
         self.previous_dir = None
 
     def __enter__(self):

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -745,7 +745,7 @@ class Runtime(object):
             replace_vars = self.group_config.vars.primitive()
         data_obj = self.gitdata.load_data(path='images', key=distgit_name, replace_vars=replace_vars)
         if not data_obj:
-            raise DoozerFatalError('Unable to resovle image metadata for {}'.format(distgit_name))
+            raise DoozerFatalError('Unable to resolve image metadata for {}'.format(distgit_name))
 
         meta = ImageMetadata(self, data_obj)
         if add:

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -109,11 +109,11 @@ def is_in_directory(path, directory):
 
 def mkdirs(path):
     """ Make sure a directory exists. Similar to shell command `mkdir -p`.
-
+    :param path: Str path or pathlib.Path
     This function will not be necessary when fully migrated to Python 3.
     """
     try:
-        os.makedirs(path)
+        os.makedirs(str(path))
     except OSError as e:
         if e.errno != errno.EEXIST:  # ignore if dest_dir exists
             raise
@@ -142,7 +142,7 @@ def analyze_debug_timing(file):
     def get_thread_name(thread):
         if thread in thread_names:
             return thread_names[thread]
-        c = chr(ord('A') + len(thread_names))
+        c = f'T{len(thread_names)}'
         thread_names[thread] = c
         return c
 
@@ -186,11 +186,11 @@ def analyze_debug_timing(file):
         print('')
 
     print('Thread timelines')
-    names = sorted(list(thread_names.values()))
+    names = sorted(list(thread_names.values()), key=lambda e: int(e[1:]))  # sorts as T1, T2, T3, .... by removing 'T'
     print_em('*', *names)
 
     sorted_intervals = sorted(list(event_timings.keys()))
-    for interval in range(0, sorted_intervals[-1]+1):
+    for interval in range(0, sorted_intervals[-1] + 1):
         print_em(interval, *names)
         if interval in event_timings:
             interval_map = event_timings[interval]
@@ -199,7 +199,4 @@ def analyze_debug_timing(file):
                 for event in events:
                     with_event = list(names)
                     with_event[i] = thread_name + ': ' + event
-                    print_em(f' {interval}', *with_event[:i+1])
-
-
-
+                    print_em(f' {interval}', *with_event[:i + 1])

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -110,7 +110,6 @@ def is_in_directory(path, directory):
 def mkdirs(path):
     """ Make sure a directory exists. Similar to shell command `mkdir -p`.
     :param path: Str path or pathlib.Path
-    This function will not be necessary when fully migrated to Python 3.
     """
     try:
         os.makedirs(str(path))

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -86,7 +86,7 @@ def convert_remote_git_to_https(source):
     :return: Normalized https git URL
     """
     url = re.sub(
-        pattern=r'git@([^:]+):([^\.]+)',
+        pattern=r'[^@]+@([^:/]+)[:/]([^\.]+)',
         repl='https://\\1/\\2',
         string=source.strip(),
     )

--- a/tests/test_distgit/support.py
+++ b/tests/test_distgit/support.py
@@ -51,6 +51,7 @@ class MockRuntime(object):
         self.logger = logger
         self.mutex = SimpleMockLock()
         self.missing_pkgs = set()
+        self.cache_dir = None
 
     def detect_remote_source_branch(self, _):
         pass

--- a/tests/test_distgit/test_convert_source_url_to_https.py
+++ b/tests/test_distgit/test_convert_source_url_to_https.py
@@ -38,12 +38,10 @@ class TestDistgitConvertSourceURLToHTTPS(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_conversion_from_ssh_org_source(self):
-        source = "git@github.com:myorg/"
-
-        actual = util.convert_remote_git_to_https(source)
         expected = "https://github.com/myorg"
-
-        self.assertEqual(actual, expected)
+        for source in ["git@github.com:myorg/", "git@github.com/myorg/", 'ssh://someone@github.com/myorg', 'ssh://someone@github.com:myorg']:
+            actual = util.convert_remote_git_to_https(source)
+            self.assertEqual(actual, expected)
 
     def test_conversion_from_https_org_source(self):
         source = "https://github.com/myorg/"

--- a/tests/test_source_modifications.py
+++ b/tests/test_source_modifications.py
@@ -5,6 +5,7 @@ import tempfile
 import os
 import shutil
 import mock
+import pathlib
 
 from doozerlib.source_modifications import SourceModifierFactory, AddModifier
 
@@ -43,7 +44,8 @@ class AddModifierTestCase(unittest.TestCase):
             session = MockSession()
             response = session.get.return_value
             response.content = expected_content
-            modifier.act(ceiling_dir=self.temp_dir, session=session)
+            context = {"distgit_path": pathlib.Path(self.temp_dir)}
+            modifier.act(ceiling_dir=self.temp_dir, session=session, context=context)
         with open(params["path"], "rb") as f:
             actual = f.read()
         self.assertEqual(actual, expected_content)
@@ -63,7 +65,8 @@ class AddModifierTestCase(unittest.TestCase):
             response = session.get.return_value
             response.content = expected_content
             with self.assertRaises(IOError) as cm:
-                modifier.act(ceiling_dir=self.temp_dir, session=session)
+                context = {"distgit_path": pathlib.Path(self.temp_dir)}
+                modifier.act(ceiling_dir=self.temp_dir, session=session, context=context)
             self.assertIn("overwrite", repr(cm.exception))
 
 


### PR DESCRIPTION
1. Added a --cache-dir options to doozer. If specified, doozer will populate distgit & sources repos there and use those repos as clone --reference. All doozer instances, regardless of group, can use this same directory. Each run will update the cached repos. This reduces images:clone time from about 20m to 3m.

2. Implemented a timing analysis tool to see where time was being spent. After a doozer run, execute something like `./doozer analyze:debug-log ../wd/debug.log > analysis.txt' . This will show you what each thread was doing over the course of the doozer run. 

3. I ran the analysis tool on a run on `images:rebase`. Not unexpectedly, the lack of threading stuck out like relative to the now fast cloning. The final commit adds threading to rebase and update-dockerfile. This forced several changes in the way file I/O was handed in these methods to make them threadsafe.

All together, changes 1-3 can reduce the rebase time from > 1 hour to ~10 minutes. 

4. The `Fix update-dockerfile KUBE_ env loss` commit is to address https://issues.redhat.com/browse/ART-1730

5. The `jenkins/brew information to distgit labels` commit aims to give us easy to reference information about brew tasks & jenkins jobs. Want to know what the last failure was for 4.5 cli image? Browse to http://pkgs.devel.redhat.com/cgit/containers/openshift-enterprise-cli/log/?h=rhaos-4.5-rhel-7 and Ctrl-F for `doozer-failure` . The annotated tag will provide you information about the Jenkins job and brew task that failed.

~~6. The `Force rebuild when ocp-build-data changes` will report source change when ocp-build-data changes. In someone changes their configuration or we update group.yml, we should rebuild instead of waiting 24 hours.~~ DROPPED