### PR TITLE
ART-2183: Add release:validate-rhcos to validate that included RHCOS …

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y \
     # provides en_US.UTF-8 locale required by tito
     glibc-langpack-en \
     # development dependencies
-    gcc krb5-devel openssl-devel \
+    gcc gcc-c++ krb5-devel openssl-devel \
     python3-devel python3-pip \
     # Microsoft Python Language Server requires .NET Core 2.1 or later
     dotnet-runtime-3.1 \

--- a/doozerlib/assertion.py
+++ b/doozerlib/assertion.py
@@ -11,13 +11,13 @@ import errno
 
 # Create FileNotFound for Python2
 try:
-    import FileNotFoundError
+    from builtins import FileNotFoundError
 except ImportError:
     FileNotFoundError = IOError
 
 # Create ChildProcessError for Python2
 try:
-    import ChildProcessError
+    from builtins import ChildProcessError
 except ImportError:
     ChildProcessError = IOError
 

--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -1,5 +1,7 @@
+import asyncio
 import os
 import sys
+from functools import update_wrapper
 
 import click
 
@@ -135,3 +137,15 @@ def cli(ctx, **kwargs):
     ctx.obj = Runtime(cfg_obj=cfg, command=ctx.invoked_subcommand, **runtime_args)
     CTX_GLOBAL = ctx
     return ctx
+
+
+def click_coroutine(f):
+    """ A wrapper to allow to use asyncio with click.
+    https://github.com/pallets/click/issues/85
+    """
+    f = asyncio.coroutine(f)
+
+    def wrapper(*args, **kwargs):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(f(*args, **kwargs))
+    return update_wrapper(wrapper, f)

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -12,6 +12,7 @@ from doozerlib import metadata
 from doozerlib.config import MetaDataConfig as mdc
 from doozerlib.cli import cli, pass_runtime
 from doozerlib.cli.release_gen_payload import release_gen_payload
+from doozerlib.cli.release_validate_rhcos import release_validate_rhcos
 from doozerlib.cli.detect_embargo import detect_embargo
 from doozerlib.cli.images_streams import images_streams, images_streams_mirror, images_streams_gen_buildconfigs
 from doozerlib.cli.scan_sources import config_scan_source_changes
@@ -2342,8 +2343,10 @@ def main():
         red_print('\nDoozer Failed With Error:\n' + str(ex))
 
         if cli_package.CTX_GLOBAL and cli_package.CTX_GLOBAL.obj:
-            cli_package.CTX_GLOBAL.obj.state['status'] = state.STATE_FAIL
-            cli_package.CTX_GLOBAL.obj.state['msg'] = str(ex)
+            runtime = cli_package.CTX_GLOBAL.obj
+            if hasattr(runtime, "state"):  # only record when state is initialized
+                cli_package.CTX_GLOBAL.obj.state['status'] = state.STATE_FAIL
+                cli_package.CTX_GLOBAL.obj.state['msg'] = str(ex)
         sys.exit(1)
     finally:
         if cli_package.CTX_GLOBAL and cli_package.CTX_GLOBAL.obj and cli_package.CTX_GLOBAL.obj.initialized:

--- a/doozerlib/cli/release_validate_rhcos.py
+++ b/doozerlib/cli/release_validate_rhcos.py
@@ -1,0 +1,72 @@
+import asyncio
+import click
+import json
+
+from doozerlib.cli import cli, pass_runtime, click_coroutine
+from doozerlib.exceptions import DoozerFatalError
+from doozerlib.rhcos import get_rhcos_pullspec_from_image_stream, get_rhcos_version_arch, get_rhcos_build_metadata, get_rhcos_pullspec_from_release
+from doozerlib.util import red_print, green_print
+
+
+@cli.command("release:validate-rhcos", short_help="validate if RHCOS in the latest nightly is viable to promote")
+@click.option("--is-name", metavar='NAME',
+              help="ImageStream .metadata.name value. Something like '4.2-art-latest'")
+@click.option("--is-namespace", metavar='NAMESPACE', required=False, default='ocp',
+              help="ImageStream .metadata.namespace value.\ndefault=ocp")
+@click.option("--rhcos-tag", metavar="TAG", default="machine-os-content",
+              help="Tag of RHCOS image in the release ImageStream. default=machine-os-content")
+@click.argument("release_pullspecs", metavar="PULLSPECS...", nargs=-1)
+@pass_runtime
+@click_coroutine
+async def release_validate_rhcos(runtime, is_name, is_namespace, rhcos_tag, release_pullspecs):
+    """Validates RHCOS is generally OK to promote.
+
+    Example 1: Validate the latest nightly in an image stream
+        doozer release:validate-rhcos --is-name=4.6-art-latest --is-namespace=ocp
+    Example 2: Validate given release images
+        doozer release:validate-rhcos registry.svc.ci.openshift.org/ocp/release:4.6.0-0.nightly-2020-09-24-074159 registry.svc.ci.openshift.org/ocp-s390x/release-s390x:4.6.0-0.nightly-s390x-2020-09-24-065929
+    """
+    runtime.initialize(no_group=True)
+    if is_name and release_pullspecs:
+        raise click.BadParameter("Use one of --is-name or PULLSPECS.")
+
+    VALIDATION_ERROR = 2  # 2 donates validation errors rather than common runtime errors
+
+    if is_name:
+        runtime.logger.info("Getting latest nightly...")
+        try:
+            pullspec = await get_rhcos_pullspec_from_image_stream(is_name, is_namespace, rhcos_tag)
+        except Exception as ex:
+            raise DoozerFatalError(f"Couldn't get RHCOS pullspec: {ex}. See debug.log for more info. Did you log in to api.ci.openshift.org?")
+        ok = await validate_pullspec(runtime, pullspec)
+        if not ok:
+            red_print(f"Latest RHCOS in ImageStream {is_namespace}/{is_name} is not in the AWS bucket.")
+            exit(VALIDATION_ERROR)
+
+    if release_pullspecs:
+        runtime.logger.info(f"Validating RHCOS images in {len(release_pullspecs)} release pullspecs...")
+        results = await asyncio.gather(*[validate_rhcos_in_release(runtime, release, rhcos_tag) for release in release_pullspecs])
+        bad_releases = [release for release, ok in zip(release_pullspecs, results) if not ok]
+        for bad_release in bad_releases:
+            red_print(f"RHCOS in {bad_release} is not in the AWS bucket.")
+        if bad_releases:
+            exit(VALIDATION_ERROR)
+
+    green_print("Passed all validations.")
+
+
+async def validate_rhcos_in_release(runtime, release_pullspec, rhcos_tag):
+    runtime.logger.info(f"Validating release {release_pullspec}...")
+    pullspec = await get_rhcos_pullspec_from_release(release_pullspec, rhcos_tag)
+    return await validate_pullspec(runtime, pullspec)
+
+
+async def validate_pullspec(runtime, pullspec):
+    runtime.logger.info(f"Determining build ID for RHCOS pullspec {pullspec}...")
+    try:
+        version, arch = await get_rhcos_version_arch(pullspec)
+    except Exception as ex:
+        raise DoozerFatalError(f"Couldn't determine RHCOS build ID: {ex}. See debug.log for more info. Did you log in to quay.io?")
+    runtime.logger.info(f"Pullspec {pullspec} is version {version}, arch {arch}. Fetching metadata from the AWS bucket...")
+    metadata = await get_rhcos_build_metadata(version, arch)
+    return metadata is not None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp[speedups] >= 3.6
 bashlex
 click >= 6.7
 dockerfile-parse >= 0.0.13

--- a/tests/test_exectools.py
+++ b/tests/test_exectools.py
@@ -5,18 +5,21 @@ Test functions related to controlled command execution
 
 from __future__ import absolute_import, print_function, unicode_literals
 
+import asyncio
+import logging
+import os
+import shutil
+import tempfile
 import unittest
+
+import mock
+
+from doozerlib import exectools
+
 try:
     from importlib import reload
 except ImportError:
     pass
-import os
-import tempfile
-import shutil
-
-import logging
-
-from doozerlib import exectools
 
 
 class RetryTestCase(unittest.TestCase):
@@ -124,6 +127,24 @@ class TestCmdExec(unittest.TestCase):
 
         self.assertEqual(len(lines), 12)
 
+    def test_cmd_assert_async(self):
+        loop = asyncio.get_event_loop()
+        cmd = ["uname", "-a"]
+        env = {"FOO": "BAR"}
+        fake_stdout = b"fake_stdout"
+        fake_stderr = b"fake_stderr"
+        with mock.patch("doozerlib.exectools.cmd_gather_async", return_value=(0, fake_stdout.decode("utf-8"), fake_stderr.decode("utf-8"))) as cmd_gather_async:
+            out, err = loop.run_until_complete(exectools.cmd_assert_async(cmd, text_mode=True, set_env=env))
+            cmd_gather_async.assert_called_once_with(cmd, text_mode=True, set_env=env)
+            self.assertEqual(out, fake_stdout.decode("utf-8"))
+            self.assertEqual(err, fake_stderr.decode("utf-8"))
+
+            cmd_gather_async.reset_mock()
+            cmd_gather_async.return_value = (1, fake_stdout, fake_stderr)
+            with self.assertRaises(ChildProcessError):
+                loop.run_until_complete(exectools.cmd_assert_async(cmd, text_mode=False, set_env=env))
+            cmd_gather_async.assert_called_once_with(cmd, text_mode=False, set_env=env)
+
 
 class TestGather(unittest.TestCase):
     """
@@ -183,6 +204,32 @@ class TestGather(unittest.TestCase):
         lines = log_file.readlines()
 
         self.assertEqual(len(lines), 6)
+
+    def test_cmd_gather_async(self):
+        loop = asyncio.get_event_loop()
+        cmd = ["uname", "-a"]
+        env = {"FOO": "BAR"}
+        fake_cwd = "/foo/bar"
+        fake_stdout = b"fake_stdout"
+        fake_stderr = b"fake_stderr"
+        with mock.patch("asyncio.create_subprocess_exec") as create_subprocess_exec, \
+             mock.patch("doozerlib.pushd.Dir.getcwd", return_value=fake_cwd):
+            proc = create_subprocess_exec.return_value
+            proc.returncode = 0
+            proc.communicate.return_value = (fake_stdout, fake_stderr)
+
+            rc, out, err = loop.run_until_complete(exectools.cmd_gather_async(cmd, text_mode=True, set_env=env))
+            create_subprocess_exec.assert_called_once_with(*cmd, cwd=fake_cwd, env=env, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, fake_stdout.decode("utf-8"))
+            self.assertEqual(err, fake_stderr.decode("utf-8"))
+
+            create_subprocess_exec.reset_mock()
+            rc, out, err = loop.run_until_complete(exectools.cmd_gather_async(cmd, text_mode=False, set_env=env))
+            create_subprocess_exec.assert_called_once_with(*cmd, cwd=fake_cwd, env=env, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, fake_stdout)
+            self.assertEqual(err, fake_stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…is in the AWS bucket

Example 1: Validate the latest nightly in an image stream

```sh
$ doozer release:validate-rhcos --is-name=4.6-art-latest --is-namespace=ocp
2020-09-24 09:00:53,810 INFO Initial execution (cwd) directory: /workspaces/doozer
2020-09-24 09:00:53,810 INFO Getting latest nightly...
2020-09-24 09:01:03,682 INFO Determining build ID for RHCOS pullspec quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b973b2f9e432b12388874a9c8d191e699106bcbf12d962c729b4e16307dbd83f...
2020-09-24 09:01:06,514 INFO Pullspec quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b973b2f9e432b12388874a9c8d191e699106bcbf12d962c729b4e16307dbd83f is version 46.82.202009222340-0, arch x86_64. Fetching metadata from the AWS bucket...
Passed all validations.
```

Example 2: Validate given release images

```sh
$ doozer release:validate-rhcos registry.svc.ci.openshift.org/ocp/release:4.6.0-0.nightly-2020-09-24-074159 registry.svc.ci.openshift.org/ocp-s390x/release-s390x:4.6.0-0.nightly-s390x-2020-09-24-065929

2020-09-24 08:55:23,242 INFO Initial execution (cwd) directory: /workspaces/doozer
2020-09-24 08:55:23,242 INFO Validating RHCOS images in 2 release pullspecs...
2020-09-24 08:55:23,243 INFO Validating release registry.svc.ci.openshift.org/ocp/release:4.6.0-0.nightly-2020-09-24-074159...
2020-09-24 08:55:23,246 INFO Validating release registry.svc.ci.openshift.org/ocp-s390x/release-s390x:4.6.0-0.nightly-s390x-2020-09-24-065929...
2020-09-24 08:55:30,019 INFO Determining build ID for RHCOS pullspec quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:66a2114e5c0ba858efca2c878246e75c58f360dc68af7301406acb6358f1a57c...
2020-09-24 08:55:30,042 INFO Determining build ID for RHCOS pullspec quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b973b2f9e432b12388874a9c8d191e699106bcbf12d962c729b4e16307dbd83f...
2020-09-24 08:55:32,650 INFO Pullspec quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b973b2f9e432b12388874a9c8d191e699106bcbf12d962c729b4e16307dbd83f is version 46.82.202009222340-0, arch x86_64. Fetching metadata from AWS bucket...
2020-09-24 08:55:33,036 INFO Pullspec quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:66a2114e5c0ba858efca2c878246e75c58f360dc68af7301406acb6358f1a57c is version 46.82.202009222339-0, arch s390x. Fetching metadata from AWS bucket...
Passed all validations.
```

Example 3: You will get this error if you test against 4.2:

``` sh
$ doozer release:validate-rhcos registry.svc.ci.openshift.org/ocp/release:4.2.0-0.nightly-2020-09-21-1905532020-09-24 10:27:47,146 INFO Initial execution (cwd) directory: /workspaces/doozer
2020-09-24 10:27:47,146 INFO Validating RHCOS images in 1 release pullspecs...
2020-09-24 10:27:47,146 INFO Validating release registry.svc.ci.openshift.org/ocp/release:4.2.0-0.nightly-2020-09-21-190553...
2020-09-24 10:27:55,101 INFO Determining build ID for RHCOS pullspec quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:17135995717b384bef7ba50c6dad5cf89cc810daea654299ab9f894c7d9c41d1...
2020-09-24 10:27:58,330 INFO Pullspec quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:17135995717b384bef7ba50c6dad5cf89cc810daea654299ab9f894c7d9c41d1 is version 42.81.20200919.0, arch x86_64. Fetching metadata from the AWS bucket...
RHCOS in registry.svc.ci.openshift.org/ocp/release:4.2.0-0.nightly-2020-09-21-190553 is not in the AWS bucket.
```