### PR TITLE
ART-1879: Implement p0/p1 release convention for private fix builds

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -11,6 +11,8 @@ RUN dnf install -y \
     # runtime dependencies
     krb5-workstation git tig rsync koji skopeo podman docker tito \
     python3 python3-certifi python3-rpm \
+    # provides en_US.UTF-8 locale required by tito
+    glibc-langpack-en \
     # development dependencies
     gcc krb5-devel openssl-devel \
     python3-devel python3-pip \
@@ -26,6 +28,8 @@ RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.open
   && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \
   && rm /tmp/openshift-client-linux-"$OC_VERSION".tar.gz
 
+# change default locale to en_US.UTF-8 - tito requires this
+RUN echo 'LANG="en_US.UTF-8"' > /etc/locale.conf
 
 # Create a non-root user - see https://aka.ms/vscode-remote/containers/non-root-user.
 ARG USERNAME=dev
@@ -54,4 +58,3 @@ RUN chown "$USERNAME" -R /tmp/doozer \
  && popd && rm -rf /tmp/doozer
 
 USER "$USER_UID"
-ENV LANG="en_US.UTF-8"

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -267,10 +267,11 @@ def rpms_clone_sources(runtime, output_yml):
               help="Version string to populate in specfile.", required=True)
 @click.option("--release", metavar='RELEASE', default=None,
               help="Release label to populate in specfile.", required=True)
+@click.option("--embargoed", is_flag=True, help="Add .p1 to the release string for all rpms, which indicates those rpms have embargoed fixes")
 @click.option('--scratch', default=False, is_flag=True, help='Perform a scratch build.')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @pass_runtime
-def rpms_build(runtime, version, release, scratch, dry_run):
+def rpms_build(runtime, version, release, embargoed, scratch, dry_run):
     """
     Attempts to build rpms for all of the defined rpms
     in a group. If an rpm has already been built, it will be treated as
@@ -281,12 +282,20 @@ def rpms_build(runtime, version, release, scratch, dry_run):
         version = version[1:]
 
     runtime.initialize(mode='rpms', clone_distgits=False)
+
+    if runtime.group_config.public_upstreams and (release is None or not release.endswith(".p?")):
+        raise click.BadParameter("You must explicitly specify a `release` ending with `.p?` when there is a public upstream mapping in ocp-build-data.")
+
     runtime.assert_mutation_is_permitted()
 
     items = runtime.rpm_metas()
     if not items:
         runtime.logger.info("No RPMs found. Check the arguments.")
         exit(0)
+
+    if embargoed:
+        for rpm in items:
+            rpm.private_fix = True
 
     results = runtime.parallel_exec(
         lambda rpm, terminate_event: rpm.build_rpm(
@@ -450,6 +459,9 @@ def images_update_dockerfile(runtime, stream, version, release, repo_type, messa
 
     runtime.initialize(validate_content_sets=True, clone_distgits=True)
 
+    if runtime.group_config.public_upstreams and (release is None or release != "+" and not release.endswith(".p?")):
+        raise click.BadParameter("You must explicitly specify a `release` ending with `.p?` (or '+') when there is a public upstream mapping in ocp-build-data.")
+
     # This is ok to run if automation is frozen as long as you are not pushing
     if push:
         runtime.assert_mutation_is_permitted()
@@ -482,7 +494,9 @@ def images_update_dockerfile(runtime, stream, version, release, repo_type, messa
     def dgr_update(image_meta):
         try:
             dgr = image_meta.distgit_repo()
-            (real_version, real_release) = dgr.update_distgit_dir(version, release)
+            _, prev_release, prev_private_fix = dgr.extract_version_release_private_fix()
+            dgr.private_fix = bool(prev_private_fix)  # preserve the .p? field when updating the release
+            (real_version, real_release) = dgr.update_distgit_dir(version, release, prev_release)
             dgr.commit(message)
             dgr.tag(real_version, real_release)
             state.record_image_success(lstate, image_meta)
@@ -557,6 +571,7 @@ def config_scan_source_changes(runtime, as_yaml):
 @click.option("--version", metavar='VERSION', default=None, callback=validate_semver_major_minor_patch,
               help="Version string to populate in Dockerfiles. \"auto\" gets version from atomic-openshift RPM")
 @click.option("--release", metavar='RELEASE', default=None, help="Release string to populate in Dockerfiles.")
+@click.option("--embargoed", is_flag=True, help="Add .p1 to the release string for all images, which indicates those images have embargoed fixes")
 @click.option("--repo-type", metavar="REPO_TYPE", envvar="OIT_IMAGES_REPO_TYPE",
               default="unsigned",
               help="Repo group type to use for version autodetection scan (e.g. signed, unsigned).")
@@ -565,7 +580,7 @@ def config_scan_source_changes(runtime, as_yaml):
 @option_commit_message
 @option_push
 @pass_runtime
-def images_rebase(runtime, stream, version, release, repo_type, message, push, upstreams):
+def images_rebase(runtime, stream, version, release, embargoed, repo_type, message, push, upstreams):
     """
     Many of the Dockerfiles stored in distgit are based off of content managed in GitHub.
     For example, openshift-enterprise-node should always closely reflect the changes
@@ -593,6 +608,9 @@ def images_rebase(runtime, stream, version, release, repo_type, message, push, u
         upstream_overrides[m[1]] = m[2]
 
     runtime.initialize(validate_content_sets=True, upstream_commitish_overrides=upstream_overrides)
+
+    if runtime.group_config.public_upstreams and (release is None or release != "+" and not release.endswith(".p?")):
+        raise click.BadParameter("You must explicitly specify a `release` ending with `.p?` (or '+') when there is a public upstream mapping in ocp-build-data.")
 
     # This is ok to run if automation is frozen as long as you are not pushing
     if push:
@@ -627,6 +645,8 @@ def images_rebase(runtime, stream, version, release, repo_type, message, push, u
     def dgr_rebase(image_meta):
         try:
             dgr = image_meta.distgit_repo()
+            if embargoed:
+                dgr.private_fix = True
             (real_version, real_release) = dgr.rebase_dir(version, release)
             sha = dgr.commit(message, log_diff=True)
             dgr.tag(real_version, real_release)

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -267,7 +267,7 @@ def rpms_clone_sources(runtime, output_yml):
               help="Version string to populate in specfile.", required=True)
 @click.option("--release", metavar='RELEASE', default=None,
               help="Release label to populate in specfile.", required=True)
-@click.option("--embargoed", is_flag=True, help="Add .p1 to the release string for all rpms, which indicates those rpms have embargoed fixes")
+@click.option("--embargoed", default=False, is_flag=True, help="Add .p1 to the release string for all rpms, which indicates those rpms have embargoed fixes")
 @click.option('--scratch', default=False, is_flag=True, help='Perform a scratch build.')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @pass_runtime
@@ -459,7 +459,7 @@ def images_update_dockerfile(runtime, stream, version, release, repo_type, messa
 
     runtime.initialize(validate_content_sets=True, clone_distgits=True)
 
-    if runtime.group_config.public_upstreams and (release is None or release != "+" and not release.endswith(".p?")):
+    if runtime.group_config.public_upstreams and (release is None or (release != "+" and not release.endswith(".p?"))):
         raise click.BadParameter("You must explicitly specify a `release` ending with `.p?` (or '+') when there is a public upstream mapping in ocp-build-data.")
 
     # This is ok to run if automation is frozen as long as you are not pushing

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1448,7 +1448,7 @@ class ImageDistGitRepo(DistGitRepo):
                     if self.runtime.group_config.public_upstreams:
                         raise ValueError("Failed to bump the release: Neither 'release' is specified in the Dockerfile nor we can use OSBS auto-bumping when a public upstream mapping is defined in ocp-build-data.")
                     self.logger.info("No release label found in Dockerfile; bumping unnecessary -- osbs will automatically select unique release value at build time")
-                    release = prev_release
+                    release = None
 
             # If a release is specified, set it. If it is not specified, remove the field.
             # If osbs finds the field, unset, it will choose a value automatically. This is
@@ -1823,7 +1823,7 @@ class ImageDistGitRepo(DistGitRepo):
             out = out.strip()
             self.source_url, _ = self.runtime.get_public_upstream(out)  # Point to public upstream if there are private components to the URL
 
-            # Determine if the source contains private fixes by checking if the private org branch commit exists in the public org
+            # If private_fix has not already been set (e.g. by --embargoed), determine if the source contains private fixes by checking if the private org branch commit exists in the public org
             if self.private_fix is None and self.metadata.public_upstream_branch:
                 self.private_fix = not util.is_commit_in_public_upstream(self.source_full_sha, self.metadata.public_upstream_branch, source_dir)
 

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -441,6 +441,12 @@ class RPMMetadata(Metadata):
                 # to this if we don't push changes back to origin.
                 self.pre_init_sha = exectools.cmd_assert('git rev-parse HEAD')[0].strip()
 
+            if self.public_upstream_branch:
+                if not release.endswith(".p?"):
+                    raise ValueError(f"'release' must end with '.p?' for an image with a public upstream but its actual value is {release}")
+                release = release[:-3]  # strip .p?
+                release += ".p1" if self.private_fix else ".p0"
+
             self.set_nvr(version, release)
             self.tito_setup()
             self.update_spec()


### PR DESCRIPTION
This PR implements the following items:

- When doozer detects that it is building an RPM with a private fix OR rebasing an image distgit with a private fix, it should enforce a release (as in NVR) convention. When a private fix is detected, add .p1 to the release component. When it is not, add .p0.
- When calling doozer images:rebase, the user/pipeline should also be able to specify "--embargoed". This should cause all images being rebased to include a .p1 field.
- doozer images:update-dockerfile should preserve the .p? field when updating the release.
- Also adds "--embargoed" option to `doozer rpms:build`.

Note:
- needs to revert e358ad760faebc66272153db62129e6b699a11f5 before merging this PR.
- Detecting if an image has private RPMs is not covered.
