### PR TITLE
devcontainer: use with podman

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,4 +1,4 @@
-## Doozer Development Container Support for VSCode
+# Doozer Development Container Support for VSCode
 
 This directory contains the `Dockerfile` and `devcontainer.json` file
 that allows you to develop and debug `doozer` inside a development container
@@ -12,3 +12,44 @@ using Visual Studio Code. See [https://code.visualstudio.com/docs/remote/contain
 4. Click the green icon on the bottom left of the VSCode window or press <kbd>F1</kbd>, then choose `Remote-Containers: Reopen in Container`.
 
 [Remote Development Extension Pack]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack
+
+# Development container use with podman
+
+The same Dockerfile can be used independently to provide a doozer environment container.
+A build with podman may look like:
+
+    podman build --build-arg USERNAME=yours --build-arg USER_UID=1234 \
+                 -f .devcontainer/dev.Dockerfile -t local/doozer .
+
+Then a script similar to the following (you will certainly want your own modifications)
+will run the container, mounting in relevant things from your own user directory to be
+accessible to the same user inside the container.
+
+#!/bin/bash
+
+    USER=yours
+    # location of doozer checkout
+    DOOZER="$HOME/openshift/doozer"
+    CONTAINER="$DOOZER/.devcontainer"
+
+    # make a copy of your kerberos credentials to mount in (if you mount in the original,
+    # the selinux labels are changed and kerberos refuses to update it).
+    cp -a "${KRB5CCNAME#FILE:}"{,_doozer}
+
+    # mounting in your .ssh dir changes selinux labels, preventing sshd from logging
+    # your user in remotely; make a copy and mount that instead if needed.
+    rm -rf $HOME/.ssh_doozer
+    cp -a $HOME/.ssh{,_doozer}
+
+    # you'll likely have to modify uidmap according to your own user's uid range.
+    # for 1234 below of course substitute your own UID.
+    podman run -it --rm \
+        --uidmap 0:10000:1000 --uidmap=1234:0:1 \
+        -v "${KRB5CCNAME#FILE:}_doozer":/tmp/krb5cc_1234:ro,z \
+        -v $DOOZER:/workspaces/doozer:cached,z \
+        -v $HOME/.ssh_doozer:/home/$USER/.ssh:ro,cached,z \
+        -v $HOME/.gitconfig:/home/$USER/.gitconfig:ro,cached,z \
+        -v $CONTAINER/settings.yaml:/home/$USER/.config/doozer/settings.yaml:ro,cached,z \
+        -v $CONTAINER/krb5-redhat.conf:/etc/krb5.conf.d/krb5-redhat.conf:ro,cached,z \
+        -v $CONTAINER/brewkoji.conf:/etc/koji.conf.d/brewkoji.conf:ro,cached,z \
+        local/doozer

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,34 +1,32 @@
 FROM fedora:31
 
+# Trust the Red Hat IT Root CA and set up rcm-tools repo
+RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
+         https://password.corp.redhat.com/RH-IT-Root-CA.crt \
+ && update-ca-trust extract \
+ && curl -o /etc/yum.repos.d/rcm-tools-fedora.repo \
+         https://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-fedora.repo
+
 RUN dnf install -y \
     # runtime dependencies
-    krb5-workstation git rsync koji skopeo podman docker tito \
+    krb5-workstation git tig rsync koji skopeo podman docker tito \
     python2 python2-certifi python2-rpm \
     python3 python3-certifi python3-rpm \
     # development dependencies
     gcc krb5-devel openssl-devel \
-    python2-devel python2-pip \
     python3-devel python3-pip \
     # other tools
-    bash-completion vim tmux procps-ng psmisc wget curl net-tools iproute \
-  # Red Hat IT Root CA
-  && curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
-    https://password.corp.redhat.com/RH-IT-Root-CA.crt \
-  && update-ca-trust extract \
-  # clean up
-  && dnf clean all
+    bash-completion vim tmux procps-ng psmisc wget net-tools iproute \
+    # install rcm-tools
+    koji brewkoji rhpkg \
+ && dnf clean all
 
-# install brewkoji
-RUN wget -O /etc/yum.repos.d/rcm-tools-fedora.repo https://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-fedora.repo \
-  && dnf install -y koji brewkoji \
-  && dnf install -y rhpkg \
-  && dnf clean all
-
-ARG OC_VERSION=4.3.0
 # include oc client
-RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux-"$OC_VERSION".tar.gz \
+ARG OC_VERSION=latest
+RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux.tar.gz \
   && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \
   && rm /tmp/openshift-client-linux-"$OC_VERSION".tar.gz
+
 
 # Create a non-root user - see https://aka.ms/vscode-remote/containers/non-root-user.
 ARG USERNAME=dev
@@ -40,7 +38,8 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid "$USER_GID" "$USERNAME" \
     && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" \
     && mkdir -p /home/"$USERNAME"/.vscode-server /home/"$USERNAME"/.vscode-server-insiders \
-    && chown -R "${USER_UID}:${USER_GID}" /home/"$USERNAME" \
+       /workspaces/doozer /workspaces/doozer-working-dir \
+    && chown -R "${USER_UID}:${USER_GID}" /home/"$USERNAME" /workspaces \
     && chmod 0755 /home/"$USERNAME" \
     && echo "$USERNAME" ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/"$USERNAME" \
     && chmod 0440 /etc/sudoers.d/"$USERNAME"
@@ -49,9 +48,10 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
 COPY .devcontainer/krb5-redhat.conf /etc/krb5.conf.d/
 
 # Preinstall dependencies
-COPY ./requirements.txt ./requirements-dev.txt /tmp/doozer/
-RUN pushd /tmp/doozer \
-  && sudo -u "$USERNAME" pip3 install --user -r ./requirements.txt -r requirements-dev.txt \
-  && popd && rm -rf /tmp/doozer
+COPY ./ /tmp/doozer/
+RUN chown "$USERNAME" -R /tmp/doozer \
+ && pushd /tmp/doozer \
+ && sudo -u "$USERNAME" pip3 install --user -r ./requirements.txt -r requirements-dev.txt ./ \
+ && popd && rm -rf /tmp/doozer
 
 USER "$USER_UID"


### PR DESCRIPTION
This adds notes about using the devcontainer with podman directly.
It also makes the build quite a bit faster as it only has to
download repo metadata once.