### PR TITLE
Restrict the number of simultaneous distgit pushes

### DIFF
--- a/doozerlib/dblib.py
+++ b/doozerlib/dblib.py
@@ -162,7 +162,7 @@ class Record(object):
 
     def __exit__(self, *args):
         if not self.dry_run and self.db.client:
-            with self.db.runtime.get_named_lock('package::boto3'):
+            with self.db.runtime.get_named_semaphore('package::boto3'):
                 try:
                     attr_payload = []
                     for k, v in self.attrs.items():

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -413,7 +413,7 @@ class RPMMetadata(Metadata):
         if self.private_fix:
             self.logger.warning("Source contains embargoed fixes.")
 
-        with self.runtime.get_named_lock(self.source_path):
+        with self.runtime.get_named_semaphore(self.source_path, is_dir=True):
 
             with Dir(self.source_path):
                 # Remember what we were at before tito activity. We may need to revert

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import re
 import tempfile
 import unittest
-
+from threading import Lock
 import flexmock
 
 from doozerlib import distgit, model
@@ -137,7 +137,8 @@ class TestImageDistGit(TestDistgit):
             .ordered())
 
         metadata = flexmock(runtime=flexmock(global_opts={"rhpkg_push_timeout": 999},
-                                             branch="_irrelevant_"),
+                                             branch="_irrelevant_",
+                                             get_named_semaphore=lambda *_, **__: Lock()),
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             name="_irrelevant_",
                             logger=flexmock(info=lambda *_: None))
@@ -158,7 +159,8 @@ class TestImageDistGit(TestDistgit):
         flexmock(distgit.exectools).should_receive("cmd_assert").and_raise(IOError("io-error"))
 
         metadata = flexmock(runtime=flexmock(global_opts={"rhpkg_push_timeout": "_irrelevant_"},
-                                             branch="_irrelevant_"),
+                                             branch="_irrelevant_",
+                                             get_named_semaphore=lambda *_, **__: Lock()),
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             name="_irrelevant_",
                             logger=flexmock(info=lambda *_: None))


### PR DESCRIPTION
With every new release, we need to populate a huge amount of data into distgit the first time a build occurs. Dozens of `rhpkg push` invocations run simultaneously -- crushing distgit (or network i/o) and making each push take hours to complete. The simple 'timeout' used for these pushes, must be set absurdly high and is thus useless -- it currently set to 9800 seconds just so we could migrate to a new rhel-8 branch for 4.6.
This implementation limits pushes to 5 distgits at a time, which will allow us to set the push timeout to something sensible again.

Changes `get_named_lock` to `get_named_semaphore` to make this type of throttling easier elsewhere. 