### PR TITLE
Re-enabled doozer tagging

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -982,8 +982,7 @@ class ImageDistGitRepo(DistGitRepo):
                            '-m', f'{build_state} from {self.runtime.uuid}'
                            ]
                 tag_cmd.extend(messages)
-                # Disable for 4.4 GA -- await fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1827706
-                # exectools.cmd_assert(tag_cmd, retries=3)
+                exectools.cmd_assert(tag_cmd, retries=3)
 
         try:
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1827706 needs to be fixed for all releases before re-enabling: https://bugzilla.redhat.com/show_bug.cgi?id=1827706#c8