### PR TITLE
make release:gen-payload command only mirror images with payload images.

### DIFF
--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -77,20 +77,22 @@ that particular tag.
     no_build_items = []
     invalid_name_items = []
 
-    ose_prefixed_images = []
+    payload_images = []
     for image in images:
         # Per clayton:
         """Tim Bielawa: note to self: is only for `ose-` prefixed images
         Clayton Coleman: Yes, Get with the naming system or get out of town
         """
-        if not image.image_name_short.startswith("ose-"):
-            invalid_name_items.append(image.image_name_short)
-            red_print("NOT adding to IS (does not meet name/version conventions): {}".format(image.image_name_short))
-            continue
-        ose_prefixed_images.append(image)
+        if image.is_payload:
+            if not image.image_name_short.startswith("ose-"):
+                invalid_name_items.append(image.image_name_short)
+                red_print("NOT adding to IS (does not meet name/version conventions): {}".format(image.image_name_short))
+                continue
+            else:
+                payload_images.append(image)
 
     runtime.logger.info("Fetching latest image builds from Brew...")
-    tag_component_tuples = [(image.candidate_brew_tag(), image.get_component_name()) for image in ose_prefixed_images]
+    tag_component_tuples = [(image.candidate_brew_tag(), image.get_component_name()) for image in payload_images]
     brew_session = runtime.build_retrying_koji_client()
     latest_builds = brew.get_latest_builds(tag_component_tuples, "image", event_id, brew_session)
     latest_builds = [builds[0] if builds else None for builds in latest_builds]  # flatten the data structure
@@ -113,7 +115,7 @@ that particular tag.
 
     # These will map[arch] -> map[image_name] -> { version: version, release: release, image_src: image_src }
     mirroring = {}
-    for i, image in enumerate(ose_prefixed_images):
+    for i, image in enumerate(payload_images):
         latest_build = latest_builds[i]
         archives = archives_list[i]
         error = None

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -86,6 +86,10 @@ class ImageMetadata(Metadata):
         """
         return self.config.base_only
 
+    @property
+    def is_payload(self):
+        return self.config.get('for_payload', False)
+
     def get_component_name(self, default=-1):
         """
         :param default: Not used. Here to stay consistent with similar rpmcfg.get_component_name


### PR DESCRIPTION
```
[dev@62111d54b562 doozer]$ ./doozer  --group openshift-4.5 release:gen-payload --is-name 4.5-art-latest --organization openshift-release-dev --repository ocp-v4.0-art-dev
2020-08-03 14:45:43,902 INFO Initial execution (cwd) directory: /workspaces/doozer
2020-08-03 14:45:43,903 INFO Data clone directory already exists, checking commit sha
2020-08-03 14:45:43,968 INFO $0: ['git', 'status', '-sb'] - [cwd=/workspaces/doozer-working-dir/ocp-build-data]: Executing:cmd_gather
2020-08-03 14:45:43,982 INFO Time elapsed (hh:mm:ss.ms) 0:00:00.013735 in /workspaces/doozer/doozerlib/exectools.py:158 from /workspaces/doozer/doozerlib/gitdata.py:102:rc, out, err = exectools.cmd_gather("git status -sb") : $0: ['git', 'status', '-sb'] - [cwd=/workspaces/doozer-working-dir/ocp-build-data]: Executed:cmd_gather
2020-08-03 14:45:43,984 INFO $1: ['git', 'rev-parse', '--abbrev-ref', 'HEAD'] - [cwd=/workspaces/doozer-working-dir/ocp-build-data]: Executing:cmd_gather
2020-08-03 14:45:43,992 INFO Time elapsed (hh:mm:ss.ms) 0:00:00.007188 in /workspaces/doozer/doozerlib/exectools.py:158 from /workspaces/doozer/doozerlib/gitdata.py:111:rc, out, err = exectools.cmd_gather("git rev-parse --abbrev-ref HEAD") : $1: ['git', 'rev-parse', '--abbrev-ref', 'HEAD'] - [cwd=/workspaces/doozer-working-dir/ocp-build-data]: Executed:cmd_gather
2020-08-03 14:45:44,003 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-08-03 14:45:44,009 INFO $2: ['git', 'clone', '--no-single-branch', '-b', 'openshift-4.5', '--depth', '1', 'https://github.com/openshift/ocp-build-data.git', '/workspaces/doozer-working-dir/ocp-build-data'] - [cwd=/workspaces/doozer] [env={'GIT_SSH_COMMAND': 'ssh -oBatchMode=yes', 'GIT_TERMINAL_PROMPT': '0'}]: Executing:cmd_gather
2020-08-03 14:48:00,602 INFO Time elapsed (hh:mm:ss.ms) 0:02:16.593120 in /workspaces/doozer/doozerlib/exectools.py:158 from /workspaces/doozer/doozerlib/gitdata.py:146:rc, out, err = exectools.cmd_gather(cmd, set_env=constants.GIT_NO_PROMPTS) : $2: ['git', 'clone', '--no-single-branch', '-b', 'openshift-4.5', '--depth', '1', 'https://github.com/openshift/ocp-build-data.git', '/workspaces/doozer-working-dir/ocp-build-data'] - [cwd=/workspaces/doozer] [env={'GIT_SSH_COMMAND': 'ssh -oBatchMode=yes', 'GIT_TERMINAL_PROMPT': '0'}]: Executed:cmd_gather
2020-08-03 14:48:00,740 INFO Using branch from group.yml: rhaos-4.5-rhel-7
2020-08-03 14:48:01,810 INFO Fetching latest image builds from Brew...
2020-08-03 14:48:17,041 INFO Fetching image archives...
2020-08-03 14:48:31,863 INFO Filtering out shipped builds...
2020-08-03 14:48:31,863 INFO Getting tags for 108 builds...
2020-08-03 14:48:37,287 INFO Fetching rpms in 310 images...
...
2020-08-03 14:50:03,099 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-ipa-downloader@sha256:57a3e5d48e7e658d3d9d6307785ac9022ac2ed4be9c6c951f4ebcf71dd1a652e to the public mirroring list with imagestream tag ironic-ipa-downloader...
2020-08-03 14:50:03,099 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-ipa-downloader@sha256:57a3e5d48e7e658d3d9d6307785ac9022ac2ed4be9c6c951f4ebcf71dd1a652e to the private mirroring list with imagestream tag ironic-ipa-downloader...
2020-08-03 14:50:03,100 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-ipa-downloader@sha256:37e96c0d9c70e5c04f441e92b69280bff84e44f4543003d437e451d7f8902d37 to the public mirroring list with imagestream tag ironic-ipa-downloader...
2020-08-03 14:50:03,100 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-ipa-downloader@sha256:37e96c0d9c70e5c04f441e92b69280bff84e44f4543003d437e451d7f8902d37 to the private mirroring list with imagestream tag ironic-ipa-downloader...
2020-08-03 14:50:03,100 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-node-tuned@sha256:7dfe664413f311f5de08e99852c74d08cb101f0062546f56176c0d864020ef53 to the public mirroring list with imagestream tag cluster-node-tuned...
2020-08-03 14:50:03,100 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-node-tuned@sha256:7dfe664413f311f5de08e99852c74d08cb101f0062546f56176c0d864020ef53 to the private mirroring list with imagestream tag cluster-node-tuned...
2020-08-03 14:50:03,100 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-node-tuned@sha256:559693a425e8bcbd8dde3e2fbed4d2e792c1bcf2e08fdf3892c3d3cad5c72d88 to the public mirroring list with imagestream tag cluster-node-tuned...
2020-08-03 14:50:03,101 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-node-tuned@sha256:559693a425e8bcbd8dde3e2fbed4d2e792c1bcf2e08fdf3892c3d3cad5c72d88 to the private mirroring list with imagestream tag cluster-node-tuned...
2020-08-03 14:50:03,101 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-node-tuned@sha256:a627e36d589e3480fb19d3815ebf3b0b841a01fe69f3500a5062cbec24b8de5d to the public mirroring list with imagestream tag cluster-node-tuned...
2020-08-03 14:50:03,101 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-node-tuned@sha256:a627e36d589e3480fb19d3815ebf3b0b841a01fe69f3500a5062cbec24b8de5d to the private mirroring list with imagestream tag cluster-node-tuned...
2020-08-03 14:50:03,101 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-csi-snapshot-controller@sha256:a0c5db58f724489fd757b39280d0c849ff86fb185b2b28e4a89e86a31c4bd8b8 to the public mirroring list with imagestream tag csi-snapshot-controller...
2020-08-03 14:50:03,101 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-csi-snapshot-controller@sha256:a0c5db58f724489fd757b39280d0c849ff86fb185b2b28e4a89e86a31c4bd8b8 to the private mirroring list with imagestream tag csi-snapshot-controller...
2020-08-03 14:50:03,101 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-csi-snapshot-controller@sha256:8ac0b42a9b832c9a9b63555f4ef0ca3497e570f2a97ba07e667b09250b57f3cc to the public mirroring list with imagestream tag csi-snapshot-controller...
2020-08-03 14:50:03,101 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-csi-snapshot-controller@sha256:8ac0b42a9b832c9a9b63555f4ef0ca3497e570f2a97ba07e667b09250b57f3cc to the private mirroring list with imagestream tag csi-snapshot-controller...
2020-08-03 14:50:03,101 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-csi-snapshot-controller@sha256:5a725a9d03a85e583f62d6a86e91193d25ab7429881bffd04513eb8f32ac30cb to the public mirroring list with imagestream tag csi-snapshot-controller...
2020-08-03 14:50:03,101 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-csi-snapshot-controller@sha256:5a725a9d03a85e583f62d6a86e91193d25ab7429881bffd04513eb8f32ac30cb to the private mirroring list with imagestream tag csi-snapshot-controller...
2020-08-03 14:50:03,101 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-aws-machine-controllers@sha256:b568c3a122debc597137c91ad2a730c90745dcb8d4c3cfbff190429e28a8b595 to the public mirroring list with imagestream tag aws-machine-controllers...
2020-08-03 14:50:03,101 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-aws-machine-controllers@sha256:b568c3a122debc597137c91ad2a730c90745dcb8d4c3cfbff190429e28a8b595 to the private mirroring list with imagestream tag aws-machine-controllers...
2020-08-03 14:50:03,102 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-docker-registry@sha256:6e32cdf6187638f9000620a1b0be7e8c8eecfdac096a3a042694b96f4a5313a2 to the public mirroring list with imagestream tag docker-registry...
2020-08-03 14:50:03,102 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-docker-registry@sha256:6e32cdf6187638f9000620a1b0be7e8c8eecfdac096a3a042694b96f4a5313a2 to the private mirroring list with imagestream tag docker-registry...
2020-08-03 14:50:03,102 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-docker-registry@sha256:01181d31f7fee136b00314d63220d22fc11c38ffb805a6dbb76e36243e858d66 to the public mirroring list with imagestream tag docker-registry...
2020-08-03 14:50:03,102 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-docker-registry@sha256:01181d31f7fee136b00314d63220d22fc11c38ffb805a6dbb76e36243e858d66 to the private mirroring list with imagestream tag docker-registry...
2020-08-03 14:50:03,102 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-docker-registry@sha256:a97254c6c35acaba16f0db20e7c000b62a15bb301a6ddde3ff2bb3552296daec to the public mirroring list with imagestream tag docker-registry...
2020-08-03 14:50:03,102 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-docker-registry@sha256:a97254c6c35acaba16f0db20e7c000b62a15bb301a6ddde3ff2bb3552296daec to the private mirroring list with imagestream tag docker-registry...
2020-08-03 14:50:03,102 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-telemeter@sha256:7995bd95abc4a2e1b92f573cfaf8bc2ecfdda1bf1858a94c098da32b83a4f72a to the public mirroring list with imagestream tag telemeter...
2020-08-03 14:50:03,102 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-telemeter@sha256:7995bd95abc4a2e1b92f573cfaf8bc2ecfdda1bf1858a94c098da32b83a4f72a to the private mirroring list with imagestream tag telemeter...
2020-08-03 14:50:03,102 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-telemeter@sha256:2acbf4cf6a66a1ea5e9c2ed0e2a8b290f967191173f38846d956fe49f37e5857 to the public mirroring list with imagestream tag telemeter...
2020-08-03 14:50:03,102 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-telemeter@sha256:2acbf4cf6a66a1ea5e9c2ed0e2a8b290f967191173f38846d956fe49f37e5857 to the private mirroring list with imagestream tag telemeter...
2020-08-03 14:50:03,102 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-telemeter@sha256:786a5b680940aab3350d2d17381b2a2b40de5c682d5662ab6d96159b495bba65 to the public mirroring list with imagestream tag telemeter...
2020-08-03 14:50:03,103 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-telemeter@sha256:786a5b680940aab3350d2d17381b2a2b40de5c682d5662ab6d96159b495bba65 to the private mirroring list with imagestream tag telemeter...
2020-08-03 14:50:03,103 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-static-ip-manager@sha256:304c0dc99812c8fa76a5671f3b8bf922b618a20680509a664011b0efda74ac50 to the public mirroring list with imagestream tag ironic-static-ip-manager...
2020-08-03 14:50:03,103 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-static-ip-manager@sha256:304c0dc99812c8fa76a5671f3b8bf922b618a20680509a664011b0efda74ac50 to the private mirroring list with imagestream tag ironic-static-ip-manager...
2020-08-03 14:50:03,104 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-static-ip-manager@sha256:8dc32d4ca2942abd784d4488d074219661353e64402aa1f6e193a5cdbaf50e36 to the public mirroring list with imagestream tag ironic-static-ip-manager...
2020-08-03 14:50:03,104 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-static-ip-manager@sha256:8dc32d4ca2942abd784d4488d074219661353e64402aa1f6e193a5cdbaf50e36 to the private mirroring list with imagestream tag ironic-static-ip-manager...
2020-08-03 14:50:03,104 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-apiserver@sha256:4d6169c31a91911e95268a3a82fc265be434dda2dd99bae887fb61e5ddcfc029 to the public mirroring list with imagestream tag openshift-apiserver...
2020-08-03 14:50:03,104 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-apiserver@sha256:4d6169c31a91911e95268a3a82fc265be434dda2dd99bae887fb61e5ddcfc029 to the private mirroring list with imagestream tag openshift-apiserver...
2020-08-03 14:50:03,105 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-apiserver@sha256:b03bc5b87eabfb710b0a71a284903a2135176e82af6490497755cfa0ee0eef71 to the public mirroring list with imagestream tag openshift-apiserver...
2020-08-03 14:50:03,105 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-apiserver@sha256:b03bc5b87eabfb710b0a71a284903a2135176e82af6490497755cfa0ee0eef71 to the private mirroring list with imagestream tag openshift-apiserver...
2020-08-03 14:50:03,105 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-apiserver@sha256:53f19248381c04b15c69502ed195699ec4ddc31a2f45c60ace87bf1ccb2a0a5f to the public mirroring list with imagestream tag openshift-apiserver...
2020-08-03 14:50:03,105 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-apiserver@sha256:53f19248381c04b15c69502ed195699ec4ddc31a2f45c60ace87bf1ccb2a0a5f to the private mirroring list with imagestream tag openshift-apiserver...
2020-08-03 14:50:03,105 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-prometheus-node-exporter@sha256:3105d1b8302758868b69cc3f8a790613f0e0c14688e6c432754c269a93d5d5e8 to the public mirroring list with imagestream tag prometheus-node-exporter...
2020-08-03 14:50:03,105 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-prometheus-node-exporter@sha256:3105d1b8302758868b69cc3f8a790613f0e0c14688e6c432754c269a93d5d5e8 to the private mirroring list with imagestream tag prometheus-node-exporter...
2020-08-03 14:50:03,105 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-prometheus-node-exporter@sha256:d8f8864a8579a0d7578278fc9cb5aa74092d5da3a42b1264e81a3814507d32a3 to the public mirroring list with imagestream tag prometheus-node-exporter...
2020-08-03 14:50:03,105 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-prometheus-node-exporter@sha256:d8f8864a8579a0d7578278fc9cb5aa74092d5da3a42b1264e81a3814507d32a3 to the private mirroring list with imagestream tag prometheus-node-exporter...
2020-08-03 14:50:03,105 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-prometheus-node-exporter@sha256:d2341196cfe11dfb420331adead871e26fbbbc6982183a212b2cb2d6176af183 to the public mirroring list with imagestream tag prometheus-node-exporter...
2020-08-03 14:50:03,105 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-prometheus-node-exporter@sha256:d2341196cfe11dfb420331adead871e26fbbbc6982183a212b2cb2d6176af183 to the private mirroring list with imagestream tag prometheus-node-exporter...
2020-08-03 14:50:03,105 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-kube-rbac-proxy@sha256:519ea4e1e8b8de8ad09c8b38941274e5e70af2d178b5754144b37a403b23cd2d to the public mirroring list with imagestream tag kube-rbac-proxy...
2020-08-03 14:50:03,106 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-kube-rbac-proxy@sha256:519ea4e1e8b8de8ad09c8b38941274e5e70af2d178b5754144b37a403b23cd2d to the private mirroring list with imagestream tag kube-rbac-proxy...
2020-08-03 14:50:03,106 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-kube-rbac-proxy@sha256:f24d19b9b881e54d652e7d4d36e7355f849a80ce085db8f8077d5f71d06da3c1 to the public mirroring list with imagestream tag kube-rbac-proxy...
2020-08-03 14:50:03,106 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-kube-rbac-proxy@sha256:f24d19b9b881e54d652e7d4d36e7355f849a80ce085db8f8077d5f71d06da3c1 to the private mirroring list with imagestream tag kube-rbac-proxy...
2020-08-03 14:50:03,106 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-kube-rbac-proxy@sha256:20f28e8d02298040c61546f3af59a15d0d9329906f0685edcd73a8576085632b to the public mirroring list with imagestream tag kube-rbac-proxy...
2020-08-03 14:50:03,106 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-kube-rbac-proxy@sha256:20f28e8d02298040c61546f3af59a15d0d9329906f0685edcd73a8576085632b to the private mirroring list with imagestream tag kube-rbac-proxy...
2020-08-03 14:50:03,106 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-machine-api-operator@sha256:48de721d2bf64514a7732493857d4566d542ed07a02622fde833987ad270c7d2 to the public mirroring list with imagestream tag machine-api-operator...
2020-08-03 14:50:03,106 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-machine-api-operator@sha256:48de721d2bf64514a7732493857d4566d542ed07a02622fde833987ad270c7d2 to the private mirroring list with imagestream tag machine-api-operator...
2020-08-03 14:50:03,106 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-machine-api-operator@sha256:eb1fc5afed7f1536a1645ac91bb33fc72989a8ebc66ddd418f1ba203103cd779 to the public mirroring list with imagestream tag machine-api-operator...
2020-08-03 14:50:03,106 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-machine-api-operator@sha256:eb1fc5afed7f1536a1645ac91bb33fc72989a8ebc66ddd418f1ba203103cd779 to the private mirroring list with imagestream tag machine-api-operator...
2020-08-03 14:50:03,106 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-machine-api-operator@sha256:cdb6197e6a55c9be317cdd057fd8ec7df469967421b6338b6ddac23b942a5a71 to the public mirroring list with imagestream tag machine-api-operator...
2020-08-03 14:50:03,106 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-machine-api-operator@sha256:cdb6197e6a55c9be317cdd057fd8ec7df469967421b6338b6ddac23b942a5a71 to the private mirroring list with imagestream tag machine-api-operator...
2020-08-03 14:50:03,106 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-kube-scheduler-operator@sha256:87bd226f209458b84ead56dcdde77f8a1e65b803b0e6f0d8b1fe4642b7061997 to the public mirroring list with imagestream tag cluster-kube-scheduler-operator...
2020-08-03 14:50:03,107 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-kube-scheduler-operator@sha256:87bd226f209458b84ead56dcdde77f8a1e65b803b0e6f0d8b1fe4642b7061997 to the private mirroring list with imagestream tag cluster-kube-scheduler-operator...
2020-08-03 14:50:03,107 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-kube-scheduler-operator@sha256:5f5337d44384491b0ac2507074c0f466b80f8cb97ad579d37297e4fa4e5ec058 to the public mirroring list with imagestream tag cluster-kube-scheduler-operator...
2020-08-03 14:50:03,107 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-kube-scheduler-operator@sha256:5f5337d44384491b0ac2507074c0f466b80f8cb97ad579d37297e4fa4e5ec058 to the private mirroring list with imagestream tag cluster-kube-scheduler-operator...
2020-08-03 14:50:03,107 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-kube-scheduler-operator@sha256:010253167b1e4afaca1411d71d40613ed2deea524dfaa89371650f314d9e8806 to the public mirroring list with imagestream tag cluster-kube-scheduler-operator...
2020-08-03 14:50:03,107 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-kube-scheduler-operator@sha256:010253167b1e4afaca1411d71d40613ed2deea524dfaa89371650f314d9e8806 to the private mirroring list with imagestream tag cluster-kube-scheduler-operator...
2020-08-03 14:50:03,107 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry@sha256:a44d196f28210286d7102f89a4cd82dd9bdb3a954e613964930dee9d5961d7ce to the public mirroring list with imagestream tag operator-registry...
2020-08-03 14:50:03,107 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry@sha256:a44d196f28210286d7102f89a4cd82dd9bdb3a954e613964930dee9d5961d7ce to the private mirroring list with imagestream tag operator-registry...
2020-08-03 14:50:03,107 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry@sha256:9cfaa8f6c3c8bc128500eeb5e44dfc31bd6e387bb1793daddd9f7f0cdcc1626c to the public mirroring list with imagestream tag operator-registry...
2020-08-03 14:50:03,107 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry@sha256:9cfaa8f6c3c8bc128500eeb5e44dfc31bd6e387bb1793daddd9f7f0cdcc1626c to the private mirroring list with imagestream tag operator-registry...
2020-08-03 14:50:03,108 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry@sha256:c0fed2fa9bd38b15f5962e4fac1e2972ffefa36bd206646bb29863517393b806 to the public mirroring list with imagestream tag operator-registry...
2020-08-03 14:50:03,108 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry@sha256:c0fed2fa9bd38b15f5962e4fac1e2972ffefa36bd206646bb29863517393b806 to the private mirroring list with imagestream tag operator-registry...
2020-08-03 14:50:03,108 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-openshift-apiserver-operator@sha256:fd42755aa0a45e7e8c9bbe4b849b73b6e4bf009ee309c62acfdb3a5bf113f975 to the public mirroring list with imagestream tag cluster-openshift-apiserver-operator...
2020-08-03 14:50:03,108 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-openshift-apiserver-operator@sha256:fd42755aa0a45e7e8c9bbe4b849b73b6e4bf009ee309c62acfdb3a5bf113f975 to the private mirroring list with imagestream tag cluster-openshift-apiserver-operator...
2020-08-03 14:50:03,108 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-openshift-apiserver-operator@sha256:b3bffe0b34c237dc5fa9697fbe53553ec6727277181f094ed821ee8e32e04933 to the public mirroring list with imagestream tag cluster-openshift-apiserver-operator...
2020-08-03 14:50:03,108 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-openshift-apiserver-operator@sha256:b3bffe0b34c237dc5fa9697fbe53553ec6727277181f094ed821ee8e32e04933 to the private mirroring list with imagestream tag cluster-openshift-apiserver-operator...
2020-08-03 14:50:03,109 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-openshift-apiserver-operator@sha256:785fd3bc3e9892abbef29d65c0ba36bb6241d4cefecb993dd0bd014d5b3df84d to the public mirroring list with imagestream tag cluster-openshift-apiserver-operator...
2020-08-03 14:50:03,109 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-openshift-apiserver-operator@sha256:785fd3bc3e9892abbef29d65c0ba36bb6241d4cefecb993dd0bd014d5b3df84d to the private mirroring list with imagestream tag cluster-openshift-apiserver-operator...
2020-08-03 14:50:03,109 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-service-ca-operator@sha256:e4d1e194ed36bcd2cf76498e107bac3d3de14a598d276df845311c02b196548c to the public mirroring list with imagestream tag service-ca-operator...
2020-08-03 14:50:03,109 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-service-ca-operator@sha256:e4d1e194ed36bcd2cf76498e107bac3d3de14a598d276df845311c02b196548c to the private mirroring list with imagestream tag service-ca-operator...
2020-08-03 14:50:03,109 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-service-ca-operator@sha256:20a1318672d423d8045365e348ee5432694c88de328fcf378262b30a6d41c8cb to the public mirroring list with imagestream tag service-ca-operator...
2020-08-03 14:50:03,109 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-service-ca-operator@sha256:20a1318672d423d8045365e348ee5432694c88de328fcf378262b30a6d41c8cb to the private mirroring list with imagestream tag service-ca-operator...
2020-08-03 14:50:03,110 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-service-ca-operator@sha256:d908715bc7102d256dc4c00bb99db860d57c85a2c6a61928ded208b2fb63a00b to the public mirroring list with imagestream tag service-ca-operator...
2020-08-03 14:50:03,110 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-service-ca-operator@sha256:d908715bc7102d256dc4c00bb99db860d57c85a2c6a61928ded208b2fb63a00b to the private mirroring list with imagestream tag service-ca-operator...
2020-08-03 14:50:03,110 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-oauth-server@sha256:92e7da82c2a8122e7e23bf51f8fea2336c6f3f1a17fa7d2b0630b56a259e10ae to the public mirroring list with imagestream tag oauth-server...
2020-08-03 14:50:03,110 INFO Adding ppc64le image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-oauth-server@sha256:92e7da82c2a8122e7e23bf51f8fea2336c6f3f1a17fa7d2b0630b56a259e10ae to the private mirroring list with imagestream tag oauth-server...
2020-08-03 14:50:03,110 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-oauth-server@sha256:fe9bf0cd53c5c42b9375c40070b7ddfed5f2f5d6ff88647ffd981c5c1876826f to the public mirroring list with imagestream tag oauth-server...
2020-08-03 14:50:03,110 INFO Adding s390x image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-oauth-server@sha256:fe9bf0cd53c5c42b9375c40070b7ddfed5f2f5d6ff88647ffd981c5c1876826f to the private mirroring list with imagestream tag oauth-server...
2020-08-03 14:50:03,110 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-oauth-server@sha256:20a46944325a5c294283bd6e04830323949d3a65affff7fcd6a74cfe016d9bef to the public mirroring list with imagestream tag oauth-server...
2020-08-03 14:50:03,110 INFO Adding x86_64 image registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-oauth-server@sha256:20a46944325a5c294283bd6e04830323949d3a65affff7fcd6a74cfe016d9bef to the private mirroring list with imagestream tag oauth-server...
Unable to find tag azure-machine-controllers for arch ppc64le ; substituting cli image
Unable to find tag aws-machine-controllers for arch ppc64le ; substituting cli image
Unable to find tag azure-machine-controllers for arch ppc64le ; substituting cli image
Unable to find tag aws-machine-controllers for arch ppc64le ; substituting cli image
Unable to find tag ironic-ipa-downloader for arch s390x ; substituting cli image
Unable to find tag ironic-inspector for arch s390x ; substituting cli image
Unable to find tag kuryr-controller for arch s390x ; substituting cli image
Unable to find tag kuryr-cni for arch s390x ; substituting cli image
Unable to find tag azure-machine-controllers for arch s390x ; substituting cli image
Unable to find tag ironic-static-ip-manager for arch s390x ; substituting cli image
Unable to find tag ironic-machine-os-downloader for arch s390x ; substituting cli image
Unable to find tag ironic for arch s390x ; substituting cli image
Unable to find tag aws-machine-controllers for arch s390x ; substituting cli image
Unable to find tag keepalived-ipfailover for arch s390x ; substituting cli image
Unable to find tag ironic-hardware-inventory-recorder for arch s390x ; substituting cli image
Unable to find tag gcp-machine-controllers for arch s390x ; substituting cli image
Unable to find tag ironic-ipa-downloader for arch s390x ; substituting cli image
Unable to find tag ironic-inspector for arch s390x ; substituting cli image
Unable to find tag kuryr-controller for arch s390x ; substituting cli image
Unable to find tag kuryr-cni for arch s390x ; substituting cli image
Unable to find tag azure-machine-controllers for arch s390x ; substituting cli image
Unable to find tag ironic-static-ip-manager for arch s390x ; substituting cli image
Unable to find tag ironic-machine-os-downloader for arch s390x ; substituting cli image
Unable to find tag ironic for arch s390x ; substituting cli image
Unable to find tag aws-machine-controllers for arch s390x ; substituting cli image
Unable to find tag keepalived-ipfailover for arch s390x ; substituting cli image
Unable to find tag ironic-hardware-inventory-recorder for arch s390x ; substituting cli image
Unable to find tag gcp-machine-controllers for arch s390x ; substituting cli image
```