### PR TITLE
Allow KUBE env vars to be sourced from go.mod

### DIFF
--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -73,29 +73,7 @@ class RPMMetadata(Metadata):
                 if self.public_upstream_branch:
                     self.private_fix = not util.is_commit_in_public_upstream(source_full_sha, self.public_upstream_branch, self.source_path)
 
-                # If this is a go project, parse the Godeps for points of interest
-                godeps_file = pathlib.Path(self.source_path, 'Godeps', 'Godeps.json')
-                if godeps_file.is_file():
-                    try:
-                        with open(str(godeps_file)) as f:
-                            godeps = json.load(f)
-                            # Reproduce https://github.com/openshift/origin/blob/6f457bc317f8ca8e514270714db6597ec1cb516c/hack/lib/build/version.sh#L82
-                            # Example of what we are after: https://github.com/openshift/origin/blob/6f457bc317f8ca8e514270714db6597ec1cb516c/Godeps/Godeps.json#L10-L15
-                            for dep in godeps.get('Deps', []):
-                                if dep.get('ImportPath', '') == 'k8s.io/kubernetes/pkg/api':
-                                    raw_kube_version = dep.get('Comment', '')  # e.g. v1.14.6-152-g117ba1f
-                                    # drop release information.
-                                    base_kube_version = raw_kube_version.split('-')[0]
-                                    kube_version_fields = base_kube_version.lstrip('v').split('.')  # v1.17.1 => [ '1', '17', '1' ]
-                                    # For historical consistency with tito's flow, we add +OS_GIT_COMMIT[:7] to the kube version
-                                    self.extra_os_git_vars['KUBE_GIT_VERSION'] = f"v{'.'.join(kube_version_fields)}+{source_full_sha[:7]}"
-                                    self.extra_os_git_vars['KUBE_GIT_COMMIT'] = dep.get('Rev', '')
-                                    self.extra_os_git_vars['KUBE_GIT_MAJOR'] = '0' if len(kube_version_fields) < 1 else kube_version_fields[0]
-                                    godep_kube_minor = '0' if len(kube_version_fields) < 2 else kube_version_fields[1]
-                                    self.extra_os_git_vars['KUBE_GIT_MINOR'] = f'{godep_kube_minor}+'  # For historical reasons, add a + since OCP patches its vendor kube.
-                    except:
-                        runtime.logger.error(f'Error parsing godeps {str(godeps_file)}')
-                        traceback.print_exc()
+                self.extra_os_git_vars.update(self.metadata.extract_kube_env_vars())
 
             if self.source.specfile:
                 self.specfile = os.path.join(self.source_path, self.source.specfile)


### PR DESCRIPTION
Example diff for hyperkube:
```
-FROM openshift/ose-base:v4.6.0-202008031851.p0
-ENV __doozer=update BUILD_RELEASE=202008061010.p0 BUILD_VERSION=v4.6.0 OS_GIT_MAJOR=4 OS_GIT_MINOR=6 OS_GIT_PATCH=0 OS_GIT_TREE_STATE=clean OS_GIT_VERSION=4.6.0-202008061010.p0 SOURCE_GIT_TREE_STATE=clean 
-ENV __doozer=merge OS_GIT_COMMIT=5241b27 OS_GIT_VERSION=4.6.0-202008061010.p0-5241b27 SOURCE_DATE_EPOCH=1596701527 SOURCE_GIT_COMMIT=5241b27b8acd73cdc99a0cac281645189189f1d8 SOURCE_GIT_TAG=v1.19.0-rc.2-444-g5241b27b8ac SOURCE_GIT_URL=https://github.com/openshift/kubernetes 
+FROM openshift/ose-base:v4.6.0.20200806.163447
+ENV __doozer=update BUILD_RELEASE=9999.p0 BUILD_VERSION=v4.6.0 OS_GIT_MAJOR=4 OS_GIT_MINOR=6 OS_GIT_PATCH=0 OS_GIT_TREE_STATE=clean OS_GIT_VERSION=4.6.0-9999.p0 SOURCE_GIT_TREE_STATE=clean 
+ENV __doozer=merge KUBE_GIT_COMMIT=5241b27b8acd73cdc99a0cac281645189189f1d8 KUBE_GIT_MAJOR=1 KUBE_GIT_MINOR=19+ KUBE_GIT_VERSION=v1.19.0-rc.2+5241b27 OS_GIT_COMMIT=5241b27 OS_GIT_VERSION=4.6.0-9999.p0-5241b27 SOURCE_DATE_EPOCH=1596701527 SOURCE_GIT_COMMIT=5241b27b8acd73cdc99a0cac281645189189f1d8 SOURCE_GIT_TAG=v1.19.0-rc.2-444-g5241b27b8ac SOURCE_GIT_URL=https://github.com/openshift/kubernetes 

```