### PR TITLE
Force user to specify workspace

### DIFF
--- a/doozerlib/config.py
+++ b/doozerlib/config.py
@@ -23,9 +23,6 @@ class MetaDataConfig(object):
     """
     def __init__(self, runtime):
         self.runtime = runtime
-        if self.runtime.remove_tmp_working_dir:
-            print('config:* options require a non-temporary working space. Must run with --working-dir')
-            sys.exit(1)
 
     def update_meta(self, meta, k, v):
         """


### PR DESCRIPTION
A single doozer invocation that uses a /tmp workspace can exhaust memory on buildvm. Let's stay safe and start to require a workspace to be specified. 