### PR TITLE
Take nightlies into account to calculate previous

### DIFF
--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -241,7 +241,7 @@ def extract_version_fields(version, at_least=0):
     :param version: A version to parse
     :param at_least: The minimum number of fields to find (else raise an error)
     """
-    fields = [int(f) for f in version.strip().lstrip('v').split('.')]  # v1.17.1 => [ '1', '17', '1' ]
+    fields = [int(f) for f in version.strip().split('-')[0].lstrip('v').split('.')]  # v1.17.1 => [ '1', '17', '1' ]
     if len(fields) < at_least:
         raise IOError(f'Unable to find required {at_least} fields in {version}')
     return fields


### PR DESCRIPTION
We are being asked for the ability to add nightlies to Cincinnati. There are two scenarios:
1. A hotfix (named the same as nightly, added to all channels)
2. A feature candidate (done after feature complete and only in candidate channel)

We need to calc-previous such that customers that have upgraded to a hotfix can migrate off gracefully to any new version.