### PR TITLE
Fix metadata build error "'Runtime' object has no attribute 'candidat…

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -462,6 +462,4 @@ class OLMBundle(object):
 
     @property
     def target(self):
-        if hasattr(self.runtime, 'brew_tag') and self.runtime.candidate_brew_tag is not None:
-            return self.runtime.candidate_brew_tag
-        return '{}-candidate'.format(self.branch)
+        return self.runtime.get_default_candidate_brew_tag() or '{}-candidate'.format(self.branch)

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -790,7 +790,7 @@ class OperatorMetadataLatestNvrReporter(object):
 
     @property
     def brew_tag(self):
-        return self.runtime.candidate_brew_tag if self.runtime.candidate_brew_tag else '{}-candidate'.format(self.operator_branch)
+        return self.runtime.get_default_candidate_brew_tag() or '{}-candidate'.format(self.operator_branch)
 
     @property
     def operator_branch(self):

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1245,7 +1245,7 @@ class Runtime(object):
         return self.branch
 
     def get_default_candidate_brew_tag(self):
-        return self.branch + '-candidate'
+        return self.branch + '-candidate' if self.branch else None
 
     def builds_for_group_branch(self):
         # return a dict of all the latest builds for this group, according to


### PR DESCRIPTION
…e_brew_tag'"

Fix this error when building a operator metadata:

```
  File "/home/jenkins/.local/lib/python3.6/site-packages/doozerlib/operator_metadata.py", line 781, in get_all_builds
    cmd = 'brew list-tagged --quiet {} {}'.format(self.brew_tag, self.metadata_component)
  File "/home/jenkins/.local/lib/python3.6/site-packages/doozerlib/operator_metadata.py", line 793, in brew_tag
    return self.runtime.candidate_brew_tag if self.runtime.candidate_brew_tag else '{}-candidate'.format(self.operator_branch)
AttributeError: 'Runtime' object has no attribute 'candidate_brew_tag'
```

https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fappregistry/6196/console