### PR TITLE
Allow mirroring of image streams to upstream locations

### DIFF
--- a/doozerlib/exectools.py
+++ b/doozerlib/exectools.py
@@ -67,13 +67,14 @@ def urlopen_assert(url_or_req, httpcode=200, retries=3):
                  wait_f=lambda x: time.sleep(30))
 
 
-def cmd_assert(cmd, retries=1, pollrate=60, on_retry=None, set_env=None, strip=False):
+def cmd_assert(cmd, realtime=False, retries=1, pollrate=60, on_retry=None, set_env=None, strip=False):
     """
     Run a command, logging (using exec_cmd) and raise an exception if the
     return code of the command indicates failure.
     Try the command multiple times if requested.
 
     :param cmd <string|list>: A shell command
+    :param realtime: If True, output stdout and stderr in realtime instead of all at once.
     :param retries int: The number of times to try before declaring failure
     :param pollrate int: how long to sleep between tries
     :param on_retry <string|list>: A shell command to run before retrying a failure
@@ -90,7 +91,7 @@ def cmd_assert(cmd, retries=1, pollrate=60, on_retry=None, set_env=None, strip=F
             if on_retry is not None:
                 cmd_gather(on_retry, set_env)  # no real use for the result though
 
-        result, stdout, stderr = cmd_gather(cmd, set_env)
+        result, stdout, stderr = cmd_gather(cmd, set_env=set_env, realtime=realtime)
         if result == SUCCESS:
             break
 

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -892,6 +892,12 @@ class Runtime(object):
 
         return self.streams[stream_name]
 
+    def get_stream_names(self):
+        """
+        :return: Returns a list of all streams defined in streams.yaml.
+        """
+        return list(self.streams.keys())
+
     def get_public_upstream(self, remote_git: str) -> (str, Optional[str]):
         """
         Some upstream repo are private in order to allow CVE workflows. While we


### PR DESCRIPTION
In an effort to make CI image builds consistent with downstream builds, https://issues.redhat.com/browse/DPTP-1340 is being implemented by DPTP. They will be inspecting ocp-build-data to identify builder & base images within the release payload images and opening PRs upstream when those images fall out of sync.

Why this PR? DPTP tooling can iterate through ocp-build-data images, de-reference image streams, etc. However, that would ultimately lead them to a brew pullspec, which they cannot use directly. Instead, this PR allows ART to do two things:
1. Mirror imagestreams to arbitrary external registries so they can be consumed by CI.
2. By virtue of that process & metadata, allow the DPTP tooling to de-reference imagestreams to an image pullspec they can actually use (streams.yaml:streams.<name>.upstream_image) outside of the firewall.

Example streams.yaml entry which will cause the stream to be mirrored to registry.svc.ci.openshift.org.
```yaml
ruby-25:
  image: openshift/ose-base:rhscl.ruby.25.rhel7
  mirror: true
  upstream_image: registry.svc.ci.openshift.org/ocp/builder:ruby-25
```
