### PR TITLE
[ART-2094] add --registry-config global options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ cover
 
 # Ignore .vscode local config files
 .vscode
+
+# Ignore ocp-build-dat
+ocp-build-data/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cover
 
 # Ignore idea backup files
 .idea
+
+# Ignore .vscode local config files
+.vscode

--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -40,6 +40,8 @@ def print_version(ctx, param, value):
               help="Git repo or directory containing groups metadata")
 @click.option("--working-dir", metavar='PATH', default=None,
               help="Existing directory in which file operations should be performed.\n Env var: DOOZER_WORKING_DIR")
+@click.option("--registry-config", metavar='PATH', default=None,
+              help="Existing directory of DOCKER_CONFIG path, If not, when DOCKER_CONFIG env var is set, If not, the default `~/.docker/config.json` is used.\n Env var: DOCKER_CONFIG")
 @click.option("--user", metavar='USERNAME', default=None,
               help="Username for rhpkg. Env var: DOOZER_USER")
 @click.option("-g", "--group", default=None, metavar='NAME',

--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -40,8 +40,8 @@ def print_version(ctx, param, value):
               help="Git repo or directory containing groups metadata")
 @click.option("--working-dir", metavar='PATH', default=None,
               help="Existing directory in which file operations should be performed.\n Env var: DOOZER_WORKING_DIR")
-@click.option("--registry-config", metavar='PATH', default=None,
-              help="Existing directory of DOCKER_CONFIG path, If not, when DOCKER_CONFIG env var is set, If not, the default `~/.docker/config.json` is used.\n Env var: DOCKER_CONFIG")
+@click.option("--registry-config-dir", metavar='PATH', default=None,
+              help="Directory containing docker config.json authentication; defaults to DOCKER_CONFIG env var if set, or `~/.docker/` if not.\n Env var: DOCKER_CONFIG")
 @click.option("--user", metavar='USERNAME', default=None,
               help="Username for rhpkg. Env var: DOOZER_USER")
 @click.option("-g", "--group", default=None, metavar='NAME',

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1125,7 +1125,13 @@ def images_mirror_streams(runtime, streams, dry_run):
             brew_image = config.image
             brew_pullspec = runtime.resolve_brew_image_url(brew_image)
             cmd = f'oc image mirror {brew_pullspec} {upstream_dest}'
+            registry_config_file = ''
             if runtime.registry_config is not None:
+                for f in os.listdir(runtime.registry_config):
+                    if f.endswith(".json"):
+                        registry_config_file = os.path.join(runtime.registry_config, f)
+                if registry_config_file == '':
+                    raise FileNotFoundError("Can not find the registry config file in {}".format(runtime.registry_config))
                 cmd += " --registry-config={}".format(runtime.registry_config)
             if dry_run:
                 print(f'Would have run: {cmd}')

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -184,7 +184,6 @@ def rpms_build(runtime, version, release, embargoed, scratch, dry_run):
 @pass_runtime
 def images_list(runtime):
     runtime.initialize(clone_distgits=False)
-
     click.echo("------------------------------------------")
     for image in runtime.image_metas():
         click.echo(image.qualified_name)
@@ -1126,6 +1125,8 @@ def images_mirror_streams(runtime, streams, dry_run):
             brew_image = config.image
             brew_pullspec = runtime.resolve_brew_image_url(brew_image)
             cmd = f'oc image mirror {brew_pullspec} {upstream_dest}'
+            if runtime.registry_config is not None:
+                cmd += " --registry-config={}".format(runtime.registry_config)
             if dry_run:
                 print(f'Would have run: {cmd}')
             else:
@@ -1240,7 +1241,7 @@ def images_build_image(runtime, repo_type, repo, push_to_defaults, push_to, scra
     results = runtime.parallel_exec(
         lambda dgr, terminate_event: dgr.build_container(
             active_profile, push_to_defaults, additional_registries=push_to,
-            terminate_event=terminate_event, scratch=scratch, realtime=(threads == 1), dry_run=dry_run),
+            terminate_event=terminate_event, scratch=scratch, realtime=(threads == 1), dry_run=dry_run, registry_config=runtime.registry_config),
         items, n_threads=threads)
     results = results.get()
 
@@ -1261,7 +1262,7 @@ def images_build_image(runtime, repo_type, repo, push_to_defaults, push_to, scra
 
     # Push all late images
     for image in runtime.image_metas():
-        image.distgit_repo().push_image([], push_to_defaults, additional_registries=push_to, push_late=True)
+        image.distgit_repo().push_image([], push_to_defaults, additional_registries=push_to, push_late=True, registry_config=runtime.registry_config)
 
     state.record_image_finish(lstate)
 
@@ -1356,7 +1357,7 @@ def images_push(runtime, tag, version_release, to_defaults, late_only, to, dry_r
         results = runtime.parallel_exec(
             lambda img, terminate_event:
                 img.distgit_repo().push_image(tag, to_defaults, additional_registries,
-                                              version_release_tuple=version_release_tuple, dry_run=dry_run),
+                                              version_release_tuple=version_release_tuple, dry_run=dry_run, registry_config=runtime.registry_config),
             items,
             n_threads=4
         )
@@ -1373,7 +1374,7 @@ def images_push(runtime, tag, version_release, to_defaults, late_only, to, dry_r
         if image.config.push.late is True:
             image.distgit_repo().push_image(tag, to_defaults, additional_registries,
                                             version_release_tuple=version_release_tuple,
-                                            push_late=True, dry_run=dry_run)
+                                            push_late=True, dry_run=dry_run, registry_config=runtime.registry_config)
 
     state.record_image_finish(lstate)
 

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1130,6 +1130,7 @@ def images_mirror_streams(runtime, streams, dry_run):
                 for f in os.listdir(runtime.registry_config):
                     if f.endswith(".json"):
                         registry_config_file = os.path.join(runtime.registry_config, f)
+                        break
                 if registry_config_file == '':
                     raise FileNotFoundError("Can not find the registry config file in {}".format(runtime.registry_config))
                 cmd += " --registry-config={}".format(runtime.registry_config)

--- a/doozerlib/cli/cli_opts.py
+++ b/doozerlib/cli/cli_opts.py
@@ -44,6 +44,10 @@ CLI_OPTS = {
         'env': 'DOOZER_RHPKG_CONFIG',
         'help': 'Config file path for rhpkg calls'
     },
+    'registry_config': {
+        'env': 'DOCKER_CONFIG',
+        'help': 'Config path for the image registry'
+    }
 }
 
 

--- a/doozerlib/cli/cli_opts.py
+++ b/doozerlib/cli/cli_opts.py
@@ -44,9 +44,9 @@ CLI_OPTS = {
         'env': 'DOOZER_RHPKG_CONFIG',
         'help': 'Config file path for rhpkg calls'
     },
-    'registry_config': {
+    'registry_config_dir': {
         'env': 'DOCKER_CONFIG',
-        'help': 'Config path for the image registry'
+        'help': 'Config directory for the image registry'
     }
 }
 

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -593,6 +593,7 @@ class ImageDistGitRepo(DistGitRepo):
                         for f in os.listdir(registry_config):
                             if f.endswith(".json"):
                                 registry_config_file = os.path.join(registry_config, f)
+                                break
                         if registry_config_file == '':
                             raise FileNotFoundError("Can not find the registry config file in {}".format(registry_config))
                         mirror_cmd += " --registry-config={}".format(registry_config)

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -496,6 +496,12 @@ class ImageDistGitRepo(DistGitRepo):
         if not push_names:
             return (self.metadata.distgit_key, True)
 
+        # get registry_config_json file must before with Dir(self.distgit_dir)
+        # so that relative path or env like DOCKER_CONFIG will not pointed to distgit dir.
+        registry_config_file = ''
+        if registry_config_dir is not None:
+            registry_config_file = util.get_docker_config_json(registry_config_dir)
+
         with Dir(self.distgit_dir):
 
             if version_release_tuple:
@@ -588,8 +594,8 @@ class ImageDistGitRepo(DistGitRepo):
                     if filter_by_os is not None:
                         mirror_cmd += "--filter-by-os={}".format(filter_by_os)
                     mirror_cmd += " {} {} --filename={}".format(dr, insecure, push_config)
-                    if registry_config_dir is not None:
-                        mirror_cmd += f" --registry-config={util.get_docker_config_json(registry_config_dir)}"
+                    if registry_config_file != '':
+                        mirror_cmd += f" --registry-config={registry_config_file}"
 
                     if dry_run:  # skip everything else if dry run
                         continue

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -585,7 +585,13 @@ class ImageDistGitRepo(DistGitRepo):
                     with io.open(push_config, 'w', encoding="utf-8") as pc:
                         pc.write('\n'.join(all_push_urls))
                     mirror_cmd = 'oc image mirror --filter-by-os=amd64 {} {} --filename={}'.format(dr, insecure, push_config)
+                    registry_config_file = ''
                     if registry_config is not None:
+                        for f in os.listdir(registry_config):
+                            if f.endswith(".json"):
+                                registry_config_file = os.path.join(registry_config, f)
+                        if registry_config_file == '':
+                            raise FileNotFoundError("Can not find the registry config file in {}".format(registry_config))
                         mirror_cmd += " --registry-config={}".format(registry_config)
 
                     if dry_run:  # skip everything else if dry run

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -269,7 +269,7 @@ def get_cincinnati_channels(major, minor):
 
 
 def get_docker_config_json(config_dir):
-    flist = os.listdir(config_dir)
+    flist = os.listdir(abspath(config_dir))
     if 'config.json' in flist:
         return abspath(os.path.join(config_dir, 'config.json'))
     else:

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -4,6 +4,7 @@ import copy
 import os
 import errno
 import re
+from os.path import abspath
 from typing import Dict
 from datetime import datetime
 from contextlib import contextmanager
@@ -265,6 +266,14 @@ def get_cincinnati_channels(major, minor):
         prefixes = ['prerelease', 'stable']
 
     return [f'{prefix}-{major}.{minor}' for prefix in prefixes]
+
+
+def get_docker_config_json(config_dir):
+    flist = os.listdir(config_dir)
+    if 'config.json' in flist:
+        return abspath(os.path.join(config_dir, 'config.json'))
+    else:
+        raise FileNotFoundError("Can not find the registry config file in {}".format(config_dir))
 
 
 # Allows you to wrap an object such that you can pass it to lru_cache

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -526,7 +526,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
         expected = ("my-distgit-key", True)
         actual = repo.push_image(tag_list,
                                  push_to_defaults,
-                                 version_release_tuple=("version", "release"))
+                                 version_release_tuple=("version", "release"), filter_by_os='amd64')
         self.assertEqual(expected, actual)
 
 

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -542,7 +542,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  readlines=lambda *_: [])))
         flexmock(distgit.util).should_receive("get_docker_config_json").and_return('/auth/config.json')
 
-        expected_cmd = "oc image mirror --registry_config /auth/config.json  --insecure=true --filename=some-workdir/push/my-distgit-key"
+        expected_cmd = "oc image mirror   --insecure=true --filename=some-workdir/push/my-distgit-key --registry-config=/auth/config.json"
 
         (flexmock(distgit.exectools)
             .should_receive("cmd_gather")

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -540,9 +540,9 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
             .should_receive("open")
             .and_return(flexmock(write=lambda *_: None,
                                  readlines=lambda *_: [])))
-        flexmock(distgit.util.get_docker_config_json).should_receive("/auth").and_return('/auth/config.json')
+        flexmock(distgit.util).should_receive("get_docker_config_json").and_return('/auth/config.json')
 
-        expected_cmd = "oc image mirror --registry_config /auth  --insecure=true --filename=some-workdir/push/my-distgit-key"
+        expected_cmd = "oc image mirror --registry_config /auth/config.json  --insecure=true --filename=some-workdir/push/my-distgit-key"
 
         (flexmock(distgit.exectools)
             .should_receive("cmd_gather")

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -529,6 +529,52 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  version_release_tuple=("version", "release"), filter_by_os='amd64')
         self.assertEqual(expected, actual)
 
+    def test_push_image_registry_config(self):
+        # preventing tests from interacting with the real filesystem
+        flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
+        flexmock(distgit.os).should_receive("mkdir").replace_with(lambda _: None)
+        flexmock(distgit.os.path).should_receive("isdir").and_return(True)
+        flexmock(distgit.os.path).should_receive("isfile").and_return(True)
+        flexmock(distgit.os).should_receive("remove").replace_with(lambda _: None)
+        (flexmock(io)
+            .should_receive("open")
+            .and_return(flexmock(write=lambda *_: None,
+                                 readlines=lambda *_: [])))
+        flexmock(distgit.util.get_docker_config_json).should_receive("/auth").and_return('/auth/config.json')
+
+        expected_cmd = "oc image mirror --registry_config /auth  --insecure=true --filename=some-workdir/push/my-distgit-key"
+
+        (flexmock(distgit.exectools)
+            .should_receive("cmd_gather")
+            .with_args(expected_cmd)
+            .once()
+            .and_return((0, "", "")))
+
+        metadata = flexmock(config=flexmock(push=flexmock(late=distgit.Missing),
+                                            name="my-name",
+                                            namespace="my-namespace",
+                                            distgit=flexmock(branch="_irrelevant_")),
+                            runtime=self.mock_runtime(),
+                            distgit_key="my-distgit-key",
+                            name="my-name",
+                            get_default_push_names=lambda *_: ["my-default-name"],
+                            get_additional_push_names=lambda *_: [],
+                            logger=flexmock(info=lambda *_: None),
+                            namespace="_irrelevant_")
+
+        metadata.runtime.working_dir = "some-workdir"
+        metadata.runtime.group_config.insecure_source = True
+
+        repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
+        tag_list = ["tag-a", "tag-b"]
+        push_to_defaults = True
+
+        expected = ("my-distgit-key", True)
+        actual = repo.push_image(tag_list,
+                                 push_to_defaults,
+                                 version_release_tuple=("version", "release"), registry_config_dir='/auth')
+        self.assertEqual(expected, actual)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
```
-sh-4.2$ ./doozer --registry-config=/home/nay/shiywang/doozer/test.json/config.json --data-path ./ocp-build-data --group openshift-4.5 -i openshift-enterprise-tests --profile unsigned images:build --push-to-defaults --dry-run
/home/nay/shiywang/doozer/test.json/config.json
2020-08-05 14:01:43,224 INFO Initial execution (cwd) directory: /home/nay/shiywang/doozer
2020-08-05 14:01:43,316 INFO Using branch from group.yml: rhaos-4.5-rhel-7
2020-08-05 14:01:43,948 INFO [containers/openshift-enterprise-tests] Distgit directory already exists; skipping clone: /home/nay/shiywang/distgits/containers/openshift-enterprise-tests
2020-08-05 14:01:43,969 INFO Time elapsed (hh:mm:ss.ms) 0:00:00.026261 in /home/nay/shiywang/doozer/doozerlib/runtime.py:1239 from /home/nay/shiywang/doozer/doozerlib/runtime.py:531:self.clone_distgits() : Full runtime clone
/home/nay/shiywang/doozer/test.json/config.json
2020-08-05 14:01:43,971 INFO [containers/openshift-enterprise-tests] Skipping image build since it is not included: ose-tools
2020-08-05 14:01:43,971 INFO [containers/openshift-enterprise-tests] Building image: openshift/ose-tests:v4.6.0-202008031049.p0
2020-08-05 14:01:43,973 WARNING [containers/openshift-enterprise-tests] [Dry Run] Would have run command rhpkg --path=/home/nay/shiywang/distgits/containers/openshift-enterprise-tests container-build --nowait --repo-url http://pkgs.devel.redhat.com/cgit/containers/openshift-enterprise-tests/plain/.oit/unsigned.repo?h=rhaos-4.5-rhel-7
2020-08-05 14:01:43,973 INFO [containers/openshift-enterprise-tests] [Dry Run] Successfully built image: openshift/ose-tests:v4.6.0-202008031049.p0
2020-08-05 14:01:44,094 INFO [containers/openshift-enterprise-tests] Adding 'quay.io/openshift-qe-optional-operator/ose-tests:v4.5.0-202007301938.p0' to push list
2020-08-05 14:01:44,094 INFO [containers/openshift-enterprise-tests] Adding 'quay.io/openshift-qe-optional-operator/ose-tests:v4.5.0' to push list
2020-08-05 14:01:44,094 INFO [containers/openshift-enterprise-tests] Adding 'quay.io/openshift-qe-optional-operator/ose-tests:v4.5.0-202007301938' to push list
2020-08-05 14:01:44,094 INFO [containers/openshift-enterprise-tests] Adding 'quay.io/openshift-qe-optional-operator/ose-tests:v4.5' to push list
2020-08-05 14:01:44,095 INFO [containers/openshift-enterprise-tests] Mirroring image [retry=0]
2020-08-05 14:01:44,098 INFO $0: ['oc', 'image', 'mirror', '--filter-by-os=amd64', '--filename=/home/nay/shiywang/push/openshift-enterprise-tests', '--registry-config=/home/nay/shiywang/doozer/test.json/config.json'] - [cwd=/home/nay/shiywang/distgits/containers/openshift-enterprise-tests]: Executing:cmd_gather
2020-08-05 14:01:47,571 INFO Time elapsed (hh:mm:ss.ms) 0:00:03.472741 in /home/nay/shiywang/doozer/doozerlib/exectools.py:159 from /home/nay/shiywang/doozer/doozerlib/distgit.py:596:rc, out, err = exectools.cmd_gather(mirror_cmd) : $0: ['oc', 'image', 'mirror', '--filter-by-os=amd64', '--filename=/home/nay/shiywang/push/openshift-enterprise-tests', '--registry-config=/home/nay/shiywang/doozer/test.json/config.json'] - [cwd=/home/nay/shiywang/distgits/containers/openshift-enterprise-tests]: Executed:cmd_gather
2020-08-05 14:01:47,571 INFO [containers/openshift-enterprise-tests] Error mirroring image -- retrying in 60 seconds.
quay.io/
  openshift-qe-optional-operator/ose-tests
    blobs:
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:e7021e0589e97471d99c4265b7c8e64da328e48f116b5f260353b2e0a2adb373 1.703KiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:8b3cc04f6d880217f99e2d9a8a8da267834e6ea23e33ac3cbd491845e566e195 5.729KiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:7c480857b6792d3c0c62b8c18a55ddd1bb86dabf7ef2e48c43a6d10dadb8f103 3.341MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:b8785a449e203ee8ddc57a1664b73cc57c99304a6fd2888f6e02d60ef72c758f 9.158MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:da3165139db60613b47740134c2caabf624de8d11cb3c5bbaa4d2f1ae355b980 23.19MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:d33e7d0f3f4daa8136edcfb7cdaa61f7c063a1018318f4f99aa9722cf533eda3 47.57MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:4e71c8d47982a66d14573cdef2e5f8b8297a357cb224bc287682b8283b57fe9a 52.99MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:fc5b206e9329a1674dd9e8efbee45c9be28d0d0dcbabba3c6bb67a2f22cfcf2a 72.71MiB
    manifests:
      sha256:2a66acbba220e9d7414ddaaa5c8237d645487854655aca9dd110a332c1f9bdc4 -> v4.5
      sha256:2a66acbba220e9d7414ddaaa5c8237d645487854655aca9dd110a332c1f9bdc4 -> v4.5.0
      sha256:2a66acbba220e9d7414ddaaa5c8237d645487854655aca9dd110a332c1f9bdc4 -> v4.5.0-202007301938
      sha256:2a66acbba220e9d7414ddaaa5c8237d645487854655aca9dd110a332c1f9bdc4 -> v4.5.0-202007301938.p0
  stats: shared=0 unique=8 size=209MiB ratio=1.00

phase 0:
  quay.io openshift-qe-optional-operator/ose-tests blobs=8 mounts=0 manifests=4 shared=0

info: Planning completed in 2.56s
error: unable to upload blob sha256:fc5b206e9329a1674dd9e8efbee45c9be28d0d0dcbabba3c6bb67a2f22cfcf2a to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorized
error: unable to upload blob sha256:d33e7d0f3f4daa8136edcfb7cdaa61f7c063a1018318f4f99aa9722cf533eda3 to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorized
error: unable to upload blob sha256:4e71c8d47982a66d14573cdef2e5f8b8297a357cb224bc287682b8283b57fe9a to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorized
error: unable to push registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests: failed to upload blob sha256:e7021e0589e97471d99c4265b7c8e64da328e48f116b5f260353b2e0a2adb373: unauthorized: access to the requested resource is not authorized
error: unable to upload blob sha256:da3165139db60613b47740134c2caabf624de8d11cb3c5bbaa4d2f1ae355b980 to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorized
error: unable to push registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests: failed to upload blob sha256:8b3cc04f6d880217f99e2d9a8a8da267834e6ea23e33ac3cbd491845e566e195: unauthorized: access to the requested resource is not authorized
error: unable to upload blob sha256:7c480857b6792d3c0c62b8c18a55ddd1bb86dabf7ef2e48c43a6d10dadb8f103 to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorized
error: unable to upload blob sha256:b8785a449e203ee8ddc57a1664b73cc57c99304a6fd2888f6e02d60ef72c758f to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorized
info: Mirroring completed in 760ms (0B/s)
error: one or more errors occurred while uploading images
```


Not being able to mirror images @sosiouxme @anpingli maybe I still haven't got the correct permission, could you guys copy my command below and give it a try, the token is in our buildvm.
```
-sh-4.2$ oc image mirror --filter-by-os=amd64 --filename=/home/nay/shiywang/push/openshift-enterprise-tests --registry-config=./test.json/config.json-sh-4.2$ oc image mirror --filter-by-os=amd64 --filename=/home/nay/shiywang/push/openshift-enterprise-tests --registry-config=./test.json/config.jsonquay.io/  openshift-qe-optional-operator/ose-tests    blobs:      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:e7021e0589e97471d99c4265b7c8e64da328e48f116b5f260353b2e0a2adb373 1.703KiB      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:8b3cc04f6d880217f99e2d9a8a8da267834e6ea23e33ac3cbd491845e566e195 5.729KiB      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:7c480857b6792d3c0c62b8c18a55ddd1bb86dabf7ef2e48c43a6d10dadb8f103 3.341MiB      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:b8785a449e203ee8ddc57a1664b73cc57c99304a6fd2888f6e02d60ef72c758f 9.158MiB      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:da3165139db60613b47740134c2caabf624de8d11cb3c5bbaa4d2f1ae355b980 23.19MiB      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:d33e7d0f3f4daa8136edcfb7cdaa61f7c063a1018318f4f99aa9722cf533eda3 47.57MiB      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:4e71c8d47982a66d14573cdef2e5f8b8297a357cb224bc287682b8283b57fe9a 52.99MiB      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:fc5b206e9329a1674dd9e8efbee45c9be28d0d0dcbabba3c6bb67a2f22cfcf2a 72.71MiB    manifests:      sha256:2a66acbba220e9d7414ddaaa5c8237d645487854655aca9dd110a332c1f9bdc4 -> v4.5      sha256:2a66acbba220e9d7414ddaaa5c8237d645487854655aca9dd110a332c1f9bdc4 -> v4.5.0      sha256:2a66acbba220e9d7414ddaaa5c8237d645487854655aca9dd110a332c1f9bdc4 -> v4.5.0-202007301938      sha256:2a66acbba220e9d7414ddaaa5c8237d645487854655aca9dd110a332c1f9bdc4 -> v4.5.0-202007301938.p0  stats: shared=0 unique=8 size=209MiB ratio=1.00
phase 0:  quay.io openshift-qe-optional-operator/ose-tests blobs=8 mounts=0 manifests=4 shared=0
info: Planning completed in 1.05serror: unable to upload blob sha256:b8785a449e203ee8ddc57a1664b73cc57c99304a6fd2888f6e02d60ef72c758f to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorizederror: unable to upload blob sha256:da3165139db60613b47740134c2caabf624de8d11cb3c5bbaa4d2f1ae355b980 to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorizederror: unable to upload blob sha256:7c480857b6792d3c0c62b8c18a55ddd1bb86dabf7ef2e48c43a6d10dadb8f103 to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorizederror: unable to upload blob sha256:4e71c8d47982a66d14573cdef2e5f8b8297a357cb224bc287682b8283b57fe9a to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorizederror: unable to upload blob sha256:d33e7d0f3f4daa8136edcfb7cdaa61f7c063a1018318f4f99aa9722cf533eda3 to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorizederror: unable to push registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests: failed to upload blob sha256:8b3cc04f6d880217f99e2d9a8a8da267834e6ea23e33ac3cbd491845e566e195: unauthorized: access to the requested resource is not authorizederror: unable to upload blob sha256:fc5b206e9329a1674dd9e8efbee45c9be28d0d0dcbabba3c6bb67a2f22cfcf2a to quay.io/openshift-qe-optional-operator/ose-tests: unauthorized: access to the requested resource is not authorizederror: unable to push registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests: failed to upload blob sha256:e7021e0589e97471d99c4265b7c8e64da328e48f116b5f260353b2e0a2adb373: unauthorized: access to the requested resource is not authorizedinfo: Mirroring completed in 880ms (0B/s)error: one or more errors occurred while uploading images-sh-4.2$ cat /home/nay/shiywang/push/openshift-enterprise-testsregistry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests:v4.5.0-202007301938.p0=quay.io/openshift-qe-optional-operator/ose-tests:v4.5.0-202007301938.p0registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests:v4.5.0-202007301938.p0=quay.io/openshift-qe-optional-operator/ose-tests:v4.5.0registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests:v4.5.0-202007301938.p0=quay.io/openshift-qe-optional-operator/ose-tests:v4.5.0-202007301938registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests:v4.5.0-202007301938.p0=quay.io/openshift-qe-optional-operator/ose-tests:v4.5-sh-4.2$-sh-4.2$ ^C-sh-4.2$ cat ./test.json/config.json{ "auths": { "quay.io": { "auth": "b3Blbxxxxxxx==" } }}
-sh-4.2$
```