### PR TITLE
[ART-2194] sync consistency

### DIFF
--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -184,6 +184,18 @@ def list_image_rpms(image_ids: List[int], session: koji.ClientSession) -> List[O
     return [task.result for task in tasks]
 
 
+def list_build_rpms(build_ids: List[int], session: koji.ClientSession) -> List[Optional[List[Dict]]]:
+    """ Retrieve RPMs in given package builds (not images)
+    :param build_ids: list of build IDs
+    :param session: instance of Brew session
+    :return: a list of Koji/Brew RPM lists
+    """
+    tasks = []
+    with session.multicall(strict=True) as m:
+        tasks = [m.listBuildRPMs(build) for build in build_ids]
+    return [task.result for task in tasks]
+
+
 # Map that records the most recent change for a tag.
 # Maps tag_id to a list containing the most recent change
 # event returned by koji's tagHistory API.

--- a/doozerlib/build_status_detector.py
+++ b/doozerlib/build_status_detector.py
@@ -6,11 +6,11 @@ from koji import ClientSession
 from doozerlib import brew
 
 
-class EmbargoDetector:
-    """ an EmbargoDetector can find builds with embargoed fixes
+class BuildStatusDetector:
+    """ a BuildStatusDetector can find builds with embargoed fixes
     """
     def __init__(self, session: ClientSession, logger: Optional[Logger] = None):
-        """ creates a new EmbargoDetector
+        """ creates a new BuildStatusDetector
         :param session: a koji client session
         :param logger: a logger
         """

--- a/doozerlib/cli/detect_embargo.py
+++ b/doozerlib/cli/detect_embargo.py
@@ -7,7 +7,8 @@ from urllib.parse import urlparse
 import click
 import yaml
 
-from doozerlib import Runtime, brew, embargo_detector, exectools
+from doozerlib import Runtime, brew, exectools
+from doozerlib import build_status_detector as bs_detector
 from doozerlib.cli import cli, pass_runtime
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.util import green_print
@@ -135,7 +136,7 @@ def detect_embargoes_in_nvrs(runtime: Runtime, nvrs: List[str]):
         if not b:
             raise DoozerFatalError(f"Unable to get {nvrs[i]} from Brew.")
     runtime.logger.info(f"Detecting embargoes for {len(nvrs)} builds...")
-    detector = embargo_detector.EmbargoDetector(brew_session, runtime.logger)
+    detector = bs_detector.BuildStatusDetector(brew_session, runtime.logger)
     embargoed_build_ids = detector.find_embargoed_builds(builds)
     embargoed_builds = [b for b in builds if b["id"] in embargoed_build_ids]
     return embargoed_builds
@@ -162,9 +163,9 @@ def detect_embargoes_in_tags(runtime: Runtime, kind: str, included_tags: List[st
         runtime.logger.info(f"Excluded {len(included_builds) - len(builds)} builds that are also tagged into {excluded_tags}.")
         included_builds = builds
 
-    # Builds may have duplicate entries if we query from multiple tags. Don't worry, EmbargoDetector is smart.
+    # Builds may have duplicate entries if we query from multiple tags. Don't worry, BuildStatusDetector is smart.
     runtime.logger.info(f"Detecting embargoes for {len(included_builds)} builds...")
-    detector = embargo_detector.EmbargoDetector(brew_session, runtime.logger)
+    detector = bs_detector.BuildStatusDetector(brew_session, runtime.logger)
     embargoed_build_ids = detector.find_embargoed_builds(included_builds)
     embargoed_builds = [b for b in included_builds if b["id"] in embargoed_build_ids]
     return embargoed_builds

--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -12,7 +12,7 @@ from dockerfile_parse import DockerfileParser
 from doozerlib.model import Missing
 from doozerlib.pushd import Dir
 from doozerlib.cli import cli, pass_runtime
-from doozerlib import brew, state, exectools, embargo_detector
+from doozerlib import brew, state, exectools
 from doozerlib.util import get_docker_config_json, convert_remote_git_to_ssh, \
     split_git_url, remove_prefix, green_print,\
     yellow_print, red_print, convert_remote_git_to_https, \

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -8,7 +8,8 @@ import koji
 import yaml
 import json
 
-from doozerlib import brew, state, exectools, embargo_detector, rhcos
+from doozerlib import brew, state, exectools, rhcos
+from doozerlib import build_status_detector as bs_detector
 from doozerlib.cli import cli, pass_runtime
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
@@ -175,8 +176,8 @@ class PayloadGenerator:
             # when public_upstreams are not configured, we assume there is no private content.
             return
 
-        # store RPM archives to EmbargoDetector cache to limit Brew queries
-        detector = embargo_detector.EmbargoDetector(self.brew_session, self.runtime.logger)
+        # store RPM archives to BuildStatusDetector cache to limit Brew queries
+        detector = bs_detector.BuildStatusDetector(self.brew_session, self.runtime.logger)
         for r in latest_builds:
             detector.archive_lists[r.build["id"]] = r.archives
 

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -67,193 +67,350 @@ is used automatically as a stand-in for images when an arch does not build
 that particular tag.
     """
     runtime.initialize(clone_distgits=False, config_excludes='non_release')
-    orgrepo = "{}/{}".format(organization, repository)
-    cmd = runtime.command
-    runtime.state[cmd] = dict(state.TEMPLATE_IMAGE)
-    lstate = runtime.state[cmd]  # get local convenience copy
-
-    if not is_name:
-        is_name = default_is_base_name(runtime.get_minor_version())
-    if not is_namespace:
-        is_namespace = default_is_base_namespace()
-
-    images = [i for i in runtime.image_metas()]
-    lstate['total'] = len(images)
-
-    no_build_items = []
-    invalid_name_items = []
-
-    payload_images = []
-    for image in images:
-        # Per clayton:
-        """Tim Bielawa: note to self: is only for `ose-` prefixed images
-        Clayton Coleman: Yes, Get with the naming system or get out of town
-        """
-        if image.is_payload:
-            if not image.image_name_short.startswith("ose-"):
-                invalid_name_items.append(image.image_name_short)
-                red_print("NOT adding to IS (does not meet name/version conventions): {}".format(image.image_name_short))
-                continue
-            else:
-                payload_images.append(image)
-
-    runtime.logger.info("Fetching latest image builds from Brew...")
-    tag_component_tuples = [(image.candidate_brew_tag(), image.get_component_name()) for image in payload_images]
     brew_session = runtime.build_retrying_koji_client()
-    latest_builds = brew.get_latest_builds(tag_component_tuples, "image", event_id, brew_session)
-    latest_builds = [builds[0] if builds else None for builds in latest_builds]  # flatten the data structure
+    base_target = SyncTarget(  # where we will mirror and record the tags
+        orgrepo=f"{organization}/{repository}",
+        istream_name=is_name if is_name else default_is_base_name(runtime.get_minor_version()),
+        istream_namespace=is_namespace if is_namespace else default_is_base_namespace()
+    )
 
-    runtime.logger.info("Fetching image archives...")
-    build_ids = [b["id"] if b else 0 for b in latest_builds]
-    archives_list = brew.list_archives_by_builds(build_ids, "image", brew_session)
-
-    mismatched_siblings = find_mismatched_siblings(payload_images, latest_builds, archives_list, runtime.logger, lstate)
-
-    embargoed_build_ids = set()  # a set of private image build ids
-    if runtime.group_config.public_upstreams:
-        # looking for embargoed image builds
-        detector = embargo_detector.EmbargoDetector(brew_session, runtime.logger)
-        for index, archive_list in enumerate(archives_list):
-            if build_ids[index]:
-                detector.archive_lists[build_ids[index]] = archive_list  # store to EmbargoDetector cache to limit Brew queries
-        suspects = [b for b in latest_builds if b]
-        embargoed_build_ids = detector.find_embargoed_builds(suspects)
-
-    runtime.logger.info("Creating mirroring lists...")
-
-    # These will map[arch] -> map[image_name] -> { version: version, release: release, image_src: image_src }
-    mirroring = {}
-    for i, image in enumerate(payload_images):
-        latest_build = latest_builds[i]
-        archives = archives_list[i]
-        error = None
-        if image.distgit_key in mismatched_siblings:
-            error = "Siblings built from different commits"
-        elif not (latest_build and archives):  # build or archive doesn't exist
-            error = f"Unable to find build for: {image.image_name_short}"
-            no_build_items.append(image.image_name_short)
-        else:
-            for archive in archives:
-                arch = archive["arch"]
-                pullspecs = archive["extra"]["docker"]["repositories"]
-                if not pullspecs or ":" not in pullspecs[-1]:  # in case of no pullspecs or invalid format
-                    error = f"Unable to find pullspecs for: {image.image_name_short}"
-                    red_print(error, file=sys.stderr)
-                    state.record_image_fail(lstate, image, error, runtime.logger)
-                    break
-                # The tag that will be used in the imagestreams
-                tag_name = image.image_name_short
-                tag_name = tag_name[4:] if tag_name.startswith("ose-") else tag_name  # it _should_ but... to be safe
-                digest = archive["extra"]['docker']['digests']['application/vnd.docker.distribution.manifest.v2+json']
-                if not digest.startswith("sha256:"):  # It should start with sha256: for now. Let's raise an error if this changes.
-                    raise ValueError(f"Received unrecognized digest {digest} for image {pullspecs[-1]}")
-                mirroring_value = {'version': latest_build["version"], 'release': latest_build["release"], 'image_src': pullspecs[-1], 'digest': digest}
-                embargoed = latest_build["id"] in embargoed_build_ids  # when public_upstreams are not configured, this is always false
-                if not embargoed:  # exclude embargoed images from the ocp[-arch] imagestreams
-                    runtime.logger.info(f"Adding {arch} image {pullspecs[-1]} to the public mirroring list with imagestream tag {tag_name}...")
-                    mirroring.setdefault(arch, {})[tag_name] = mirroring_value
-                else:
-                    red_print(f"Found embargoed image {pullspecs[-1]}")
-                if runtime.group_config.public_upstreams:
-                    # when public_upstreams are configured, both embargoed and non-embargoed images should be included in the ocp[-arch]-priv imagestreams
-                    runtime.logger.info(f"Adding {arch} image {pullspecs[-1]} to the private mirroring list with imagestream tag {tag_name}...")
-                    mirroring.setdefault(f"{arch}-priv", {})[tag_name] = mirroring_value
-        if not error:
-            state.record_image_success(lstate, image)
-        else:
-            red_print(error, file=sys.stderr)
-            state.record_image_fail(lstate, image, error, runtime.logger)
-
-    for key in mirroring:
-        private = key.endswith("-priv")
-        arch = key[:-5] if private else key  # strip `-priv` suffix
-
-        mirror_filename = 'src_dest.{}'.format(key)
-        imagestream_filename = 'image_stream.{}'.format(key)
-        target_is_name, target_is_namespace = is_name_and_space(is_name, is_namespace, arch, private)
-
-        def build_dest_name(tag_name):
-            entry = mirroring[key][tag_name]
-            tag = entry["digest"].replace(":", "-")  # sha256:abcdef -> sha256-abcdef
-            return f"quay.io/{orgrepo}:{tag}"
-
-        # Save the default SRC=DEST 'oc image mirror' input to a file for
-        # later.
-        with io.open(mirror_filename, 'w+', encoding="utf-8") as out_file:
-            for tag_name in mirroring[key]:
-                dest = build_dest_name(tag_name)
-                out_file.write("{}={}\n".format(mirroring[key][tag_name]['image_src'], dest))
-
-        with io.open("{}.yaml".format(imagestream_filename), 'w+', encoding="utf-8") as out_file:
-            # Add a tag spec to the image stream. The name of each tag
-            # spec does not include the 'ose-' prefix. This keeps them
-            # consistent between OKD and OCP
-
-            # Template Base Image Stream object.
-            tag_list = []
-            isb = {
-                'kind': 'ImageStream',
-                'apiVersion': 'image.openshift.io/v1',
-                'metadata': {
-                    'name': target_is_name,
-                    'namespace': target_is_namespace,
-                },
-                'spec': {
-                    'tags': tag_list,
-                }
-            }
-
-            for tag_name in mirroring[key]:
-                tag_list.append({
-                    'name': tag_name,
-                    'from': {
-                        'kind': 'DockerImage',
-                        'name': build_dest_name(tag_name)
-                    }
-                })
-
-            # mirroring rhcos
-            runtime.logger.info(f"Getting latest RHCOS pullspec for {target_is_name}...")
-            mosc_istag = _latest_mosc_istag(runtime, arch, private)
-            if mosc_istag:
-                tag_list.append(mosc_istag)
-
-            # Not all images are built for non-x86 arches (e.g. kuryr), but they
-            # may be mentioned in image references. Thus, make sure there is a tag
-            # for every tag we find in x86_64 and provide just a dummy image.
-            if 'cli' not in mirroring[key]:  # `cli` serves as the dummy image for the replacement
-                if runtime.group_config.public_upstreams and not private:  # If cli is embargoed, it is expected that cli is missing in any non *-priv imagestreams.
-                    runtime.logger.warning(f"Unable to find cli tag from {key} imagestream. Is `cli` image embargoed?")
-                else:  # if CVE embargoes supporting is disabled or the "cli" image is also missing in *-priv namespaces, an error will be raised.
-                    raise DoozerFatalError('A dummy image is required for tag {} on arch {}, but unable to find cli tag for this arch'.format(tag_name, arch))
-            else:
-                extra_tags = mirroring['x86_64-priv' if private else 'x86_64'].keys() - mirroring[key].keys()
-                for tag_name in extra_tags:
-                    yellow_print('Unable to find tag {} for arch {} ; substituting cli image'.format(tag_name, arch))
-                    tag_list.append({
-                        'name': tag_name,
-                        'from': {
-                            'kind': 'DockerImage',
-                            'name': build_dest_name('cli')  # cli is always built and is harmless
-                        }
-                    })
-
-            yaml.safe_dump(isb, out_file, indent=2, default_flow_style=False)
-
-    if no_build_items:
-        yellow_print("No builds found for:")
-        for img in sorted(no_build_items):
-            click.echo("   {}".format(img))
+    gen = PayloadGenerator(runtime, brew_session, event_id, base_target)
+    latest_builds, invalid_name_items, images_missing_builds, mismatched_siblings = gen.load_latest_builds()
+    gen.write_mirror_destinations(latest_builds, mismatched_siblings)
 
     if invalid_name_items:
         yellow_print("Images skipped due to invalid naming:")
         for img in sorted(invalid_name_items):
             click.echo("   {}".format(img))
 
+    if images_missing_builds:
+        yellow_print("No builds found for:")
+        for img in sorted(images_missing_builds):
+            click.echo("   {}".format(img))
+
     if mismatched_siblings:
         yellow_print("Images skipped due to siblings mismatch:")
-        for img in sorted(invalid_name_items):
+        for img in sorted(mismatched_siblings):
             click.echo("   {}".format(img))
+
+
+class PayloadGenerator:
+
+    def __init__(self, runtime, brew_session, brew_event, base_target):
+        self.runtime = runtime
+        self.brew_session = brew_session
+        self.brew_event = brew_event
+        self.base_target = base_target
+        self.state = runtime.state[runtime.command] = dict(state.TEMPLATE_IMAGE)
+
+    def load_latest_builds(self):
+        images = list(self.runtime.image_metas())
+        self.state['total_images'] = len(images)
+
+        self.runtime.logger.info("Fetching latest image builds from Brew...")
+        payload_images, invalid_name_items = self._get_payload_images(images)
+        self.state['payload_images'] = len(payload_images)
+        latest_builds, images_missing_builds = self._get_latest_builds(payload_images)
+        self._designate_privacy(latest_builds)
+        mismatched_siblings = self._find_mismatched_siblings(latest_builds)
+
+        return latest_builds, invalid_name_items, images_missing_builds, mismatched_siblings
+
+    def _get_payload_images(self, images):
+        # images is a list of image metadata - pick out payload images
+        payload_images = []
+        invalid_name_items = []
+        for image in images:
+            if image.is_payload:
+                """
+                <Tim Bielawa> note to self: is only for `ose-` prefixed images
+                <Clayton Coleman> Yes, Get with the naming system or get out of town
+                """
+                if image.image_name_short.startswith("ose-"):
+                    payload_images.append(image)
+                    continue
+
+                invalid_name_items.append(image.image_name_short)
+                red_print(f"NOT adding to IS (does not meet name/version conventions): {image.image_name_short}")
+
+        return payload_images, invalid_name_items
+
+    def _get_latest_builds(self, payload_images):
+        """
+        find latest brew build (at event, if given) of each payload image.
+        :param payload_images: a list of image metadata for payload images
+        :return: list of build records, list of images missing builds
+        """
+        tag_component_tuples = [(image.candidate_brew_tag(), image.get_component_name()) for image in payload_images]
+        brew_latest_builds = brew.get_latest_builds(tag_component_tuples, "image", self.brew_event, self.brew_session)
+        # there's zero or one "latest" build in each list; flatten the data structure.
+        brew_latest_builds = [builds[0] if builds else {} for builds in brew_latest_builds]
+
+        # look up the archives for each image (to get the RPMs that went into them)
+        brew_build_ids = [b["id"] if b else 0 for b in brew_latest_builds]
+        archives_list = brew.list_archives_by_builds(brew_build_ids, "image", self.brew_session)
+
+        # at this point payload_images, brew_latest_builds, and archives_list should be matching lists;
+        # combine them into dict build records.
+        latest_builds, missing_images = [], []
+        for image, build, archives in zip(payload_images, brew_latest_builds, archives_list):
+            if build and archives:
+                latest_builds.append(BuildRecord(image, build, archives))
+            else:
+                missing_images.append(image)
+                state.record_image_fail(self.state, image, f"Unable to find build for: {image.image_name_short}", self.runtime.logger)
+
+        self.state["builds_missing"] = len(missing_images)
+        self.state["builds_found"] = len(latest_builds)
+        return latest_builds, missing_images
+
+    def _designate_privacy(self, latest_builds):
+        """
+        For a list of build records, determine if they have private contents. If
+        so, then set "private" to True for that build record. This is done for a
+        whole set of builds since we have to look up parents and we would like to
+        cache those lookups.
+        """
+        if not self.runtime.group_config.public_upstreams:
+            # when public_upstreams are not configured, we assume there is no private content.
+            return
+
+        # store RPM archives to EmbargoDetector cache to limit Brew queries
+        detector = embargo_detector.EmbargoDetector(self.brew_session, self.runtime.logger)
+        for r in latest_builds:
+            detector.archive_lists[r.build["id"]] = r.archives
+
+        # determine if each image build is embargoed (or otherwise "private")
+        embargoed_build_ids = detector.find_embargoed_builds([r.build for r in latest_builds])
+        for r in latest_builds:
+            if r.build["id"] in embargoed_build_ids:
+                r.private = True
+
+    def write_mirror_destinations(self, latest_builds, mismatched_siblings):
+        self.runtime.logger.info("Creating mirroring lists...")
+
+        # returns map[arch] -> map[image_name] -> { version: version, release: release, image_src: image_src }
+        mirror_src_for_arch_and_name = self._get_mirror_sources(latest_builds, mismatched_siblings)
+
+        for dest, source_for_name in mirror_src_for_arch_and_name.items():
+            private = dest.endswith("-priv")
+            arch = dest[:-5] if private else dest  # strip `-priv` suffix
+
+            # Save the default SRC=DEST input to a file for syncing by 'oc image mirror'
+            with io.open(f"src_dest.{dest}", "w+", encoding="utf-8") as out_file:
+                for source in source_for_name.values():
+                    mirror_dest = self._build_dest_name(source, self.base_target.orgrepo)
+                    out_file.write(f"{source['image_src']}={mirror_dest}\n")
+
+            # build the local tag target from the base
+            name, namespace = is_name_and_space(
+                self.base_target.istream_name,
+                self.base_target.istream_namespace,
+                arch, private)
+            target = SyncTarget(self.base_target.orgrepo, name, namespace)
+            with io.open(f"image_stream.{dest}.yaml", "w+", encoding="utf-8") as out_file:
+                x86_source_for_name = mirror_src_for_arch_and_name['x86_64-priv' if private else 'x86_64']
+                istag_spec = self._get_istag_spec(arch, private, target, source_for_name, x86_source_for_name)
+                yaml.safe_dump(istag_spec, out_file, indent=2, default_flow_style=False)
+
+    def _get_mirror_sources(self, latest_builds, mismatched_siblings):
+        """
+        Determine the image sources to mirror to each arch-private-specific imagestream,
+        excluding mismatched siblings; also record success/failure per state.
+
+        :return: map[arch] -> map[image_name] -> { version: version, release: release, image_src: image_src }
+        """
+        mirroring = {}
+        for record in latest_builds:
+            image = record.image
+            error = None
+            if image.distgit_key in mismatched_siblings:
+                error = "Siblings built from different commits"
+            else:
+                for archive in record.archives:
+                    arch = archive["arch"]
+                    pullspecs = archive["extra"]["docker"]["repositories"]
+                    if not pullspecs or ":" not in pullspecs[-1]:  # in case of no pullspecs or invalid format
+                        error = f"Unable to find pullspecs for: {image.image_name_short}"
+                        red_print(error)
+                        state.record_image_fail(self.state, image, error, self.runtime.logger)
+                        continue
+                    # The tag that will be used in the imagestreams
+                    tag_name = image.image_name_short
+                    tag_name = tag_name[4:] if tag_name.startswith("ose-") else tag_name  # it _should_ but... to be safe
+                    digest = archive["extra"]['docker']['digests']['application/vnd.docker.distribution.manifest.v2+json']
+                    if not digest.startswith("sha256:"):  # It should start with sha256: for now. Let's raise an error if this changes.
+                        raise ValueError(f"Received unrecognized digest {digest} for image {pullspecs[-1]}")
+
+                    mirroring_value = dict(
+                        version=record.build["version"],
+                        release=record.build["release"],
+                        image_src=pullspecs[-1],
+                        digest=digest
+                    )
+
+                    if record.private:  # exclude embargoed images from the ocp[-arch] imagestreams
+                        yellow_print(f"Omitting embargoed image {pullspecs[-1]}")
+                    else:
+                        self.runtime.logger.info(f"Adding {arch} image {pullspecs[-1]} to the public mirroring list with imagestream tag {tag_name}...")
+                        mirroring.setdefault(arch, {})[tag_name] = mirroring_value
+
+                    if self.runtime.group_config.public_upstreams:
+                        # when public_upstreams are configured, both embargoed and non-embargoed images should be included in the ocp[-arch]-priv imagestreams
+                        self.runtime.logger.info(f"Adding {arch} image {pullspecs[-1]} to the private mirroring list with imagestream tag {tag_name}...")
+                        mirroring.setdefault(f"{arch}-priv", {})[tag_name] = mirroring_value
+
+            # per build, record in the state whether we can successfully mirror it
+            if error:
+                red_print(error)
+                state.record_image_fail(self.state, image, error, self.runtime.logger)
+            else:
+                state.record_image_success(self.state, image)
+
+        return mirroring
+
+    @staticmethod
+    def _build_dest_name(source, orgrepo):
+        tag = source["digest"].replace(":", "-")  # sha256:abcdef -> sha256-abcdef
+        return f"quay.io/{orgrepo}:{tag}"
+
+    def _get_istag_spec(self, arch, private, target, source_for_name, x86_source_for_name):
+        # Write tag specs for the image stream. The name of each tag
+        # spec does not include the 'ose-' prefix. This keeps them
+        # consistent between OKD and OCP.
+
+        # Template Base Image Stream object.
+        tag_list = []
+        istag_spec = {
+            'kind': 'ImageStream',
+            'apiVersion': 'image.openshift.io/v1',
+            'metadata': {
+                'name': target.istream_name,
+                'namespace': target.istream_namespace,
+            },
+            'spec': {
+                'tags': tag_list,
+            }
+        }
+
+        for tag_name, source in source_for_name.items():
+            tag_list.append({
+                'name': tag_name,
+                'from': {
+                    'kind': 'DockerImage',
+                    'name': self._build_dest_name(source, target.orgrepo)
+                }
+            })
+
+        # mirroring rhcos
+        self.runtime.logger.info(f"Getting latest RHCOS pullspec for {target.istream_name}...")
+        mosc_istag = self._latest_mosc_istag(arch, private)
+        if mosc_istag:
+            tag_list.append(mosc_istag)
+
+        tag_list.extend(self._extra_dummy_tags(arch, private, source_for_name, x86_source_for_name, target))
+
+        return istag_spec
+
+    def _extra_dummy_tags(self, arch, private, source_for_name, x86_source_for_name, target):
+        """
+        For non-x86 arches, not all images are built (e.g. kuryr), but they may
+        be mentioned in CVO image references. Thus, make sure there is a tag for
+        every tag we find in x86_64 and provide a dummy image to stand in if needed.
+
+        :return: a list of tag specs for the payload images not built in this arch.
+        """
+        tag_list = []
+        if 'cli' in source_for_name:  # `cli` serves as the dummy image for the replacement
+            extra_tags = x86_source_for_name.keys() - source_for_name.keys()
+            for tag_name in extra_tags:
+                yellow_print('Unable to find tag {} for arch {} ; substituting cli image'.format(tag_name, arch))
+                tag_list.append({
+                    'name': tag_name,
+                    'from': {
+                        'kind': 'DockerImage',
+                        'name': self._build_dest_name(source_for_name['cli'], target.orgrepo)
+                    }
+                })
+        elif self.runtime.group_config.public_upstreams and not private:
+            # If cli is embargoed, it is expected that cli is missing in any non *-priv imagestreams.
+            self.runtime.logger.warning(f"Unable to find cli tag from {arch} imagestream. Is `cli` image embargoed?")
+        else:
+            # if CVE embargoes supporting is disabled or the "cli" image is also
+            # missing in *-priv namespaces, an error will be raised.
+            raise DoozerFatalError('A dummy image is required for tag {} on arch {}, but unable to find cli tag for this arch'.format(tag_name, arch))
+
+        return tag_list
+
+    def _latest_mosc_istag(self, arch, private):
+        try:
+            version = self.runtime.get_minor_version()
+            _, pullspec = rhcos.latest_machine_os_content(version, arch, private)
+            if not pullspec:
+                yellow_print(f"No RHCOS found for {version} arch={arch} private={private}")
+                return None
+        except Exception as ex:
+            yellow_print(f"error finding RHCOS: {ex}")
+            return None
+
+        return {
+            'name': "machine-os-content",
+            'from': {
+                'kind': 'DockerImage',
+                'name': pullspec
+            }
+        }
+
+    def _find_mismatched_siblings(self, builds):
+        """ Sibling images are those built from the same repository. We need to throw an error if there are sibling built from different commit.
+        """
+        # First, loop over all builds and store their source repos and commits to a dict
+        repo_commit_nvrs = {}  # key is source repo url, value is another dict that key is commit hash and value is a set of nvrs.
+        # Second, build a dict with keys are NVRs and values are the ImageMetadata objects. ImageMetadatas are used for logging state.
+        nvr_images = {}
+
+        for record in builds:
+            # source repo url and commit hash are stored in image's environment variables.
+            ar = record.archives[0]  # the build is a manifest list, let's look at the first architecture
+            envs = ar["extra"]["docker"]["config"]["config"].get("Env", [])
+            source_repo_entry = list(filter(lambda env: env.startswith("SOURCE_GIT_URL="), envs))
+            source_commit_entry = list(filter(lambda env: env.startswith("SOURCE_GIT_COMMIT="), envs))
+            if not source_repo_entry or not source_commit_entry:
+                continue  # this image doesn't have required environment variables. is it a dist-git only image?
+            source_repo = source_repo_entry[0][source_repo_entry[0].find("=") + 1:]  # SOURCE_GIT_URL=https://example.com => https://example.com
+            source_commit = source_commit_entry[0][source_commit_entry[0].find("=") + 1:]  # SOURCE_GIT_COMMIT=abc => abc
+            nvrs = repo_commit_nvrs.setdefault(source_repo, {}).setdefault(source_commit, set())
+            nvrs.add(record.build["nvr"])
+            nvr_images[record.build["nvr"]] = record.image
+
+        # Finally, look at the dict and print an error if one repo has 2 or more commits
+        mismatched_siblings = set()
+        for repo, commit_nvrs in repo_commit_nvrs.items():
+            if len(commit_nvrs) >= 2:
+                red_print("The following NVRs are siblings but built from different commits:")
+                for commit, nvrs in commit_nvrs.items():
+                    for nvr in nvrs:
+                        image = nvr_images[nvr]
+                        mismatched_siblings.add(image.distgit_key)
+                        red_print(f"{nvr}\t{image.distgit_key}\t{repo}\t{commit}")
+        return mismatched_siblings
+
+
+class BuildRecord(object):
+
+    def __init__(self, image=None, build=None, archives=None, private=False):
+        self.image = image
+        self.build = build
+        self.archives = archives
+        self.private = private
+
+
+class SyncTarget(object):
+
+    def __init__(self, orgrepo=None, istream_name=None, istream_namespace=None):
+        self.orgrepo = orgrepo
+        self.istream_name = istream_name
+        self.istream_namespace = istream_namespace
 
 
 def default_is_base_name(version):
@@ -270,62 +427,3 @@ def is_name_and_space(base_name, base_namespace, arch, private):
     name = f"{base_name}{arch_suffix}{priv_suffix}"
     namespace = f"{base_namespace}{arch_suffix}{priv_suffix}"
     return name, namespace
-
-
-def _latest_mosc_istag(runtime, arch, private):
-    try:
-        version = runtime.get_minor_version()
-        _, pullspec = rhcos.latest_machine_os_content(version, arch, private)
-        if not pullspec:
-            yellow_print(f"No RHCOS found for {version} arch={arch} private={private}")
-            return None
-    except Exception as ex:
-        yellow_print(f"error finding RHCOS: {ex}")
-        return None
-
-    return {
-        'name': "machine-os-content",
-        'from': {
-            'kind': 'DockerImage',
-            'name': pullspec
-        }
-    }
-
-
-def find_mismatched_siblings(images, builds, archives_list, logger, lstate):
-    """ Sibling images are those built from the same repository. We need to throw an error if there are sibling built from different commit.
-    """
-    # First, loop over all builds and store their source repos and commits to a dict
-    repo_commit_nvrs = {}  # key is source repo url, value is another dict that key is commit hash and value is a set of nvrs.
-    for build, archives in zip(builds, archives_list):
-        if not build or not archives:
-            continue  # the image has no builds yet. should be captured by latter logic.
-        # source repo url and commit hash are stored in image's environment variables.
-        ar = archives[0]  # in case the build is a manifest list, let's look at the first architecture
-        envs = ar["extra"]["docker"]["config"]["config"].get("Env", [])
-        source_repo_entry = list(filter(lambda env: env.startswith("SOURCE_GIT_URL="), envs))
-        source_commit_entry = list(filter(lambda env: env.startswith("SOURCE_GIT_COMMIT="), envs))
-        if not source_repo_entry or not source_commit_entry:
-            continue  # this image doesn't have required environment variables. is it a dist-git only image?
-        source_repo = source_repo_entry[0][source_repo_entry[0].find("=") + 1:]  # SOURCE_GIT_URL=https://example.com => https://example.com
-        source_commit = source_commit_entry[0][source_commit_entry[0].find("=") + 1:]  # SOURCE_GIT_COMMIT=abc => abc
-        nvrs = repo_commit_nvrs.setdefault(source_repo, {}).setdefault(source_commit, set())
-        nvrs.add(build["nvr"])
-
-    # Second, build a dict with keys are NVRs and values are the ImageMetadata objects. ImageMetadatas are used for logging state.
-    nvr_images = {}
-    for image, build in zip(images, builds):
-        if build:
-            nvr_images[build["nvr"]] = image
-
-    # Finally, look at the dict and print an error if one repo has 2 or more commits
-    mismatched_siblings = set()
-    for repo, commit_nvrs in repo_commit_nvrs.items():
-        if len(commit_nvrs) >= 2:
-            red_print("The following NVRs are siblings but built from different commits:", file=sys.stderr)
-            for commit, nvrs in commit_nvrs.items():
-                for nvr in nvrs:
-                    image = nvr_images[nvr]
-                    mismatched_siblings.add(image.distgit_key)
-                    red_print(f"{nvr}\t{image.distgit_key}\t{repo}\t{commit}")
-    return mismatched_siblings

--- a/tests/cli/test_detect_embargo.py
+++ b/tests/cli/test_detect_embargo.py
@@ -17,7 +17,7 @@ class TestDetectEmbargoCli(TestCase):
         nvrs = [b["nvr"] for b in builds]
         expected = [builds[1]]
         with patch("doozerlib.brew.get_build_objects", return_value=builds), \
-             patch("doozerlib.embargo_detector.EmbargoDetector.find_embargoed_builds", return_value=[2]):
+             patch("doozerlib.build_status_detector.BuildStatusDetector.find_embargoed_builds", return_value=[2]):
             actual = detect_embargo.detect_embargoes_in_nvrs(MagicMock(), nvrs)
         self.assertListEqual(actual, expected)
 
@@ -37,7 +37,7 @@ class TestDetectEmbargoCli(TestCase):
         expected = [b for builds in included_builds for b in builds if b["id"] in {13, 23}]
         with patch("doozerlib.brew.get_latest_builds", return_value=included_builds), \
              patch("doozerlib.brew.get_tagged_builds", return_value=excluded_builds), \
-             patch("doozerlib.embargo_detector.EmbargoDetector.find_embargoed_builds", return_value=[13, 23]) as find_embargoed_builds:
+             patch("doozerlib.build_status_detector.BuildStatusDetector.find_embargoed_builds", return_value=[13, 23]) as find_embargoed_builds:
             actual = detect_embargo.detect_embargoes_in_tags(MagicMock(), "all", included_tags, excluded_tags, event_id)
             find_embargoed_builds.assert_called_once_with(builds_to_detect)
         self.assertEqual(actual, expected)

--- a/tests/cli/test_release_gen_payload.py
+++ b/tests/cli/test_release_gen_payload.py
@@ -1,0 +1,82 @@
+import json
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from doozerlib.cli import release_gen_payload as rgp
+import doozerlib.runtime
+
+
+def _fake_generator():
+    runtime = MagicMock(doozerlib.runtime)
+    runtime.command = "dummy"
+    runtime.state = {}
+    runtime.logger = MagicMock()
+    return rgp.PayloadGenerator(
+        runtime,
+        brew_session=MagicMock(),
+        brew_event=None,
+        base_target=rgp.SyncTarget(),
+    )
+
+
+class TestReleaseGenPayloadCli(TestCase):
+
+    def test_get_istag_spec(self):
+        gen = _fake_generator()
+        tag_name = "cvo-tag"
+        pullspec = "dummy-pullspec"
+        record = rgp.BuildRecord(image=MagicMock(), archives=None)
+        record.image.candidate_brew_tag.return_value = "tag-candidate"
+        inconsistencies = {"foo is old": "should be foo-new"}
+        expected = {
+            'annotations': {'release.openshift.io/inconsistency': '["foo is old"]'},
+            'name': tag_name,
+            'from': {
+                'kind': 'DockerImage',
+                'name': pullspec
+            }
+        }
+        with patch.object(gen, "_find_rpm_inconsistencies") as find_inc, \
+             patch.object(gen, "_build_dest_name") as bdest:
+            find_inc.return_value = inconsistencies
+            bdest.return_value = pullspec
+            source = dict(build_record=record, archive=None)
+            actual = gen._get_istag_spec(tag_name, source, gen.base_target)
+            self.assertEqual(actual, expected)
+            self.assertEqual({tag_name: ["should be foo-new"]}, gen.state["inconsistencies"])
+
+    def test_find_rpm_inconsistencies(self):
+        archive = dict(
+            build_id=1,
+            rpms=[
+                dict(name="foo", nvr="foo-1.2-1"),
+                dict(name="bar", nvr="bar-3.4-1"),
+            ],
+        )
+        gen = _fake_generator()
+        with patch.object(gen.bs_detector, "find_unshipped_candidate_rpms") as func_rpms:
+            func_rpms.return_value = [
+                dict(name="foo", nvr="foo-1.2-1", build_id=2),
+                dict(name="bar", nvr="bar-3.4-42", build_id=3),
+            ]
+            expected = {
+                "Contains outdated RPM bar":
+                "RPM bar-3.4-1 is installed in image build 1 but bar-3.4-42 from package build 3 is latest candidate"
+            }
+            actual = gen._find_rpm_inconsistencies(archive, "tag-candidate")
+            self.assertEqual(actual, expected)
+
+    def test_inconsistency_annotation(self):
+        entries = ["a", "b", "c", "d", "e"]
+        expected = json.dumps(entries)
+        actual = list(_fake_generator()._inconsistency_annotation(entries).values())[0]
+        self.assertEqual(actual, expected)
+
+        entries.append("f")
+        annotation = list(_fake_generator()._inconsistency_annotation(entries).values())[0]
+        self.assertIn("(...and more)", annotation)
+
+        entries = []
+        expected = {}
+        actual = _fake_generator()._inconsistency_annotation(entries)
+        self.assertEqual(actual, expected)

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -52,22 +52,27 @@ class TestBrew(unittest.TestCase):
 
     def test_list_archives_by_builds(self):
         build_ids = [1, 2, 3, None, 4, 0, 5, None]
+        rpms = [object()]
         expected = [
-            [{"build_id": 1, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 1000000}],
-            [{"build_id": 2, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 2000000}],
-            [{"build_id": 3, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 3000000}],
+            [{"build_id": 1, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 1000000, "rpms": rpms}],
+            [{"build_id": 2, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 2000000, "rpms": rpms}],
+            [{"build_id": 3, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 3000000, "rpms": rpms}],
             None,
-            [{"build_id": 4, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 4000000}],
+            [{"build_id": 4, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 4000000, "rpms": rpms}],
             None,
-            [{"build_id": 5, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 5000000}],
+            [{"build_id": 5, "type_name": "tar", "arch": "x86_64", "btype": "image", "id": 5000000, "rpms": rpms}],
             None,
         ]
 
-        def fake_response(buildID, type):
+        def fake_archives_response(buildID, type):
             return mock.MagicMock(result=[{"build_id": buildID, "type_name": "tar", "arch": "x86_64", "btype": type, "id": buildID * 1000000}])
+
+        def fake_rpms_response(imageID):
+            return mock.MagicMock(result=rpms)
 
         fake_session = mock.MagicMock()
         fake_context_manager = fake_session.multicall.return_value.__enter__.return_value
-        fake_context_manager.listArchives.side_effect = fake_response
+        fake_context_manager.listArchives.side_effect = fake_archives_response
+        fake_context_manager.listRPMs.side_effect = fake_rpms_response
         actual = brew.list_archives_by_builds(build_ids, "image", fake_session)
         self.assertListEqual(actual, expected)

--- a/tests/test_build_status_detector.py
+++ b/tests/test_build_status_detector.py
@@ -1,10 +1,10 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from doozerlib.embargo_detector import EmbargoDetector
+from doozerlib.build_status_detector import BuildStatusDetector
 
 
-class TestEmbargoDetector(TestCase):
+class TestBuildStatusDetector(TestCase):
     def test_find_embargoed_builds(self):
         builds = [
             {"id": 1, "release": "1.p0"},
@@ -36,8 +36,8 @@ class TestEmbargoDetector(TestCase):
 
         with patch("doozerlib.brew.get_builds_tags", return_value=tags), \
              patch("doozerlib.brew.list_image_rpms", return_value=rpm_lists), \
-             patch("doozerlib.embargo_detector.EmbargoDetector.find_shipped_builds", side_effect=lambda builds: {b for b in builds if b in shipped_builds}):
-            detector = EmbargoDetector(MagicMock(), MagicMock())
+             patch("doozerlib.build_status_detector.BuildStatusDetector.find_shipped_builds", side_effect=lambda builds: {b for b in builds if b in shipped_builds}):
+            detector = BuildStatusDetector(MagicMock(), MagicMock())
             detector.archive_lists = archive_lists
             actual = detector.find_embargoed_builds(builds)
             self.assertEqual(actual, expected)
@@ -54,26 +54,26 @@ class TestEmbargoDetector(TestCase):
                 [{"name": "bar-candidate"}, {"name": "bar-released"}, ],
             ]
             expected = {2}
-            actual = EmbargoDetector(MagicMock(), MagicMock()).find_shipped_builds(build_ids)
+            actual = BuildStatusDetector(MagicMock(), MagicMock()).find_shipped_builds(build_ids)
             self.assertEqual(actual, expected)
             get_builds_tags.return_value = [
                 [{"name": "foo-candidate"}, {"name": "bar-released"}],
                 [{"name": "bar-candidate"}, {"name": "bar-released"}, ],
             ]
             expected = {1, 2}
-            actual = EmbargoDetector(MagicMock(), MagicMock()).find_shipped_builds(build_ids)
+            actual = BuildStatusDetector(MagicMock(), MagicMock()).find_shipped_builds(build_ids)
             self.assertEqual(actual, expected)
             get_builds_tags.return_value = [
                 [],
                 [],
             ]
             expected = set()
-            actual = EmbargoDetector(MagicMock(), MagicMock()).find_shipped_builds(build_ids)
+            actual = BuildStatusDetector(MagicMock(), MagicMock()).find_shipped_builds(build_ids)
             self.assertEqual(actual, expected)
             get_builds_tags.return_value = [
                 [{"name": "foo-released"}],
                 [{"name": "bar-candidate"}, {"name": "bar-released"}, ]
             ]
             expected = {1, 2}
-            actual = EmbargoDetector(MagicMock(), MagicMock()).find_shipped_builds(build_ids)
+            actual = BuildStatusDetector(MagicMock(), MagicMock()).find_shipped_builds(build_ids)
             self.assertEqual(actual, expected)

--- a/tests/test_build_status_detector.py
+++ b/tests/test_build_status_detector.py
@@ -20,17 +20,17 @@ class TestBuildStatusDetector(TestCase):
             [{"name": "foo-candidate"}],
             [{"name": "foo-released"}],
         ]
-        archive_lists = {
-            1: [{"build_id": 1, "id": 11}],
-            2: [{"build_id": 2, "id": 21}],
-            3: [{"build_id": 3, "id": 31}],
-            4: [{"build_id": 4, "id": 41}],
-            5: [{"build_id": 5, "id": 51}],
-        }
         rpm_lists = [
             [{"id": 0, "build_id": 101, "release": "101.p1"}],
             [{"id": 1, "build_id": 201, "release": "201.p1"}],
         ]
+        archive_lists = {
+            1: [{"build_id": 1, "id": 11, "rpms": rpm_lists[0]}],
+            2: [{"build_id": 2, "id": 21, "rpms": rpm_lists[1]}],
+            3: [{"build_id": 3, "id": 31, "rpms": []}],
+            4: [{"build_id": 4, "id": 41, "rpms": []}],
+            5: [{"build_id": 5, "id": 51, "rpms": []}],
+        }
         shipped_builds = {3, 5, 101}
         expected = {2, 4}
 


### PR DESCRIPTION
The first commit is a big refactor of release:gen-payload, which should end up working the same at the end.
The second commit is a smaller refactor, really just a renaming of the EmbargoDetector to BuildStatusDetector; again, no change in function.
The remaining commits implement the actual changes for [ART-2194](https://issues.redhat.com/browse/ART-2194).

Example run is [#3 ​OCP ​4.7 ​- ​x86_64, ​ppc64le, ​s390x](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-stage/job/build%252Fbuild-sync/3/) - the failure is with the CI cluster and came after relevant artifacts were created:
* [image_stream.x86_64.yaml.txt](https://github.com/openshift/doozer/files/5398669/202010-inc-image_stream.x86_64.yaml.txt)
* [state.yaml.txt](https://github.com/openshift/doozer/files/5398670/202010-inc-state.yaml.txt)
