### PR TITLE
Initial code to open upstream reconciliation prs

### DIFF
--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -1,13 +1,21 @@
 import io
 import os
 import click
+import yaml
+import hashlib
+
+from github import Github, UnknownObjectException, GithubException
+from dockerfile_parse import DockerfileParser
 
 from dockerfile_parse import DockerfileParser
 from doozerlib.model import Missing
+from doozerlib.pushd import Dir
 from doozerlib.cli import cli, pass_runtime
 from doozerlib import brew, state, exectools, embargo_detector
-from doozerlib.util import get_docker_config_json
-import yaml
+from doozerlib.util import get_docker_config_json, convert_remote_git_to_ssh, \
+    split_git_url, remove_prefix, green_print,\
+    yellow_print, red_print, convert_remote_git_to_https, \
+    what_is_in_master, extract_version_fields, convert_remote_git_to_https
 
 
 @cli.group("images:streams", short_help="Manage ART equivalent images in upstream CI.")
@@ -18,9 +26,10 @@ def images_streams():
 @images_streams.command('mirror')
 @click.option('--stream', 'streams', metavar='STREAM_NAME', default=[], multiple=True, help='If specified, only these stream names will be mirrored.')
 @click.option('--only-if-missing', default=False, is_flag=True, help='Only mirror the image if there is presently no equivalent image upstream.')
+@click.option('--live-test-mode', default=False, is_flag=True, help='Append "test" to destination images to exercise live-test-mode buildconfigs')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @pass_runtime
-def images_streams_mirror(runtime, streams, only_if_missing, dry_run):
+def images_streams_mirror(runtime, streams, only_if_missing, live_test_mode, dry_run):
     runtime.initialize(clone_distgits=False, clone_source=False)
     runtime.assert_mutation_is_permitted()
 
@@ -57,6 +66,9 @@ def images_streams_mirror(runtime, streams, only_if_missing, dry_run):
                     print(f'Image {upstream_dest} seems to exist already; skipping because of --only-if-missing')
                     continue
 
+            if live_test_mode:
+                upstream_dest += '.test'
+
             cmd = f'oc image mirror {brew_pullspec} {upstream_dest}'
 
             if runtime.registry_config_dir is not None:
@@ -68,8 +80,9 @@ def images_streams_mirror(runtime, streams, only_if_missing, dry_run):
 
 
 @images_streams.command('check-upstream', short_help='Dumps information about CI buildconfigs/mirrored images associated with this group')
+@click.option('--live-test-mode', default=False, is_flag=True, help='Scan for live-test mode buildconfigs')
 @pass_runtime
-def images_streams_check_upstream(runtime):
+def images_streams_check_upstream(runtime, live_test_mode):
     runtime.initialize(clone_distgits=False, clone_source=False)
 
     streams = runtime.get_stream_names()
@@ -83,7 +96,9 @@ def images_streams_check_upstream(runtime):
 
         upstream_dest = config.upstream_image
         _, dest_ns, dest_istag = upstream_dest.rsplit('/', maxsplit=2)
-        dest_imagestream, dest_tag = dest_istag.split(':')
+
+        if live_test_mode:
+            dest_istag += '.test'
 
         rc, stdout, stderr = exectools.cmd_gather(f'oc get -n {dest_ns} istag {dest_istag} --no-headers')
         if rc:
@@ -91,9 +106,13 @@ def images_streams_check_upstream(runtime):
         else:
             istags_status.append(f'OK: {stream} exists, but check whether it is recently updated\n{stdout}')
 
-    bc_stdout, bc_stderr = exectools.cmd_assert(f'oc -n ci get -o=wide buildconfigs -l art-builder-group={runtime.group_config.name}')
-    builds_stdout, builds_stderr = exectools.cmd_assert(f'oc -n ci get -o=wide builds -l art-builder-group={runtime.group_config.name}')
-    ds_stdout, ds_stderr = exectools.cmd_assert(f'oc -n ci get ds -l art-builder-group={runtime.group_config.name}')
+    group_label = runtime.group_config.name
+    if live_test_mode:
+        group_label += '.test'
+
+    bc_stdout, bc_stderr = exectools.cmd_assert(f'oc -n ci get -o=wide buildconfigs -l art-builder-group={group_label}')
+    builds_stdout, builds_stderr = exectools.cmd_assert(f'oc -n ci get -o=wide builds -l art-builder-group={group_label}')
+    ds_stdout, ds_stderr = exectools.cmd_assert(f'oc -n ci get ds -l art-builder-group={group_label}')
     print('Daemonset status (pins image to prevent gc on node; verify that READY=CURRENT):')
     print(ds_stdout or ds_stderr)
     print('Build configs:')
@@ -108,10 +127,16 @@ def images_streams_check_upstream(runtime):
 
 
 @images_streams.command('start-builds', short_help='Triggers a build for each buildconfig associated with this group')
+@click.option('--live-test-mode', default=False, is_flag=True, help='Act on live-test mode buildconfigs')
 @pass_runtime
-def images_streams_start_buildconfigs(runtime):
+def images_streams_start_buildconfigs(runtime, live_test_mode):
     runtime.initialize(clone_distgits=False, clone_source=False)
-    bc_stdout, bc_stderr = exectools.cmd_assert(f'oc -n ci get -o=name buildconfigs -l art-builder-group={runtime.group_config.name}')
+
+    group_label = runtime.group_config.name
+    if live_test_mode:
+        group_label += '.test'
+
+    bc_stdout, bc_stderr = exectools.cmd_assert(f'oc -n ci get -o=name buildconfigs -l art-builder-group={group_label}')
     bc_stdout = bc_stdout.strip()
 
     if bc_stdout:
@@ -120,15 +145,16 @@ def images_streams_start_buildconfigs(runtime):
             stdout, stderr = exectools.cmd_assert(f'oc -n ci start-build {name}')
             print('   ' + stdout or stderr)
     else:
-        print('No buildconfigs associated with this group')
+        print(f'No buildconfigs associated with this group: {group_label}')
 
 
 @images_streams.command('gen-buildconfigs', short_help='Generates buildconfigs necessary to assemble ART equivalent images upstream')
 @click.option('--stream', 'streams', metavar='STREAM_NAME', default=[], multiple=True, help='If specified, only these stream names will be processed.')
 @click.option('-o', '--output', metavar='FILENAME', required=True, help='The filename into which to write the YAML. It should be oc applied against api.ci as art-publish. The file may be empty if there are no buildconfigs.')
 @click.option('--apply', default=False, is_flag=True, help='Apply the output if any buildconfigs are generated')
+@click.option('--live-test-mode', default=False, is_flag=True, help='Generate live-test mode buildconfigs')
 @pass_runtime
-def images_streams_gen_buildconfigs(runtime, streams, output, apply):
+def images_streams_gen_buildconfigs(runtime, streams, output, apply, live_test_mode):
     """
     ART has a mandate to make "ART equivalent" images available usptream for CI workloads. This enables
     CI to compile with the same golang version ART is using and use identical UBI8 images, etc. To accomplish
@@ -210,9 +236,13 @@ def images_streams_gen_buildconfigs(runtime, streams, output, apply):
         # split a pullspec like registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}.art
         # into  OpenShift namespace, imagestream, and tag
         _, intermediate_ns, intermediate_istag = upstream_intermediate_image.rsplit('/', maxsplit=2)
+        if live_test_mode:
+            intermediate_istag += '.test'
         intermediate_imagestream, intermediate_tag = intermediate_istag.split(':')
 
         _, dest_ns, dest_istag = upstream_dest.rsplit('/', maxsplit=2)
+        if live_test_mode:
+            dest_istag += '.test'
         dest_imagestream, dest_tag = dest_istag.split(':')
 
         python_file_dir = os.path.dirname(__file__)
@@ -228,8 +258,12 @@ def images_streams_gen_buildconfigs(runtime, streams, output, apply):
         # Make sure that upstream images can discern they are building in CI with ART equivalent images
         dfp.envs['OPENSHIFT_CI'] = 'true'
 
+        group_label = runtime.group_config.name
+        if live_test_mode:
+            group_label += '.test'
+
         dfp.labels['io.k8s.display-name'] = f'{dest_imagestream}-{dest_tag}'
-        dfp.labels['io.k8s.description'] = f'ART equivalent image {runtime.group_config.name}-{stream} - {transform}'
+        dfp.labels['io.k8s.description'] = f'ART equivalent image {group_label}-{stream} - {transform}'
 
         if transform == transform_rhel_8_base_repos or config.transform == transform_rhel_8_golang:
             # The repos transform create a build config that will layer the base image with CI appropriate yum
@@ -260,7 +294,7 @@ def images_streams_gen_buildconfigs(runtime, streams, output, apply):
                 'name': f'{dest_imagestream}-{dest_tag}--art-builder',
                 'namespace': 'ci',
                 'labels': {
-                    'art-builder-group': runtime.group_config.name,
+                    'art-builder-group': group_label,
                     'art-builder-stream': stream,
                 },
                 'annotations': {
@@ -318,7 +352,7 @@ def images_streams_gen_buildconfigs(runtime, streams, output, apply):
             "imagePullPolicy": "Always"
         })
 
-    ds_name = 'art-managed-' + runtime.group_config.name + '-dont-gc-me-bro'
+    ds_name = 'art-managed-' + group_label + '-dont-gc-me-bro'
     daemonset_definition = {
         "kind": "DaemonSet",
         "spec": {
@@ -371,3 +405,301 @@ def images_streams_gen_buildconfigs(runtime, streams, output, apply):
             exectools.cmd_assert(f'oc apply -f {output}')
         else:
             print('No buildconfigs were generated; skipping apply.')
+
+
+def calc_parent_digest(parent_images):
+    m = hashlib.md5()
+    m.update(';'.join(parent_images).encode('utf-8'))
+    return m.hexdigest()
+
+
+def extract_parent_digest(dockerfile_path):
+    with dockerfile_path.open(mode='r') as handle:
+        dfp = DockerfileParser(cache_content=True, fileobj=io.BytesIO())
+        dfp.content = handle.read()
+    return calc_parent_digest(dfp.parent_images), dfp.parent_images
+
+
+def resolve_upstream_from(runtime, image_entry):
+    """
+    :param runtime: The runtime object
+    :param image_entry: A builder or from entry. e.g. { 'member': 'openshift-enterprise-base' }  or { 'stream': 'golang; }
+    :return: The upstream CI pullspec to which this entry should resolve.
+    """
+    major = runtime.group_config.vars['MAJOR']
+    minor = runtime.group_config.vars['MINOR']
+
+    if image_entry.member:
+        target_meta = runtime.resolve_image(image_entry.member, True)
+        image_name = target_meta.config.name.split('/')[-1]
+        # In release payloads, images are promoted into an imagestream
+        # tag name without the ose- prefix.
+        image_name = remove_prefix(image_name, 'ose-')
+
+        # e.g. registry.svc.ci.openshift.org/ocp/4.6:base
+        return f'registry.svc.ci.openshift.org/ocp/{major}.{minor}:{image_name}'
+
+    if image_entry.image:
+        # CI is on its own. We can't give them an image that isn't available outside the firewall.
+        return None
+    elif image_entry.stream:
+        return runtime.resolve_stream(image_entry.stream).upstream_image
+
+
+def _get_upstream_source(runtime, image_meta):
+    """
+    Analyzes an image metadata to find the upstream URL and branch associated with its content.
+    :param runtime: The runtime object
+    :param image_meta: The metadata to inspect
+    :return: A tuple containing (url, branch) for the upstream source OR (None, None) if there
+            is no upstream source.
+    """
+    if "git" in image_meta.config.content.source:
+        source_repo_url = image_meta.config.content.source.git.url
+        source_repo_branch = image_meta.config.content.source.git.branch.target
+    elif "alias" in image_meta.config.content.source:
+        alias = image_meta.config.content.source.alias
+        if alias not in runtime.group_config.sources:
+            raise IOError(f'Unable to find source alias {alias} for {image_meta.distgit_key}')
+        source_repo_url = runtime.group_config.sources[alias].url
+        source_repo_branch = runtime.group_config.sources[alias].branch.target
+    else:
+        # No upstream source, no PR to open
+        return None, None
+
+    return source_repo_url, source_repo_branch
+
+
+@images_streams.group("prs", short_help="Manage ART equivalent PRs in upstream.")
+def prs():
+    pass
+
+
+@prs.command('open', short_help='Open PRs against upstream component repos that have a FROM that differs from ART metadata')
+@click.option('--github-access-token', metavar='TOKEN', required=True, help='Github access token for user.')
+@click.option('--ignore-ci-master', default=False, is_flag=True, help='Do not consider what is in master branch when determining what branch to target')
+@click.option('--draft-prs', default=False, is_flag=True, help='Open PRs as draft PRs')
+@click.option('--moist-run', default=False, is_flag=True, help='Do everything except opening the final PRs')
+@pass_runtime
+def images_streams_prs(runtime, github_access_token, ignore_ci_master, draft_prs, moist_run):
+    runtime.initialize(clone_distgits=False, clone_source=False)
+    g = Github(login_or_token=github_access_token)
+    github_user = g.get_user()
+
+    major = runtime.group_config.vars['MAJOR']
+    minor = runtime.group_config.vars['MINOR']
+
+    master_major, master_minor = extract_version_fields(what_is_in_master(), at_least=2)
+    if not ignore_ci_master and (major > master_major or minor > master_minor):
+        # ART building a release before is is in master. Too early to open PRs.
+        runtime.logger.warning(f'Target {major}.{minor} has not been in master yet (it is tracking {master_major}.{master_minor}); skipping PRs')
+        exit(0)
+
+    prs_in_master = (major == master_major and minor == master_minor) and not ignore_ci_master
+
+    pr_links = {}  # map of distgit_key to PR URLs associated with updates
+    new_pr_links = {}
+    for image_meta in runtime.ordered_image_metas():
+        dgk = image_meta.distgit_key
+        logger = image_meta.logger
+        logger.info('Analyzing image')
+
+        from_config = image_meta.config['from']
+        if not from_config:
+            logger.info('Skipping PRs since there is no configured .from')
+            continue
+
+        desired_parents = []
+        builders = from_config.builder or []
+        for builder in builders:
+            upstream_image = resolve_upstream_from(runtime, builder)
+            if not upstream_image:
+                logger.warning(f'Unable to resolve upstream image for: {builder}')
+                break
+            desired_parents.append(upstream_image)
+
+        parent_upstream_image = resolve_upstream_from(runtime, from_config)
+        if len(desired_parents) != len(builders) or not parent_upstream_image:
+            logger.warning('Unable to find all ART equivalent upstream images for this image')
+            continue
+
+        desired_parents.append(parent_upstream_image)
+        desired_parent_digest = calc_parent_digest(desired_parents)
+        logger.info(f'Found desired FROM state of: {desired_parents} with digest: {desired_parent_digest}')
+
+        source_repo_url, source_repo_branch = _get_upstream_source(runtime, image_meta)
+
+        if not source_repo_url:
+            # No upstream to clone; no PRs to open
+            continue
+
+        public_repo_url, public_branch = runtime.get_public_upstream(source_repo_url)
+        if not public_branch:
+            public_branch = source_repo_branch
+
+        # There are two standard upstream branching styles:
+        # release-4.x   : CI fast-forwards from master when appropriate
+        # openshift-4.x : Upstream team manages completely.
+        # For the former style, we may need to open the PRs against master.
+        # For the latter style, always open directly against named branch
+        if public_branch.startswith('release-') and prs_in_master:
+            # TODO: auto-detect default branch for repo instead of assuming master
+            public_branch = 'master'
+
+        _, org, repo_name = split_git_url(public_repo_url)
+
+        public_source_repo = g.get_repo(f'{org}/{repo_name}')
+
+        try:
+            fork_repo_name = f'{github_user.login}/{repo_name}'
+            fork_repo = g.get_repo(fork_repo_name)
+        except UnknownObjectException:
+            # Repo doesn't exist; fork it
+            fork_repo = github_user.create_fork(public_source_repo)
+
+        fork_branch_name = f'art-consistency-{runtime.group_config.name}-{dgk}'
+        fork_branch_head = f'{github_user.login}:{fork_branch_name}'
+
+        fork_branch = None
+        try:
+            fork_branch = fork_repo.get_branch(fork_branch_name)
+        except UnknownObjectException:
+            # Doesn't presently exist and will need to be created
+            pass
+        except GithubException as ge:
+            # This API seems to return 404 instead of UnknownObjectException.
+            # So allow 404 to pass through as well.
+            if ge.status != 404:
+                raise
+
+        public_repo_url = convert_remote_git_to_ssh(public_repo_url)
+        clone_dir = os.path.join(runtime.working_dir, 'clones', dgk)
+        # Clone the private url to make the best possible use of our doozer_cache
+        runtime.git_clone(source_repo_url, clone_dir)
+
+        with Dir(clone_dir):
+            exectools.cmd_assert(f'git remote add public {public_repo_url}')
+            exectools.cmd_assert(f'git remote add fork {convert_remote_git_to_ssh(fork_repo.git_url)}')
+            exectools.cmd_assert('git fetch --all')
+
+            # The path to the Dockerfile in the target branch
+            if image_meta.config.content.source.dockerfile is not Missing:
+                # Be aware that this attribute sometimes contains path elements too.
+                dockerfile_name = image_meta.config.content.source.dockerfile
+            else:
+                dockerfile_name = "Dockerfile"
+
+            df_path = Dir.getpath()
+            if image_meta.config.content.source.path:
+                dockerfile_name = os.path.join(image_meta.config.content.source.path, dockerfile_name)
+
+            df_path = df_path.joinpath(dockerfile_name)
+
+            fork_branch_parent_digest = None
+            fork_branch_parents = None
+            if fork_branch:
+                # If there is already an art reconciliation branch, get an MD5
+                # of the FROM images in the Dockerfile in that branch.
+                exectools.cmd_assert(f'git checkout fork/{fork_branch_name}')
+                fork_branch_parent_digest, fork_branch_parents = extract_parent_digest(df_path)
+
+            # Now change over to the target branch in the actual public repo
+            exectools.cmd_assert(f'git checkout public/{public_branch}')
+
+            source_branch_parent_digest, source_branch_parents = extract_parent_digest(df_path)
+
+            if desired_parent_digest == source_branch_parent_digest:
+                green_print('Desired digest and source digest match; Upstream is in a good state')
+                continue
+
+            yellow_print(f'Upstream dockerfile does not match desired state in {public_repo_url}/blob/{public_branch}/{dockerfile_name}')
+            print(f'Desired parents: {desired_parents} ({desired_parent_digest})')
+            print(f'Source parents: {source_branch_parents} ({source_branch_parent_digest})')
+            print(f'Fork branch digest: {fork_branch_parents} ({fork_branch_parent_digest})')
+
+            pr_title = f"AUTOMATION TESTING - PLEASE DISREGARD - Updating {image_meta.name} builder & base images to be consistent with ART"
+            reconcile_info = f"Reconciling with {convert_remote_git_to_https(runtime.gitdata.origin_url)}/tree/{runtime.gitdata.commit_hash}/images/{os.path.basename(image_meta.config_filename)}"
+
+            diff_text = None
+            if fork_branch_parent_digest != desired_parent_digest:
+                # The fork branch either does not exist, or does not have the desired parent image state
+                # Let's create a local branch that will contain the Dockerfile in the state we desire.
+                work_branch_name = '__mod'
+                exectools.cmd_assert(f'git checkout public/{public_branch}')
+                exectools.cmd_assert(f'git checkout -b {work_branch_name}')
+                with df_path.open(mode='r+') as handle:
+                    dfp = DockerfileParser(cache_content=True, fileobj=io.BytesIO())
+                    dfp.content = handle.read()
+                    dfp.parent_images = desired_parents
+                    handle.truncate(0)
+                    handle.seek(0)
+                    handle.write(dfp.content)
+
+                diff_text, _ = exectools.cmd_assert(f'git diff {str(df_path)}')
+
+                if not moist_run:
+                    exectools.cmd_assert(f'git add {str(df_path)}')
+                    commit_prefix = ''
+                    if repo_name.startswith('kubernetes'):
+                        # couple repos have this requirement; openshift/kubernetes & openshift/kubernetes-autoscaler.
+                        # This check may suffice  for now, but it may eventually need to be in doozer metadata.
+                        commit_prefix = 'UPSTREAM: <carry>: '
+                    commit_msg = f"""{commit_prefix}{pr_title}
+{reconcile_info}
+"""
+                    exectools.cmd_assert(f'git commit -m "{commit_msg}"')  # Add a commit atop the public branch's current state
+                    # Create or update the remote fork branch
+                    exectools.cmd_assert(f'git push --force fork {work_branch_name}:{fork_branch_name}')
+
+            # At this point, we have a fork branch in the proper state
+            pr_body = f"""{pr_title}
+{reconcile_info}
+
+If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
+"""
+            parent_pr_url = None
+            parent_meta = image_meta.resolve_parent()
+            if parent_meta:
+                parent_pr_url = pr_links.get(parent_meta.distgit_key, None)
+                if parent_pr_url:
+                    # If the parent has an open PR associated with it, make sure the
+                    # child PR notes that the parent PR should merge first.
+                    pr_body += f'\nDepends on {parent_pr_url} . Allow it to merge and then run `/test all` on this PR.'
+
+            # Let's see if there is a PR opened
+            open_prs = list(public_source_repo.get_pulls(state='open', head=fork_branch_head))
+            if open_prs:
+                existing_pr = open_prs[0]
+                # Update body, but never title; The upstream team may need set something like a Bug XXXX: there.
+                # Don't muck with it.
+                existing_pr.edit(body=pr_body)
+                pr_url = existing_pr.html_url
+                pr_links[dgk] = pr_url
+                yellow_print(f'A PR is already open requesting desired reconciliation with ART: {pr_url}')
+                continue
+
+            # Otherwise, we need to create a pull request
+            if moist_run:
+                pr_links[dgk] = f'MOIST-RUN-PR:{dgk}'
+                green_print(f'Would have opened PR against: {public_source_repo.html_url}/blob/{public_branch}/{dockerfile_name}.')
+                if parent_pr_url:
+                    green_print(f'Would have identified dependency on PR: {parent_pr_url}.')
+                if diff_text:
+                    yellow_print(diff_text)
+                else:
+                    yellow_print(f'Fork from which PR would be created ({fork_branch_head}) is populated with desired state.')
+            else:
+                new_pr = public_source_repo.create_pull(title=pr_title, body=pr_body, base=public_branch, head=fork_branch_head, draft=draft_prs)
+                pr_msg = f'A new PR has been opened: {new_pr.html_url}'
+                pr_links[dgk] = new_pr.html_url
+                new_pr_links[dgk] = new_pr.html_url
+                logger.info(pr_msg)
+                yellow_print(pr_msg)
+
+    if new_pr_links:
+        print('Newly opened PRs:')
+        print(yaml.safe_dump(new_pr_links))
+
+    if pr_links:
+        print('Currently open PRs:')
+        print(yaml.safe_dump(pr_links))

--- a/doozerlib/gitdata.py
+++ b/doozerlib/gitdata.py
@@ -80,6 +80,8 @@ class GitData(object):
         self.remote_path = None
         self.sub_dir = sub_dir
         self.exts = ['.' + e.lower() for e in exts]
+        self.commit_hash = None
+        self.origin_url = None
         if data_path:
             self.clone_data(data_path)
 
@@ -162,6 +164,10 @@ class GitData(object):
             self.data_dir = os.path.join(self.data_path, self.sub_dir)
         else:
             self.data_dir = self.data_path
+
+        self.origin_url, _ = exectools.cmd_assert(f'git -C {self.data_path} remote get-url origin', strip=True)
+        self.commit_hash, _ = exectools.cmd_assert(f'git -C {self.data_path} rev-parse HEAD', strip=True)
+
         if not os.path.isdir(self.data_dir):
             raise GitDataPathException('{} is not a valid sub-directory in the data'.format(self.sub_dir))
 

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -59,6 +59,9 @@ class ImageMetadata(Metadata):
         return descendants
 
     def resolve_parent(self):
+        """
+        :return: Resolves and returns imagemeta.parent attribute for this image's parent image OR None if no parent is defined.
+        """
         if 'from' in self.config:
             if 'member' in self.config['from']:
                 base = self.config['from']['member']
@@ -69,6 +72,7 @@ class ImageMetadata(Metadata):
 
                 if self.parent:
                     self.parent.add_child(self)
+        return self.parent
 
     def add_child(self, child):
         """

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -15,7 +15,7 @@ import traceback
 import glob
 
 from .pushd import Dir
-from .distgit import ImageDistGitRepo, RPMDistGitRepo
+from .distgit import ImageDistGitRepo, RPMDistGitRepo, DistGitRepo
 from . import exectools
 from . import logutil
 
@@ -112,7 +112,7 @@ class Metadata(object):
             return f'ssh://{self.runtime.user}@{pkgs_host}/{self.qualified_name}'
         return f'ssh://{pkgs_host}/{self.qualified_name}'
 
-    def distgit_repo(self, autoclone=True):
+    def distgit_repo(self, autoclone=True) -> DistGitRepo:
         if self._distgit_repo is None:
             self._distgit_repo = DISTGIT_TYPES[self.meta_type](self, autoclone=autoclone)
         return self._distgit_repo

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -834,6 +834,12 @@ class Runtime(object):
             f.write(diff)
 
     def resolve_image(self, distgit_name, required=True):
+        """
+        Returns an ImageMetadata for the specified group member name.
+        :param distgit_name: The name of an image member in this group
+        :param required: If True, raise an exception if the member is not found.
+        :return: The ImageMetadata object associated with the name
+        """
         if distgit_name not in self.image_map:
             if not required:
                 return None


### PR DESCRIPTION
`images:streams prs open` will scan through image metadatas public upstream git repos and check the FROM statements within its corresponding Dockerfile. If the upstream Dockerfile does not have the desired state relative to the imagemetadata and streams.yml, a fork of the repository will be created (if it does not already exist) and the desired state populated within a branch of that fork. A PR will be opened against the public upstream indicating the desired state.

The tool is idempotent and can be run multiple times without opening new PRs. However, if a PR is not open and the desired state has not been reached, a new PR will be created.