### PR TITLE
Hack & Hustle Record keeping in simpledb

### DIFF
--- a/doozerlib/dblib.py
+++ b/doozerlib/dblib.py
@@ -1,0 +1,204 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import time
+import os
+import sys
+import threading
+import hashlib
+import boto3
+import traceback
+from .model import Missing
+
+# Records need unique names. Use this int atomically for extra protection.
+record_sequence = 0
+
+
+class DB(object):
+
+    def __init__(self, runtime, environment, dry_run=False):
+        """
+        :param runtime: The runtime
+        :param environment: int / stage / prod  for database environment. None will not write any data.
+        :param dry_run: If True, not data will be written
+        """
+        self.lock = threading.Lock()
+        self.existing_domains = {}  # maps existing domain names to True
+        self.runtime = runtime
+        self.environment = environment
+        self.cmd_line = ','.join(sys.argv)
+        m = hashlib.md5()
+        m.update(self.cmd_line.encode('utf-8'))
+        self.uniq = m.hexdigest()  # help guarantee record uniqueness
+
+        self.client = None
+        if environment and not dry_run:
+            try:
+                self.client = boto3.client('sdb', region_name='us-east-1')
+                for name in self.client.list_domains()['DomainNames']:
+                    self.existing_domains[name] = True
+            except:
+                traceback.print_exc()
+                runtime.logger.error('Unable to acquire simpledb client; please check AWS creds')
+
+    def create_domain_if_missing(self, domain):
+        if self.client:
+            with self.lock:
+                if domain in self.existing_domains:
+                    # Already exists
+                    return
+                self.client.create_domain(
+                    DomainName=domain,
+                )
+                self.existing_domains[domain] = True
+
+    def record(self, operation, metadata=None, dry_run=False):
+        """
+        :param operation: The type of operation being tracked
+        :param metadata: Distgit metadata if any
+        :param dry_run: If true, this record will not be written to the datastore. e.g. scratch builds.
+        :return:
+        """
+        domain = f'ART_{self.environment}_{operation}'
+        self.create_domain_if_missing(domain)
+
+        extras = {}
+        if metadata:
+            extras['dg.name'] = metadata.namespace
+            extras['dg.namespace'] = metadata.namespace
+            extras['dg.qualified_key'] = metadata.qualified_key
+            extras['dg.qualified_name'] = metadata.qualified_name
+
+        return Record(self, domain, extras, dry_run)
+
+    def select(self, expression, consistent_read=True):
+        """
+        https://docs.aws.amazon.com/AmazonSimpleDB/latest/DeveloperGuide/UsingSelect.html
+        :param expression: Select expression to execute
+        :param consistent_read: If True, ensures consistency before read. Minor performance penalty.
+        :return: An array of item records. e.g.
+                [
+                    { 'Name': 'test.202', 'Attributes': [{'Name': 'jenkins.build_url', 'Value': '..''}, ...] },
+                    { 'Name': 'test.203', 'Attributes': [{'Name': 'jenkins.build_url', 'Value': '..''}, ...] },
+                    ...
+                ]
+
+        """
+        items = []
+        self.runtime.logger.info(f'Running db query: {expression}')
+        if self.client:
+            nt = ''
+            while True:
+                r = self.client.select(
+                    SelectExpression=expression,
+                    NextToken=nt,
+                    ConsistentRead=consistent_read,
+                )
+                nt = r.get('NextToken', None)
+                items.extend(r.get('Items', []))
+                if not nt:
+                    break
+            return items
+        else:
+            raise IOError('No simpledb client has been initialized')
+
+
+class Record(object):
+    """
+    Context manager to handle records being added to datastore
+    """
+
+    _tl = threading.local()
+
+    def __init__(self, db, domain, extras={}, dry_run=False):
+        global record_sequence
+        self.previous_record = None
+        self.domain = domain
+        self.db = db
+        self.runtime = db.runtime
+        self.dry_run = dry_run
+
+        with self.runtime.mutex:
+            self.seq = record_sequence
+            record_sequence += 1
+
+        self.name = f'{self.runtime.uuid}.{self.seq}.{self.db.uniq}'
+
+        # A set of attributes for the record
+        self.attrs = {
+            'time.unix': str(int(round(time.time() * 1000))),  # utc milliseconds since epoch
+            'time.iso': self.runtime.timestamp(),  # for humans
+            'record.seq': self.seq,
+            'runtime.uuid': str(self.runtime.uuid),
+            'runtime.user': self.runtime.user or '',
+            'group': self.runtime.group_config['name'],
+        }
+
+        for jenkins_var in ['BUILD_NUMBER', 'BUILD_URL', 'JOB_NAME', 'NODE_NAME', 'JOB_URL']:
+            self.attrs[f'jenkins.{jenkins_var.lower()}'] = os.getenv(jenkins_var, '')
+
+        self.attrs.update(extras)
+
+    def __enter__(self):
+        if hasattr(self._tl, 'record'):
+            self.previous_record = self._tl.record
+        self._tl.record = self
+        return self
+
+    def __exit__(self, *args):
+        if not self.dry_run and self.db.client:
+            with self.db.runtime.get_dir_lock('package::boto3'):
+                try:
+                    attr_payload = []
+                    for k, v in self.attrs.items():
+
+                        if v is None or v is Missing:
+                            v = ''
+
+                        attr_payload.append({
+                            'Name': k,
+                            'Value': str(v),
+                            'Replace': True
+                        })
+                    self.db.client.put_attributes(
+                        DomainName=self.domain,
+                        ItemName=self.name,
+                        Attributes=attr_payload
+                    )
+                except:
+                    traceback.print_exc()
+                    self.runtime.logger.error(f'Unable to write to simpledb: {self.name}={self.attrs}')
+
+        self._tl.record = self.previous_record
+
+    @classmethod
+    def set(cls, name, value):
+        """
+        Sets an attribute name=value for the most recent Record context
+        :param name: The name of the attribute to set (limit 1024 chars)
+        :param value: The value of the attribute to set (limit 1024 chars)
+        :return:
+        """
+        if not hasattr(cls._tl, "record"):
+            # Caller is not within runtime.record(...):
+            raise IOError(f'No database record context has been established. Unable to set {name}={value}.')
+        cls._tl.record.attrs[name] = value
+
+    @classmethod
+    def update(cls, a_dict):
+        """
+        Sets attributes for the most recent Record context
+        :param a_dict: key / values to set
+        :return:
+        """
+        if not hasattr(cls._tl, "record"):
+            # Caller is not within runtime.record(...):
+            raise IOError(f'No database record context has been established. Unable to set {a_dict}.')
+        cls._tl.record.attrs.update(a_dict)
+
+    @classmethod
+    def current(cls):
+        """
+        :return: Returns the current Record object or None
+        """
+        if not hasattr(cls._tl, "record"):
+            return None
+        return cls._tl.record

--- a/doozerlib/pushd.py
+++ b/doozerlib/pushd.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import threading
+import pathlib
 
 
 class Dir(object):
@@ -61,3 +62,11 @@ class Dir(object):
         if not hasattr(cls._tl, "cwd"):
             cls._tl.cwd = os.getcwd()
         return cls._tl.cwd
+
+    @classmethod
+    def getpath(cls):
+        """
+        Provide a context dependent current working directory. This method
+        will return a pathlib.Path for the directory currently holding the lock.
+        """
+        return pathlib.Path(Dir.getcwd())

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ retry
 requests
 requests_kerberos
 semver
+boto3


### PR DESCRIPTION
Creates a record in simpledb for each build attempt. Allows correlation between jenkins jobs, shas, source commits, distgit commits, etc, with SQL-like logic. 

This will provide a means to correlated tons of data:
- What jenkins job last built <component>
- What jenkins job built distgit commit X?
- What jenkins job built build sha256:...?
- What percentage of 4.5 builds are failing?  (e.g. a dashboard)
- art-bot what was the last successful build of <distgit>?
- art-bot notify me when <distgit> is built.   (simpledb supports get_waiter)
- etc.

If we like it, it could also replace record and state.yaml. 

(Note datastore is either int, stage, or prod, so we can test different things without affecting prod data)

```
$ ./doozer --datastore int db:query --operation build -l brew.image_shas="%sha256:0ac0cd78f1a06b6084c5032845461636b6d6fcc4cd48d9cd54b3107b0942d734%" -o yaml
2020-05-01 15:59:36,290 INFO Running db query: SELECT * FROM ART_int_build WHERE `brew.image_shas` LIKE "%sha256:0ac0cd78f1a06b6084c5032845461636b6d6fcc4cd48d9cd54b3107b0942d734%"
```

Would output YAML for an event like:
```yaml
- Attributes:
  - Name: brew.task_id
    Value: '28324126'
  - Name: brew.task_state
    Value: success
  - Name: build.time.iso
    Value: '2020-05-01T19:13:24.522751'
  - Name: build.time.unix
    Value: '1588360404523'
  - Name: dg.commit
    Value: 9f26f1a3
  - Name: dg.name
    Value: containers
  - Name: dg.namespace
    Value: containers
  - Name: dg.qualified_key
    Value: containers/openshift-enterprise-tests
  - Name: dg.qualified_name
    Value: containers/openshift-enterprise-tests
  - Name: group
    Value: openshift-4.5
  - Name: jenkins.build_number
    Value: ''
  - Name: jenkins.build_url
    Value: ''
  - Name: jenkins.job_name
    Value: ''
  - Name: jenkins.job_url
    Value: ''
  - Name: jenkins.node_name
    Value: ''
  - Name: record.seq
    Value: '0'
  - Name: runtime.user
    Value: jupierce
  - Name: runtime.uuid
    Value: '20200501.151306'
  - Name: time.iso
    Value: '2020-05-01T19:13:24.522846'
  - Name: time.unix
    Value: '1588360404523'
  - Name: brew.build_ids
    Value: '1182190'
  - Name: brew.faultCode
    Value: '0'
  - Name: brew.image_shas
    Value: sha256:0ac0cd78f1a06b6084c5032845461636b6d6fcc4cd48d9cd54b3107b0942d734,sha256:d588547c2884d8c702ff4edc98571b7602bb2603d4c09850bd7b62df5a8dce42,sha256:57c9847c11119307e4efbd324431a414fb86d2a7a24a2334ba9eb852b9f40de3
  - Name: env.KUBE_GIT_COMMIT
    Value: 2f054b7646dc9e98f6dea458d2fb65e1d2c1f731
  - Name: env.KUBE_GIT_MAJOR
    Value: '1'
  - Name: env.KUBE_GIT_MINOR
    Value: 18+
  - Name: env.KUBE_GIT_VERSION
    Value: v1.18.0-rc.1
  - Name: env.OS_GIT_COMMIT
    Value: 44d2daa
  - Name: env.OS_GIT_MAJOR
    Value: '4'
  - Name: env.OS_GIT_MINOR
    Value: '5'
  - Name: env.OS_GIT_PATCH
    Value: '0'
  - Name: env.OS_GIT_TREE_STATE
    Value: clean
  - Name: env.OS_GIT_VERSION
    Value: 4.5.0-202005011615-44d2daa
  - Name: incomplete
    Value: 'False'
  - Name: label.com.redhat.component
    Value: openshift-enterprise-tests-container
  - Name: label.io.openshift.build.commit.id
    Value: 44d2daadc8d474ca40498e74c97feba3ffbe93f3
  - Name: label.io.openshift.build.commit.url
    Value: https://github.com/openshift/origin/commit/44d2daadc8d474ca40498e74c97feba3ffbe93f3
  - Name: label.io.openshift.build.source-location
    Value: https://github.com/openshift/origin
  - Name: label.io.openshift.maintainer.product
    Value: OpenShift Container Platform
  - Name: label.io.openshift.tags
    Value: openshift,tests,e2e
  - Name: label.name
    Value: openshift/ose-tests
  - Name: label.release
    Value: '202005011615'
  - Name: label.version
    Value: v4.5.0
  - Name: build.0.id
    Value: '1182190'
  - Name: build.0.name
    Value: openshift-enterprise-tests-container
  - Name: build.0.nvr
    Value: openshift-enterprise-tests-container-v4.3.18-202005011805
  - Name: build.0.package_id
    Value: '67814'
  - Name: build.0.release
    Value: '202005011805'
  - Name: build.0.source
    Value: git://pkgs.devel.redhat.com/containers/openshift-enterprise-tests#02fd1ea09d7f08e708cd49b8a88d499d922d332a
  - Name: build.0.version
    Value: v4.3.18
  Name: 20200501.151306.0.58590ef50178d383e74acc2b8f95eb0d
```

Printing only specific attributes
```
./doozer --datastore int db:query -p build -a dg.commit -a brew.image_shas -l brew.image_shas="%sha256:0ac0cd78f1a06b6084c5032845461636b6d6fcc4cd48d9cd54b3107b0942d734%" -o yaml
```

```yaml
- Attributes:
  - Name: dg.commit
    Value: 9f26f1a3
  - Name: brew.image_shas
    Value: sha256:0ac0cd78f1a06b6084c5032845461636b6d6fcc4cd48d9cd54b3107b0942d734,sha256:d588547c2884d8c702ff4edc98571b7602bb2603d4c09850bd7b62df5a8dce42,sha256:57c9847c11119307e4efbd324431a414fb86d2a7a24a2334ba9eb852b9f40de3
  Name: 20200501.151306.0.58590ef50178d383e74acc2b8f95eb0d
```

A browser plugin allows us to intertact with this data as well:
![image](https://user-images.githubusercontent.com/19783215/80837703-56d77380-8bc5-11ea-97b4-83cce26f2971.png)
