### PR TITLE
Add get_brew_buildinfo back

### DIFF
--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -685,6 +685,14 @@ class OperatorMetadataBuilder(object):
     def get_operator(self):
         return self.runtime.image_map[self.operator_name]
 
+    @log
+    def get_brew_buildinfo(self):
+        """Output of this command is used to extract the operator name and its commit hash
+        """
+        cmd = 'brew buildinfo {}'.format(self.nvr)
+        stdout, stderr = exectools.cmd_assert(cmd, retries=3)
+        return 0, stdout, stderr  # In this used to be cmd_gather, so return rc=0.
+
     def get_csv(self):
         return yaml.safe_load(io.open(self.metadata_csv_yaml_filename(), encoding="utf-8"))['metadata']['name']
 

--- a/tests/test_operator_metadata.py
+++ b/tests/test_operator_metadata.py
@@ -1115,6 +1115,18 @@ other:
             'my.registry.svc:5000'
         )
 
+    def test_get_brew_buildinfo(self):
+        nvr = 'my-operator-container-v0.1.2-201901010000'
+        stream = '...irrelevant...'
+        runtime = '...irrelevant...'
+
+        (flexmock(operator_metadata.exectools)
+            .should_receive('cmd_assert')
+            .with_args('brew buildinfo {}'.format(nvr), retries=3)
+            .replace_with(lambda *_, **kwargs: ('...irrelevant...', '...irrelevant...')))
+
+        operator_metadata.OperatorMetadataBuilder(nvr, stream, runtime).get_brew_buildinfo()
+
 
 class TestOperatorMetadataLatestBuildReporter(unittest.TestCase):
     def test_get_latest_build(self):


### PR DESCRIPTION
This method is called by getattr(self, 'get_{}'.format(attr))()