### PR TITLE
[ART-1981] distinguish between enabled and shipping repos

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -429,13 +429,16 @@ class ImageDistGitRepo(DistGitRepo):
 
         repos = self.runtime.repos
         enabled_repos = self.config.get('enabled_repos', [])
+        non_shipping_repos = self.config.get('non_shipping_repos', [])
+        shipping_repos = [repo for repo in enabled_repos if repo not in non_shipping_repos]
+
         for t in repos.repotypes:
             with self.dg_path.joinpath('.oit', f'{t}.repo').open('w', encoding="utf-8") as rc:
                 content = repos.repo_file(t, enabled_repos=enabled_repos)
                 rc.write(content)
 
         with self.dg_path.joinpath('content_sets.yml').open('w', encoding="utf-8") as rc:
-            rc.write(repos.content_sets(enabled_repos=enabled_repos))
+            rc.write(repos.content_sets(shipping_repos=shipping_repos))
 
     def _read_master_data(self):
         with Dir(self.distgit_dir):

--- a/doozerlib/repos.py
+++ b/doozerlib/repos.py
@@ -267,7 +267,7 @@ class Repos(object):
 
         return result
 
-    def content_sets(self, enabled_repos=[]):
+    def content_sets(self, shipping_repos=[]):
         """Generates a valid content_sets.yml file based on the currently
         configured and enabled repos in the collection. Using the correct
         name for each arch."""
@@ -276,7 +276,7 @@ class Repos(object):
         for a in self._arches:
             content_sets = []
             for r in self._repos.values():
-                if r.enabled or r.name in enabled_repos:
+                if r.enabled or r.name in shipping_repos:
                     cs = r.content_set(a)
                     if cs:  # possible to be forced off by setting to null
                         content_sets.append(cs)


### PR DESCRIPTION
There are new check that verify that if all the rpms on the images can
be accounted for, and that there are no unused repositories declared to
be enabled.

The repositories that are enabled, are configured through the
`enabled_repos` key in the image definition. Setting a repository here
has two effects:
1. It will be written in `.oit/{un,}signed.repo`, one of which will end
up as `/etc/yum.repos.d/ubi.repo` in the resulting image.
2. A metadata file in distgit, `content_sets.yml`, which is consumed by
TPS tests to verify if all the RPMs are accounted for.

This poses an issue with dependencies for BUILDER images, as the
repository definition file is for all images used during the build
process, and content_set.yml only affects the shipping artifact.

This change allows the following configuration in `images/*.yml`:
```yaml
enabled_repos:
- rhel-server-rpms
- rhel-server-optional-rpms
non_shipping_repos:
- rhel-server-optional-rpms
```

The end result is:
- both repositories are enabled in `/etc/yum.repos.d/`
- `rhel-server-optional-rpms` is _not_ present in `content_set.yml`