### PR TITLE
[ART-2290] Make Greenwave "uniqueness" test happy

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -410,7 +410,7 @@ class OLMBundle(object):
 
     @property
     def bundle_brew_component(self):
-        return self.operator_brew_component.replace('-container', '-bundle-container')
+        return self.operator_brew_component.replace('-container', '-metadata-container')
 
     @property
     def branch(self):


### PR DESCRIPTION
> only one package name is allowed to release operator metadata/bundle for a
> particular operator name. I thought the old format and new format would be
> treated separately, but they're conflicting. We will continue building
> metadata for 4.3-4.5 and bundles for 4.6, but the different package names
> are not allowed. So for now (until someone relaxes the uniqueness rule,
> which may never happen) we're forced to use a single package name. So,
> instead of bundles building as foo-operator-bundle-container we're going to
> need to reuse the foo-operator-metadata-container components