### PR TITLE
fix bugs by rename registry_config_file to registry_config_dir

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1127,8 +1127,8 @@ def images_mirror_streams(runtime, streams, dry_run):
             brew_pullspec = runtime.resolve_brew_image_url(brew_image)
             cmd = f'oc image mirror {brew_pullspec} {upstream_dest}'
 
-            if runtime.registry_config_file is not None:
-                cmd += f" --registry-config={get_docker_config_json(runtime.registry_config_file)}"
+            if runtime.registry_config_dir is not None:
+                cmd += f" --registry-config={get_docker_config_json(runtime.registry_config_dir)}"
             if dry_run:
                 print(f'Would have run: {cmd}')
             else:


### PR DESCRIPTION
```
[dev@62111d54b562 doozer]$ doozer --group openshift-4.6-rhel-8 images:mirror-streams
2020-08-27 07:00:55,602 INFO Initial execution (cwd) directory: /workspaces/doozer
2020-08-27 07:00:55,605 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-08-27 07:00:55,702 INFO $0: ['git', 'clone', '--no-single-branch', '-b', 'openshift-4.6-rhel-8', '--depth', '1', 'https://github.com/openshift/ocp-build-data.git', '/workspaces/doozer-working-dir/ocp-build-data'] - [cwd=/workspaces/doozer] [env={'GIT_SSH_COMMAND': 'ssh -oBatchMode=yes', 'GIT_TERMINAL_PROMPT': '0'}]: Executing:cmd_gather
2020-08-27 07:01:04,430 INFO Time elapsed (hh:mm:ss.ms) 0:00:08.728625 in /workspaces/doozer/doozerlib/exectools.py:159 from /workspaces/doozer/doozerlib/gitdata.py:146:rc, out, err = exectools.cmd_gather(cmd, set_env=constants.GIT_NO_PROMPTS) : $0: ['git', 'clone', '--no-single-branch', '-b', 'openshift-4.6-rhel-8', '--depth', '1', 'https://github.com/openshift/ocp-build-data.git', '/workspaces/doozer-working-dir/ocp-build-data'] - [cwd=/workspaces/doozer] [env={'GIT_SSH_COMMAND': 'ssh -oBatchMode=yes', 'GIT_TERMINAL_PROMPT': '0'}]: Executed:cmd_gather
2020-08-27 07:01:04,662 INFO Using branch from group.yml: rhaos-4.6-rhel-8
2020-08-27 07:01:06,120 INFO $1: ['oc', 'image', 'mirror', 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-base:ubi8', 'registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6.art'] - [cwd=/workspaces/doozer]: Executing:cmd_gather
```