### PR TITLE
Move `commitish` field to Metadata class

### DIFF
--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -9,13 +9,12 @@ from doozerlib import assertion, exectools
 class ImageMetadata(Metadata):
 
     def __init__(self, runtime, data_obj: Dict, commitish: Optional[str] = None):
-        super(ImageMetadata, self).__init__('image', runtime, data_obj)
+        super(ImageMetadata, self).__init__('image', runtime, data_obj, commitish)
         self.image_name = self.config.name
         self.required = self.config.get('required', False)
         self.image_name_short = self.image_name.split('/')[-1]
         self.parent = None
         self.children = []
-        self.commitish = commitish
         dependents = self.config.get('dependents', [])
         for d in dependents:
             self.children.append(self.runtime.late_resolve_image(d, add=True))

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from future import standard_library
 standard_library.install_aliases
+from typing import Dict, Optional
 import urllib.parse
 from retry import retry
 import requests
@@ -32,17 +33,19 @@ CONFIG_MODE_DEFAULT = CONFIG_MODES[0]
 
 
 class Metadata(object):
-    def __init__(self, meta_type, runtime, data_obj):
+    def __init__(self, meta_type, runtime, data_obj: Dict, commitish: Optional[str] = None):
         """
         :param: meta_type - a string. Index to the sub-class <'rpm'|'image'>.
         :param: runtime - a Runtime object.
         :param: name - a filename to load as metadata
+        :param: commitish: If not None, build from the specified commit-ish instead of the branch tip.
         """
         self.meta_type = meta_type
         self.runtime = runtime
         self.data_obj = data_obj
         self.config_filename = data_obj.filename
         self.full_config_path = data_obj.path
+        self.commitish = commitish
 
         # Some config filenames have suffixes to avoid name collisions; strip off the suffix to find the real
         # distgit repo name (which must be combined with the distgit namespace).


### PR DESCRIPTION
This is to fix the following issue introduced by https://github.com/openshift/doozer/pull/202

```
ERROR: failed shell command: doozer --datastore prod --cache-dir ...-version v4.5 --release 202006031359
with rc=1 and output:
[...see full archive #3...]
  File "/home/jenkins/.local/lib/python3.6/site-packages/doozerlib/rpmcfg.py", line 61, in __init__
    self.source_path = self.runtime.resolve_source(self)
  File "/home/jenkins/.local/lib/python3.6/site-packages/doozerlib/runtime.py", line 964, in resolve_source
    if meta.commitish:
AttributeError: 'RPMMetadata' object has no attribute 'commitish'
```