### PR TITLE
[ART-1159] allow non-semver versions so we can omit the .z

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1262,7 +1262,7 @@ class ImageDistGitRepo(DistGitRepo):
             vsplit = version.split(".")
 
             major_version = vsplit[0].lstrip('v')
-            # Click validation should have ensured user specified semver, but double check because of version=None flow.
+            # ensure that we have minor and patch segments in the version for semver
             minor_version = '0' if len(vsplit) < 2 else vsplit[1]
             patch_version = '0' if len(vsplit) < 3 else vsplit[2]
 

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -272,15 +272,11 @@ class RPMMetadata(Metadata):
 
         # self.version example: 3.9.0
         # Extract the major, minor, patch
-        major, minor, patch = self.version.split('.')
-        full = "v{}".format(self.version)
-
-        # If this is a pre-release RPM, the include the release field in
-        # the full version.
-        # pre-release full version: v3.9.0-0.20.1
-        # release full version: v3.9.0
-        if self.release.startswith("0."):
-            full += "-{}".format(self.release)
+        vsplit = self.version.split(".")
+        major = vsplit[0].lstrip('v')
+        # ensure that we have minor and patch segments in the version for semver
+        minor = '0' if len(vsplit) < 2 else vsplit[1]
+        patch = '0' if len(vsplit) < 3 else vsplit[2]
 
         with Dir(self.source_path):
             commit_sha = exectools.cmd_assert('git rev-parse HEAD')[0].strip()


### PR DESCRIPTION
I'll take http://post-office.corp.redhat.com/archives/aos-team-art/2020-April/msg00109.html as approval that we can version the brew builds however we see fit.

This allows us to build packages and images with version `v4.4` and not have a confusing `.0` added on. However note that env vars aimed at build scripts in spec files and dockerfiles will continue to be set as if the version implicitly had `0` for any missing segments.