### PR TITLE
cmd_assert's on_retry receives string/list, not function

### DIFF
--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -131,20 +131,10 @@ class OperatorMetadataBuilder(object):
         cmd += '--user {} '.format(self.rhpkg_user) if self.rhpkg_user else ''
         cmd += 'clone containers/{} --branch {}'.format(repo, branch)
 
-        def delete_repo():
-            self.delete_repo(repo)
+        delete_repo = 'rm -rf {}/{}'.format(self.working_dir, repo)
 
         with pushd.Dir(self.working_dir):
             exectools.cmd_assert(cmd, retries=3, on_retry=delete_repo)
-
-    @log
-    def delete_repo(self, repo):
-        """Delete repository from working_dir. Ignore errors if repo is already absent
-        """
-        try:
-            shutil.rmtree('{}/{}'.format(self.working_dir, repo))
-        except OSError:
-            pass
 
     @log
     def checkout_repo(self, repo, commit_hash):


### PR DESCRIPTION
https://github.com/openshift/doozer/blob/master/doozerlib/exectools.py#L82

This PR addresses the following error that eventually happens in the appregistry job:
```
AttributeError: 'function' object has no attribute 'read'
```
Example: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fappregistry/7143/console