### PR TITLE
Allow extra_packages to be specified in image metadata

### DIFF
--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -257,6 +257,28 @@ class ImageMetadata(Metadata):
             image_nvr = image_build['nvr']
             image_build_event_id = image_build['creation_event_id']  # the brew even that created this build
 
+            # Very rarely, an image might need to pull an package that is not actually installed in the
+            # builder image or in the final image.
+            # e.g. https://github.com/openshift/ironic-ipa-downloader/blob/999c80f17472d5dbbd4775d901e1be026b239652/Dockerfile.ocp#L11-L14
+            # This is programmatically undetectable through koji queries. So we allow extra scan-sources hints to
+            # be placed in the image metadata.
+            if self.config.scan_sources.extra_packages is not Missing:
+                for package_details in self.config.scan_sources.extra_packages:
+                    extra_package_name = package_details.name
+                    extra_package_brew_tag = package_details.tag
+                    # Example output: https://gist.github.com/jupierce/3bbc8be7265348a8f549d401664c9972
+                    extra_latest_tagging_infos = koji_api.tagHistory(package=extra_package_name, tag=extra_package_brew_tag, queryOpts={'limit': 1})
+                    if not extra_latest_tagging_infos:
+                        self.logger.warning(f'Unable to find tagging event for for extra_packages {extra_package_name}')
+                        continue
+                    # Otherwise, we have information about the most recent time this package was tagged into the
+                    # relevant tag. Why the tagging event and not the build time? Well, the build could have been
+                    # made long ago, but only tagged into the relevant tag recently.
+                    extra_latest_tagging_event = extra_latest_tagging_infos[0]['create_event']
+                    self.logger.debug(f'Checking image creation time against extra_packages {extra_package_name} in tag {extra_package_brew_tag} @ tagging event {extra_latest_tagging_event}')
+                    if extra_latest_tagging_event > image_build_event_id:
+                        return True, f'Image {dgk} is sensitive to extra_packages {extra_package_name} which changed at event {extra_latest_tagging_event}'
+
             # Collect build times from any build images
             builders = self.config['from'].builder or []
             for builder in builders:
@@ -465,105 +487,106 @@ def is_image_older_than_rpm(image_meta, image_build_event_id, ri, rpm_entries, c
 
     return False, None
 
-    def covscan(self, result_archive, repo_type='unsigned', local_repo=[]):
-        self.logger.info('Setting up for coverity scan')
-        all_js = 'all_results.js'
-        diff_js = 'diff_results.js'
-        all_html = 'all_results.html'
-        diff_html = 'diff_results.html'
-        waived_flag = 'waived.flag'
 
-        archive_path = pathlib.Path(result_archive)
-        dg_archive_path = archive_path.joinpath(self.distgit_key)
-        dg_archive_path.mkdir(parents=True, exist_ok=True)  # /<archive-dir>/<dg-key>
+def covscan(self, result_archive, repo_type='unsigned', local_repo=[]):
+    self.logger.info('Setting up for coverity scan')
+    all_js = 'all_results.js'
+    diff_js = 'diff_results.js'
+    all_html = 'all_results.html'
+    diff_html = 'diff_results.html'
+    waived_flag = 'waived.flag'
 
-        builders = self.config['from'].builder
-        if builders is Missing:
-            self.logger.info('No builder images -- does not appear to be container first. Skipping.')
+    archive_path = pathlib.Path(result_archive)
+    dg_archive_path = archive_path.joinpath(self.distgit_key)
+    dg_archive_path.mkdir(parents=True, exist_ok=True)  # /<archive-dir>/<dg-key>
+
+    builders = self.config['from'].builder
+    if builders is Missing:
+        self.logger.info('No builder images -- does not appear to be container first. Skipping.')
+        return
+
+    dgr = self.distgit_repo()
+    with Dir(dgr.distgit_dir):
+        dg_commit_hash, _ = exectools.cmd_assert('git rev-parse HEAD', strip=True)
+        archive_commit_results_path = dg_archive_path.joinpath(dg_commit_hash)  # /<archive-dir>/<dg-key>/<hash>
+        archive_all_results_js_path = archive_commit_results_path.joinpath(all_js)  # /<archive-dir>/<dg-key>/<hash>/all_results.js
+        archive_all_results_html_path = archive_commit_results_path.joinpath(all_html)  # /<archive-dir>/<dg-key>/<hash>/all_results.html
+        archive_diff_results_js_path = archive_commit_results_path.joinpath(diff_js)
+        archive_diff_results_html_path = archive_commit_results_path.joinpath(diff_html)
+        archive_waived_flag_path = archive_commit_results_path.joinpath(waived_flag)
+
+        def write_record():
+            diff = json.loads(archive_diff_results_js_path.read_text(encoding='utf-8'))
+            diff_count = len(diff['issues'])
+            if diff_count == 0:
+                self.logger.info('No new issues found during scan')
+                archive_waived_flag_path.write_text('')  # No new differences, mark as waived
+
+            owners = ",".join(self.config.owners or [])
+            self.runtime.add_record('covscan',
+                                    distgit=self.qualified_name,
+                                    distgit_key=self.distgit_key,
+                                    commit_results_path=str(archive_commit_results_path),
+                                    all_results_js_path=str(archive_all_results_js_path),
+                                    all_results_html_path=str(archive_all_results_html_path),
+                                    diff_results_js_path=str(archive_diff_results_js_path),
+                                    diff_results_html_path=str(archive_diff_results_html_path),
+                                    diff_count=str(diff_count),
+                                    waive_path=str(archive_waived_flag_path),
+                                    waived=str(archive_waived_flag_path.exists()).lower(),
+                                    owners=owners,
+                                    image=self.config.name,
+                                    commit_hash=dg_commit_hash)
+
+        if archive_diff_results_html_path.exists():
+            self.logger.info(f'This commit already has scan results ({str(archive_all_results_js_path)}; skipping scan')
+            write_record()
             return
 
-        dgr = self.distgit_repo()
-        with Dir(dgr.distgit_dir):
-            dg_commit_hash, _ = exectools.cmd_assert('git rev-parse HEAD', strip=True)
-            archive_commit_results_path = dg_archive_path.joinpath(dg_commit_hash)  # /<archive-dir>/<dg-key>/<hash>
-            archive_all_results_js_path = archive_commit_results_path.joinpath(all_js)  # /<archive-dir>/<dg-key>/<hash>/all_results.js
-            archive_all_results_html_path = archive_commit_results_path.joinpath(all_html)  # /<archive-dir>/<dg-key>/<hash>/all_results.html
-            archive_diff_results_js_path = archive_commit_results_path.joinpath(diff_js)
-            archive_diff_results_html_path = archive_commit_results_path.joinpath(diff_html)
-            archive_waived_flag_path = archive_commit_results_path.joinpath(waived_flag)
+        archive_commit_results_path.mkdir(parents=True, exist_ok=True)
 
-            def write_record():
-                diff = json.loads(archive_diff_results_js_path.read_text(encoding='utf-8'))
-                diff_count = len(diff['issues'])
-                if diff_count == 0:
-                    self.logger.info('No new issues found during scan')
-                    archive_waived_flag_path.write_text('')  # No new differences, mark as waived
+        dg_path = pathlib.Path(Dir.getcwd())
+        cov_path = dg_path.joinpath('cov')
 
-                owners = ",".join(self.config.owners or [])
-                self.runtime.add_record('covscan',
-                                        distgit=self.qualified_name,
-                                        distgit_key=self.distgit_key,
-                                        commit_results_path=str(archive_commit_results_path),
-                                        all_results_js_path=str(archive_all_results_js_path),
-                                        all_results_html_path=str(archive_all_results_html_path),
-                                        diff_results_js_path=str(archive_diff_results_js_path),
-                                        diff_results_html_path=str(archive_diff_results_html_path),
-                                        diff_count=str(diff_count),
-                                        waive_path=str(archive_waived_flag_path),
-                                        waived=str(archive_waived_flag_path.exists()).lower(),
-                                        owners=owners,
-                                        image=self.config.name,
-                                        commit_hash=dg_commit_hash)
+        dockerfile_path = dg_path.joinpath('Dockerfile')
+        if not dockerfile_path.exists():
+            self.logger.error('Dockerfile does not exist in distgit; not rebased yet?')
+            return
 
-            if archive_diff_results_html_path.exists():
-                self.logger.info(f'This commit already has scan results ({str(archive_all_results_js_path)}; skipping scan')
-                write_record()
-                return
+        dfp = DockerfileParser(str(dockerfile_path))
+        covscan_builder_df_path = dg_path.joinpath('Dockerfile.covscan.builder')
 
-            archive_commit_results_path.mkdir(parents=True, exist_ok=True)
-
-            dg_path = pathlib.Path(Dir.getcwd())
-            cov_path = dg_path.joinpath('cov')
-
-            dockerfile_path = dg_path.joinpath('Dockerfile')
-            if not dockerfile_path.exists():
-                self.logger.error('Dockerfile does not exist in distgit; not rebased yet?')
-                return
-
-            dfp = DockerfileParser(str(dockerfile_path))
-            covscan_builder_df_path = dg_path.joinpath('Dockerfile.covscan.builder')
-
-            with covscan_builder_df_path.open(mode='w+') as df_out:
-                first_parent = dfp.parent_images[0]
-                ns, repo_tag = first_parent.split(
-                    '/')  # e.g. openshift/golang-builder:latest => [openshift, golang-builder:latest]
-                if '@' in repo_tag:
-                    repo, tag = repo_tag.split(
-                        '@')  # e.g. golang-builder@sha256:12345 =>  golang-builder & tag=sha256:12345
-                    tag = '@' + tag
+        with covscan_builder_df_path.open(mode='w+') as df_out:
+            first_parent = dfp.parent_images[0]
+            ns, repo_tag = first_parent.split(
+                '/')  # e.g. openshift/golang-builder:latest => [openshift, golang-builder:latest]
+            if '@' in repo_tag:
+                repo, tag = repo_tag.split(
+                    '@')  # e.g. golang-builder@sha256:12345 =>  golang-builder & tag=sha256:12345
+                tag = '@' + tag
+            else:
+                if ':' in repo_tag:
+                    repo, tag = repo_tag.split(':')  # e.g. golang-builder:latest =>  golang-builder & tag=latest
                 else:
-                    if ':' in repo_tag:
-                        repo, tag = repo_tag.split(':')  # e.g. golang-builder:latest =>  golang-builder & tag=latest
-                    else:
-                        repo = repo_tag
-                        tag = 'latest'
-                    tag = ':' + tag
+                    repo = repo_tag
+                    tag = 'latest'
+                tag = ':' + tag
 
-                first_parent_url = f'registry-proxy.engineering.redhat.com/rh-osbs/{ns}-{repo}{tag}'
+            first_parent_url = f'registry-proxy.engineering.redhat.com/rh-osbs/{ns}-{repo}{tag}'
 
-                # build a local image name we can use.
-                # We will build a local scanner image based on the target distgit's first parent.
-                # It will have coverity tools installed.
-                m = hashlib.md5()
-                m.update(first_parent.encode('utf-8'))
-                local_builder_tag = f'{repo}-{m.hexdigest()}'
+            # build a local image name we can use.
+            # We will build a local scanner image based on the target distgit's first parent.
+            # It will have coverity tools installed.
+            m = hashlib.md5()
+            m.update(first_parent.encode('utf-8'))
+            local_builder_tag = f'{repo}-{m.hexdigest()}'
 
-                vol_mount_arg = ''
-                make_image_repo_files = ''
+            vol_mount_arg = ''
+            make_image_repo_files = ''
 
-                if local_repo:
-                    for idx, lr in enumerate(local_repo):
-                        make_image_repo_files += f"""
+            if local_repo:
+                for idx, lr in enumerate(local_repo):
+                    make_image_repo_files += f"""
 # Create a repo able to pull from the local filesystem and prioritize it for speed.
 RUN echo '[covscan_local_{idx}]' > /etc/yum.repos.d/covscan_local_{idx}.repo
 RUN echo 'baseurl=file:///covscan_local_{idx}' >> /etc/yum.repos.d/covscan_local_{idx}.repo
@@ -573,11 +596,11 @@ RUN echo enabled=1 >> /etc/yum.repos.d/covscan_local_{idx}.repo
 RUN echo enabled_metadata=1 >> /etc/yum.repos.d/covscan_local_{idx}.repo
 RUN echo priority=1 >> /etc/yum.repos.d/covscan_local_{idx}.repo
 """
-                        vol_mount_arg += f' -mount {lr}:/covscan_local_{idx}'
-                else:
-                    make_image_repo_files = 'RUN wget https://cov01.lab.eng.brq.redhat.com/coverity/install/covscan/covscan-rhel-7.repo -O /etc/yum.repos.d/covscan.repo\n'
+                    vol_mount_arg += f' -mount {lr}:/covscan_local_{idx}'
+            else:
+                make_image_repo_files = 'RUN wget https://cov01.lab.eng.brq.redhat.com/coverity/install/covscan/covscan-rhel-7.repo -O /etc/yum.repos.d/covscan.repo\n'
 
-                df_out.write(f'''FROM {first_parent_url}
+            df_out.write(f'''FROM {first_parent_url}
 LABEL DOOZER_COVSCAN_PARENT_IMAGE=true
 LABEL DOOZER_COVSCAN_FIRST_PARENT={local_builder_tag}
 LABEL DOOZER_COVSCAN_GROUP={self.runtime.group_config.name}
@@ -603,123 +626,123 @@ RUN update-ca-trust enable
 RUN yum install -y cov-sa csmock csmock-plugin-coverity csdiff
 ''')
 
-            rc, out, err = exectools.cmd_gather(f'docker image inspect {local_builder_tag}')
+        rc, out, err = exectools.cmd_gather(f'docker image inspect {local_builder_tag}')
+        if rc != 0:
+            rc, _, _ = exectools.cmd_gather(f'imagebuilder {vol_mount_arg} -t {local_builder_tag} -f {str(covscan_builder_df_path)} {str(dg_path)}')
             if rc != 0:
-                rc, _, _ = exectools.cmd_gather(f'imagebuilder {vol_mount_arg} -t {local_builder_tag} -f {str(covscan_builder_df_path)} {str(dg_path)}')
-                if rc != 0:
-                    self.logger.error(f'Unable to create scanner image based on builder image: {first_parent_url}')
-                    # TODO: log this as a record and make sure the pipeline warns artist.
-                    # until covscan can be installed on rhel-8, this is expected for some images.
-                    return
+                self.logger.error(f'Unable to create scanner image based on builder image: {first_parent_url}')
+                # TODO: log this as a record and make sure the pipeline warns artist.
+                # until covscan can be installed on rhel-8, this is expected for some images.
+                return
 
-            # We should now have an image tagged local_builder_tag based on the original image's builder image
-            # but also with covscan tools installed.
+        # We should now have an image tagged local_builder_tag based on the original image's builder image
+        # but also with covscan tools installed.
 
-            covscan_df_path = dg_path.joinpath('Dockerfile.covscan')
+        covscan_df_path = dg_path.joinpath('Dockerfile.covscan')
 
-            runs = ['#!/bin/bash', 'set -o xtrace']
-            setup = []
-            first_from = False
-            for entry in dfp.structure:
-                content = entry['content']
-                instruction = entry['instruction'].upper()
-                if instruction.upper() == 'FROM':
-                    if first_from:
-                        break
-                    first_from = True
-
-                if instruction == 'COPY':
-                    setup.append(content)
-
-                if instruction == 'ENV':
-                    setup.append(content)
-
-                if instruction == 'RUN':
-                    runs.append(content.strip()[4:])
-
-                if instruction == 'WORKDIR':
-                    setup.append(content)  # Pass into setup so things like ADD work as expected
-                    path = content.strip()[7:]
-                    runs.append('mkdir -p ' + path)  # Also pass into RUN so they have the correct working dir
-                    runs.append('cd ' + path)
-
-            run_file = '\n'.join(runs)
-            self.logger.info(f'Constructed run file:\n{run_file}')
-
-            build_script_name = 'doozer_covscan_runit.sh'
-            with dg_path.joinpath(build_script_name).open(mode='w+') as runit:
-                runit.write(run_file)
-
-            with covscan_df_path.open(mode='w+') as df_out:
-                df_out.write(f'FROM {local_builder_tag}\n')
-                df_out.write(f'LABEL DOOZER_COVSCAN_GROUP={self.runtime.group_config.name}\n')
-                df_out.write(f'ADD {build_script_name} /\n')
-                df_out.write(f'RUN chmod +x /{build_script_name}\n')
-                df_out.write('\n'.join(setup) + '\n')
-                df_out.write('ENV PATH=/opt/coverity/bin:${PATH}\n')
-
-            run_tag = f'{local_builder_tag}.{self.image_name_short}'
-            rc, out, err = exectools.cmd_gather(f'docker image inspect {run_tag}')
-            if rc != 0:
-                exectools.cmd_assert(f'imagebuilder -t {run_tag} -f {str(covscan_df_path)} {str(dg_path)}')
-
-            cov_path.mkdir(exist_ok=True)
-            emit_path = cov_path.joinpath('emit')
-            if not emit_path.exists():
-                rc, out, err = exectools.cmd_gather(f'docker run --hostname=covscan --rm -v {str(cov_path)}:/cov:z {run_tag} cov-build --dir=/cov /{build_script_name}')
-                if rc != 0:
-                    self.logger.error('Did not achieve full compilation')
-
-                builg_log_path = cov_path.joinpath('build-log.txt')
-                build_log = builg_log_path.read_text(encoding='utf-8')
-                if '[WARNING] No files were emitted' in build_log:
-                    self.logger.error(f'Build did not emit anything. Check out the build-log.txt: {builg_log_path}')
-                    # TODO: log this as a record and make sure the pipeline warns artitst
-                    return
-
-            else:
-                self.logger.info('covscan emit already exists -- skipping this step')
-
-            def run_docker_cov(cmd):
-                return exectools.cmd_assert(f'docker run --hostname=covscan --rm -v {str(cov_path)}:/cov:z {run_tag} {cmd}')
-
-            summary_path = cov_path.joinpath('output', 'summary.txt')
-            if not summary_path.exists() or 'Time taken by analysis' not in summary_path.read_text(encoding='utf-8'):
-                # This can take an extremely long time and use virtually all CPU
-                run_docker_cov('cov-analyze  --dir=/cov "--wait-for-license" "-co" "ASSERT_SIDE_EFFECT:macro_name_lacks:^assert_(return|se)\\$" "-co" "BAD_FREE:allow_first_field:true" "--include-java" "--fb-max-mem=4096" "--security" "--concurrency" --allow-unmerged-emits')
-            else:
-                self.logger.info('covscan analysis already exists -- skipping this step')
-
-            all_results_js, _ = run_docker_cov('cov-format-errors --json-output-v2 /dev/stdout --dir=/cov')
-            all_results_js_path = cov_path.joinpath(all_js)
-            all_results_js_path.write_text(all_results_js, encoding='utf-8')
-
-            all_results_html, _ = run_docker_cov(f'cshtml /cov/{all_js}')
-            all_results_html_path = cov_path.joinpath(all_html)
-            all_results_html_path.write_text(all_results_html, encoding='utf-8')
-
-            run_docker_cov(f'chown -R {os.getuid()}:{os.getgid()} /cov')  # Otherwise, root will own these files
-
-            # Write out the files to the archive directory as well
-            archive_all_results_js_path.write_text(all_results_js, encoding='utf-8')
-            archive_all_results_html_path.write_text(all_results_html, encoding='utf-8')
-
-            # Now on to computing diffs
-
-            # Search backwards through commit history; try to find a hash for this distgit that has been scanned before
-            diff_results_js = all_results_js  # Unless we find an old has, diff results matches all results
-            commit_log, _ = exectools.cmd_assert("git --no-pager log --pretty='%H' -1000")
-            for old_commit in commit_log.split()[1:]:
-                old_all_results_js_path = dg_archive_path.joinpath(old_commit, all_js)
-                old_are_results_waived_path = dg_archive_path.joinpath(old_commit, waived_flag)
-                # Only compute diff from commit if results were actually waived
-                # This file should be created by the Jenkins / scanning pipeline.
-                if old_are_results_waived_path.exists():
-                    diff_results_js, _ = exectools.cmd_assert(f'csdiff {str(archive_all_results_js_path)} {str(old_all_results_js_path)}')
+        runs = ['#!/bin/bash', 'set -o xtrace']
+        setup = []
+        first_from = False
+        for entry in dfp.structure:
+            content = entry['content']
+            instruction = entry['instruction'].upper()
+            if instruction.upper() == 'FROM':
+                if first_from:
                     break
+                first_from = True
 
-            archive_diff_results_js_path.write_text(diff_results_js, encoding='utf-8')
-            diff_results_html, _ = exectools.cmd_assert(f'cshtml {str(archive_diff_results_js_path)}')
-            archive_diff_results_html_path.write_text(diff_results_html, encoding='utf-8')
+            if instruction == 'COPY':
+                setup.append(content)
 
-            write_record()
+            if instruction == 'ENV':
+                setup.append(content)
+
+            if instruction == 'RUN':
+                runs.append(content.strip()[4:])
+
+            if instruction == 'WORKDIR':
+                setup.append(content)  # Pass into setup so things like ADD work as expected
+                path = content.strip()[7:]
+                runs.append('mkdir -p ' + path)  # Also pass into RUN so they have the correct working dir
+                runs.append('cd ' + path)
+
+        run_file = '\n'.join(runs)
+        self.logger.info(f'Constructed run file:\n{run_file}')
+
+        build_script_name = 'doozer_covscan_runit.sh'
+        with dg_path.joinpath(build_script_name).open(mode='w+') as runit:
+            runit.write(run_file)
+
+        with covscan_df_path.open(mode='w+') as df_out:
+            df_out.write(f'FROM {local_builder_tag}\n')
+            df_out.write(f'LABEL DOOZER_COVSCAN_GROUP={self.runtime.group_config.name}\n')
+            df_out.write(f'ADD {build_script_name} /\n')
+            df_out.write(f'RUN chmod +x /{build_script_name}\n')
+            df_out.write('\n'.join(setup) + '\n')
+            df_out.write('ENV PATH=/opt/coverity/bin:${PATH}\n')
+
+        run_tag = f'{local_builder_tag}.{self.image_name_short}'
+        rc, out, err = exectools.cmd_gather(f'docker image inspect {run_tag}')
+        if rc != 0:
+            exectools.cmd_assert(f'imagebuilder -t {run_tag} -f {str(covscan_df_path)} {str(dg_path)}')
+
+        cov_path.mkdir(exist_ok=True)
+        emit_path = cov_path.joinpath('emit')
+        if not emit_path.exists():
+            rc, out, err = exectools.cmd_gather(f'docker run --hostname=covscan --rm -v {str(cov_path)}:/cov:z {run_tag} cov-build --dir=/cov /{build_script_name}')
+            if rc != 0:
+                self.logger.error('Did not achieve full compilation')
+
+            builg_log_path = cov_path.joinpath('build-log.txt')
+            build_log = builg_log_path.read_text(encoding='utf-8')
+            if '[WARNING] No files were emitted' in build_log:
+                self.logger.error(f'Build did not emit anything. Check out the build-log.txt: {builg_log_path}')
+                # TODO: log this as a record and make sure the pipeline warns artitst
+                return
+
+        else:
+            self.logger.info('covscan emit already exists -- skipping this step')
+
+        def run_docker_cov(cmd):
+            return exectools.cmd_assert(f'docker run --hostname=covscan --rm -v {str(cov_path)}:/cov:z {run_tag} {cmd}')
+
+        summary_path = cov_path.joinpath('output', 'summary.txt')
+        if not summary_path.exists() or 'Time taken by analysis' not in summary_path.read_text(encoding='utf-8'):
+            # This can take an extremely long time and use virtually all CPU
+            run_docker_cov('cov-analyze  --dir=/cov "--wait-for-license" "-co" "ASSERT_SIDE_EFFECT:macro_name_lacks:^assert_(return|se)\\$" "-co" "BAD_FREE:allow_first_field:true" "--include-java" "--fb-max-mem=4096" "--security" "--concurrency" --allow-unmerged-emits')
+        else:
+            self.logger.info('covscan analysis already exists -- skipping this step')
+
+        all_results_js, _ = run_docker_cov('cov-format-errors --json-output-v2 /dev/stdout --dir=/cov')
+        all_results_js_path = cov_path.joinpath(all_js)
+        all_results_js_path.write_text(all_results_js, encoding='utf-8')
+
+        all_results_html, _ = run_docker_cov(f'cshtml /cov/{all_js}')
+        all_results_html_path = cov_path.joinpath(all_html)
+        all_results_html_path.write_text(all_results_html, encoding='utf-8')
+
+        run_docker_cov(f'chown -R {os.getuid()}:{os.getgid()} /cov')  # Otherwise, root will own these files
+
+        # Write out the files to the archive directory as well
+        archive_all_results_js_path.write_text(all_results_js, encoding='utf-8')
+        archive_all_results_html_path.write_text(all_results_html, encoding='utf-8')
+
+        # Now on to computing diffs
+
+        # Search backwards through commit history; try to find a hash for this distgit that has been scanned before
+        diff_results_js = all_results_js  # Unless we find an old has, diff results matches all results
+        commit_log, _ = exectools.cmd_assert("git --no-pager log --pretty='%H' -1000")
+        for old_commit in commit_log.split()[1:]:
+            old_all_results_js_path = dg_archive_path.joinpath(old_commit, all_js)
+            old_are_results_waived_path = dg_archive_path.joinpath(old_commit, waived_flag)
+            # Only compute diff from commit if results were actually waived
+            # This file should be created by the Jenkins / scanning pipeline.
+            if old_are_results_waived_path.exists():
+                diff_results_js, _ = exectools.cmd_assert(f'csdiff {str(archive_all_results_js_path)} {str(old_all_results_js_path)}')
+                break
+
+        archive_diff_results_js_path.write_text(diff_results_js, encoding='utf-8')
+        diff_results_html, _ = exectools.cmd_assert(f'cshtml {str(archive_diff_results_js_path)}')
+        archive_diff_results_html_path.write_text(diff_results_html, encoding='utf-8')
+
+        write_record()


### PR DESCRIPTION
Through [devilish means](https://github.com/openshift/ironic-ipa-downloader/blob/999c80f17472d5dbbd4775d901e1be026b239652/Dockerfile.ocp#L11-L14), upstream Dockerfiles can hide the rpms they are dependent on. This new metadata allows us to check rpm build dates for rpms we could not otherwise determine programmatically. 

Example:
```
scan_sources:
  extra_packages:
  - name: rhosp-director-images
    tag: rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
```

Test run:
```
IMAGES:
  ironic-ipa-downloader is changed (reason: Image ironic-ipa-downloader is sensitive to extra_packages rhosp-director-images which changed at event 33223565)
```
