### PR TITLE
Generate source revisions for images

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -16,6 +16,7 @@ from doozerlib.exceptions import DoozerFatalError
 from doozerlib import exectools
 from doozerlib.util import green_prefix, red_prefix, green_print, red_print, yellow_print, yellow_prefix, color_print, dict_get, analyze_debug_timing, get_cincinnati_channels, extract_version_fields
 from doozerlib import operator_metadata
+from doozerlib.cli.releaseapi_cli import releaseapi_cli
 import click
 import os
 import shutil
@@ -2408,5 +2409,6 @@ def main():
             CTX_GLOBAL.obj.save_state()
 
 
+cli.add_command(releaseapi_cli)
 if __name__ == '__main__':
     main()

--- a/doozerlib/cli/releaseapi_cli.py
+++ b/doozerlib/cli/releaseapi_cli.py
@@ -1,0 +1,57 @@
+from typing import List, Dict, Optional
+from pathlib import Path
+import click
+import yaml
+import semver
+import sys
+import threading
+
+from doozerlib import exectools
+from doozerlib.runtime import Runtime
+from doozerlib.image import ImageMetadata
+from doozerlib.releaseapi import create_source_revision_for_image, sanitize_for_serialization
+
+
+@click.group("beta:releaseapi", short_help="(Beta) Release APIServer objects")
+@click.pass_context
+def releaseapi_cli(ctx):
+    pass
+
+
+@releaseapi_cli.command(short_help="Generate source revisions (currently only support images)")
+@click.option("--kind", "-k", metavar='KIND', type=click.Choice(['all', 'image']), default="all", required=True)
+@click.option("--out", "-o", metavar='FILE', type=Path, default="-", required=True)
+@click.option("--release-name", "-r", metavar="RELEASE_NAME", type=str, required=True)
+@click.pass_context
+def gen_source_revisions(ctx, kind: str, out: Path, release_name: str):
+    """ Record the latest upstream commit hashes for a release branch and generate source revison objects.
+
+    Example 1: Generate source revisions for OpenShift 4.4
+        doozer -g openshift-4.4 beta:releaseapi gen-source-revisions -r openshift-4.4.1 -k image -o openshift-4.4.1.source-revisions.yaml
+
+    Example 2: Generate source revisions for specified components
+        doozer -g openshift-4.4 -i ose-installer-artifacts,openshift-enterprise-cli beta:releaseapi gen-source-revisions -r openshift-4.4.1 -k image -o openshift-4.4.1.source-revisions.yaml
+
+    """
+    # version = version.lstrip("v")
+    # semver.parse_version_info(version)  # assert semver
+    # release_name = f"openshift-{version}"
+    runtime: Runtime = ctx.obj
+    runtime.initialize(clone_distgits=False)
+    release_stream_name = runtime.group
+
+    images: List[ImageMetadata] = [image for image in runtime.image_metas()]
+
+    def _create_source_revision(image: ImageMetadata):
+        runtime.logger.info(f"Processing {image.name}...")
+        url, ref, commit = image.get_source()
+        sr = create_source_revision_for_image(release_stream_name, release_name, image, commit)
+        return sr
+
+    results = runtime._parallel_exec(_create_source_revision, images, 64)
+    results = sanitize_for_serialization(results)
+    if str(out) == "-":
+        yaml.safe_dump_all(results, sys.stdout)
+    else:
+        with open(out, "w") as f:
+            yaml.safe_dump_all(results, f)

--- a/doozerlib/releaseapi.py
+++ b/doozerlib/releaseapi.py
@@ -1,0 +1,42 @@
+import asyncio
+from doozerlib.image import ImageMetadata
+from openshift_release import ApiClient
+
+from openshift_release.models.io_k8s_apimachinery_pkg_apis_meta_v1_object_meta \
+    import IoK8sApimachineryPkgApisMetaV1ObjectMeta as ObjectMeta
+
+from openshift_release.models.com_github_vfreex_release_apiserver_pkg_apis_art_v1alpha1_source_revision \
+    import ComGithubVfreexReleaseApiserverPkgApisArtV1alpha1SourceRevision as SourceRevision
+from openshift_release.models.com_github_vfreex_release_apiserver_pkg_apis_art_v1alpha1_source_revision_spec \
+    import ComGithubVfreexReleaseApiserverPkgApisArtV1alpha1SourceRevisionSpec as SourceRevisionSpec
+
+
+DEFAULT_API_VERSION = "art.openshift.io/v1alpha1"
+
+
+def sanitize_for_serialization(objects):
+    api_client = ApiClient(pool_threads=0)
+    for obj in objects:
+        yield api_client.sanitize_for_serialization(obj)
+
+
+def create_source_revision_for_image(group_name: str, release_name: str, image_meta: ImageMetadata, commit_hash: str) -> SourceRevision:
+    sv = SourceRevision(
+        api_version=DEFAULT_API_VERSION,
+        kind="SourceRevision",
+        metadata=ObjectMeta(
+            name=f"{release_name}-image-{image_meta.image_name_short}",
+            labels={
+                "release-stream": group_name,
+                "release": release_name,
+                "kind": "image",
+                "distgit-key": image_meta.distgit_key,
+                "image-name": image_meta.image_name_short,
+            },
+        ),
+        spec=SourceRevisionSpec(
+            component_name=f"{group_name}-image-{image_meta.image_name_short}",
+            commit_hash=commit_hash,
+        )
+    )
+    return sv

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ dockerfile-parse >= 0.0.13
 future
 koji
 mock
+openshift-release >= 0.0.2
 pyyaml >= 5.1
 retry
 requests


### PR DESCRIPTION
This PR adds a new command to generate source revisions for images.

- On the build the product day, run this command to record the upstream
  commit hashes as source revision objects for all images.
- Store the source revision objects to the apiserver using `oc` or
  `kubectl`.

Example 1: Generate source revisions for OpenShift 4.4

        doozer -g openshift-4.4 beta:releaseapi gen-source-revisions -r openshift-4.4.1 -o openshift-4.4.1.source-revisions.yaml

Example 2: Generate source revisions for specified components

        doozer -g openshift-4.4 -i ose-installer-artifacts,openshift-enterprise-cli beta:releaseapi gen-source-revisions -r openshift-4.4.1 -o openshift-4.4.1.source-revisions.yaml

Example YAML output:

```yaml
---
apiVersion: art.openshift.io/v1alpha1
kind: SourceRevision
metadata:
  labels:
    distgit-key: openshift-enterprise-cli
    image-name: ose-cli
    kind: image
    release: openshift-4.4.1
    release-stream: openshift-4.4
  name: openshift-4.4.1-image-ose-cli
spec:
  commitHash: 2576e482bf003e34e67ba3d69edcf5d411cfd6f3
  componentName: openshift-4.4-image-ose-cli
---
apiVersion: art.openshift.io/v1alpha1
kind: SourceRevision
metadata:
  labels:
    distgit-key: ose-installer-artifacts
    image-name: ose-installer-artifacts
    kind: image
    release: openshift-4.4.1
    release-stream: openshift-4.4
  name: openshift-4.4.1-image-ose-installer-artifacts
spec:
  commitHash: 78b817ceb7657f81176bbe182cc6efc73004c841
  componentName: openshift-4.4-image-ose-installer-artifacts
```

## Note
- The `openshift-release` package is a auto generated from the OpenAPI derived from the Golang structs: https://github.com/vfreex/release-apiserver/tree/master/python-openshift-release