### PR TITLE
Hack'n'Hustle: Support rebasing images from specified Git commit hashes

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -28,6 +28,7 @@ import koji
 import io
 import json
 import functools
+import re
 import semver
 import urllib
 from numbers import Number
@@ -463,10 +464,12 @@ def config_scan_source_changes(runtime, as_yaml):
 @click.option("--repo-type", metavar="REPO_TYPE", envvar="OIT_IMAGES_REPO_TYPE",
               default="unsigned",
               help="Repo group type to use for version autodetection scan (e.g. signed, unsigned).")
+@click.option("--upstream", "upstreams", metavar="DISTGIT_KEY=COMMIT-ISH", multiple=True,
+              help="Override upstream source commits [multiple]")
 @option_commit_message
 @option_push
 @pass_runtime
-def images_rebase(runtime, stream, version, release, repo_type, message, push):
+def images_rebase(runtime, stream, version, release, repo_type, message, push, upstreams):
     """
     Many of the Dockerfiles stored in distgit are based off of content managed in GitHub.
     For example, openshift-enterprise-node should always closely reflect the changes
@@ -482,7 +485,18 @@ def images_rebase(runtime, stream, version, release, repo_type, message, push):
     distgit), the Dockerfile in distgit will not be rebased, but other aspects of the
     metadata may be applied (base image, tags, etc) along with the version and release.
     """
-    runtime.initialize(validate_content_sets=True)
+
+    upstream_pattern = re.compile(r"(.+)=(.+)")  # TODO: Use a more precise regexp
+    upstream_overrides = {}
+    for upstream in upstreams:
+        click.echo(f"Use {upstream}")
+        m = upstream_pattern.fullmatch(upstream)
+        if not m:
+            raise ValueError(f"Invalid `upstream` string: {upstream}, expecting like some-image=https://github.com/foo/bar#commitish")
+        click.echo(f"\tdistgit={m[1]},commitish={m[2]}")
+        upstream_overrides[m[1]] = m[2]
+
+    runtime.initialize(validate_content_sets=True, upstream_commitish_overrides=upstream_overrides)
 
     # This is ok to run if automation is frozen as long as you are not pushing
     if push:

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1745,6 +1745,10 @@ class ImageDistGitRepo(DistGitRepo):
         self.env_vars_from_source = {}
 
         with Dir(self.source_path()):
+            if self.metadata.commitish:
+                self.runtime.logger.info(f"Rebasing image {self.name} from speicified commit-ish {self.metadata.commitish}...")
+                cmd = ["git", "checkout", self.metadata.commitish]
+                exectools.cmd_assert(cmd)
             # gather source repo short sha for audit trail
             rc, out, _ = exectools.cmd_gather(["git", "rev-parse", "--short", "HEAD"])
             self.source_sha = out.strip()

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, unicode_literals
+from typing import Dict, Optional
 from doozerlib.distgit import pull_image
 from doozerlib.metadata import Metadata
 from doozerlib.model import Missing
@@ -7,13 +8,14 @@ from doozerlib import assertion, exectools
 
 class ImageMetadata(Metadata):
 
-    def __init__(self, runtime, data_obj):
+    def __init__(self, runtime, data_obj: Dict, commitish: Optional[str] = None):
         super(ImageMetadata, self).__init__('image', runtime, data_obj)
         self.image_name = self.config.name
         self.required = self.config.get('required', False)
         self.image_name_short = self.image_name.split('/')[-1]
         self.parent = None
         self.children = []
+        self.commitish = commitish
         dependents = self.config.get('dependents', [])
         for d in dependents:
             self.children.append(self.runtime.late_resolve_image(d, add=True))


### PR DESCRIPTION

This PR adds a new option `--upstream` to the `images:rebase` command so that Doozer can build images from specified Git commits.
This would give us the ability to rebuilding an image any time without introducing unwanted code changes.

To specify the commit hashes, use this syntax:

```bash
doozer images:rebase --upstream distgit_key_1=commitish_1 --upstream
distgit_key_2=commitish_2 ...
```

For example:

```bash
doozer -g openshift-4.4 --images ose-metering-ansible-operator:c0d9aaf5a901cc9b40068cac0b9c037579d72dc7,openshift-enterprise-ansible-operator \
    --latest-parent-version images:rebase -m 'test' --version v4.4 --release 202001010000 --upstream ose-metering-ansible-operator=c0d9aaf5a901cc9b40068cac0b9c037579d72dc7
```

Note you images specified in `--images` without `--upstream` will use
the tip commit of the branch so it will not break the backward
compatibility.

Limitations:
- Building RPMs from commit hashes is not covered in this PR.
- The behavior of `--latest-parent-version` is not changed, so it could use a base image from the latest Brew build.
- commit-ish format is not checked, so it relies on `git` to check that.

In the future we can also have an option like `--parent` with the same
syntax to allow us to
specify parent image NVRs.
