### PR TITLE
[ART-2336] Don't rebuild bundle if already exists for given NVR

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -33,10 +33,7 @@ class OLMBundle(object):
         self.operator_nvr = operator_nvr
         self.get_operator_buildinfo()
 
-        builds = brew.get_tagged_builds(tags=[self.target],
-                                        build_type='image',
-                                        event=None,
-                                        session=self.brew_session)[0]
+        builds = self.brew_session.listTagged(tag=self.target, package=self.bundle_brew_component)
         vr = self.operator_nvr.replace(self.operator_brew_component, '')[1:].replace('-', '.', 1)
         bundle_nvrs = [build['nvr'] for build in builds]
         found = list(filter(lambda bundle_nvr: vr in bundle_nvr, bundle_nvrs))

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -33,14 +33,15 @@ class OLMBundle(object):
         self.operator_nvr = operator_nvr
         self.get_operator_buildinfo()
 
-        _rc, out, _err = exectools.cmd_gather(
-            'brew list-builds --quiet --package={}'.format(self.bundle_brew_component)
-        )
-
+        builds = brew.get_tagged_builds(tags=[self.target],
+                                        build_type='image',
+                                        event=None,
+                                        session=self.brew_session)[0]
         vr = self.operator_nvr.replace(self.operator_brew_component, '')[1:].replace('-', '.', 1)
-        bundle_nvrs = [line.split(' ')[0] for line in out.split('\n')]
+        bundle_nvrs = [build['nvr'] for build in builds]
         found = list(filter(lambda bundle_nvr: vr in bundle_nvr, bundle_nvrs))
-        return found[-1].split(' ')[0] if found else None
+        found.sort(reverse=True)
+        return found[0] if found else None
 
     def rebase(self, operator_nvr):
         """Update bundle distgit contents with manifests from given operator NVR

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -35,8 +35,7 @@ class OLMBundle(object):
 
         builds = self.brew_session.listTagged(tag=self.target, package=self.bundle_brew_component)
         vr = self.operator_nvr.replace(self.operator_brew_component, '')[1:].replace('-', '.', 1)
-        bundle_nvrs = [build['nvr'] for build in builds]
-        found = list(filter(lambda bundle_nvr: vr in bundle_nvr, bundle_nvrs))
+        found = list(build for build in builds if vr == build['version'])
         found.sort(reverse=True, key=lambda build: int(build['release']))
         return found[0]['nvr'] if found else None
 

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -37,8 +37,8 @@ class OLMBundle(object):
         vr = self.operator_nvr.replace(self.operator_brew_component, '')[1:].replace('-', '.', 1)
         bundle_nvrs = [build['nvr'] for build in builds]
         found = list(filter(lambda bundle_nvr: vr in bundle_nvr, bundle_nvrs))
-        found.sort(reverse=True)
-        return found[0] if found else None
+        found.sort(reverse=True, key=lambda build: int(build['release']))
+        return found[0]['nvr'] if found else None
 
     def rebase(self, operator_nvr):
         """Update bundle distgit contents with manifests from given operator NVR

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -24,6 +24,24 @@ class OLMBundle(object):
     def __init__(self, runtime):
         self.runtime = runtime
 
+    def find_bundle_for(self, operator_nvr):
+        """Check if a bundle already exists for a given `operator_nvr`.
+
+        :param string operator_nvr: Operator NVR (format: my-operator-v4.2.30-202004200449)
+        :return string: NVR of latest found bundle build, or None.
+        """
+        self.operator_nvr = operator_nvr
+        self.get_operator_buildinfo()
+
+        _rc, out, _err = exectools.cmd_gather(
+            'brew list-builds --quiet --package={}'.format(self.bundle_brew_component)
+        )
+
+        vr = self.operator_nvr.replace(self.operator_brew_component, '')[1:].replace('-', '.', 1)
+        bundle_nvrs = [line.split(' ')[0] for line in out.split('\n')]
+        found = list(filter(lambda bundle_nvr: vr in bundle_nvr, bundle_nvrs))
+        return found[-1].split(' ')[0] if found else None
+
     def rebase(self, operator_nvr):
         """Update bundle distgit contents with manifests from given operator NVR
         Perform image SHA replacement on manifests before commit & push


### PR DESCRIPTION
Tries to solve the following scenario:

> 1. foo-operator-4.6-42 builds
> 2. foo-operator-metadata-4.6.42-1 builds
> 3. foo-operator-4.6-43 builds
> 4. foo-operator-metadata-4.6.43-1 builds
> 5. We decide to ship foo-operator-4.6-42 and attach it to an advisory
> 6. Now we want to attach the corresponding bundles, so we run olm_bundles against the advisory... which does see changes when it rebases back to 4.6-42, and so builds and attaches foo-operator-metadata-4.6.42-2.

Example:
```
$ doozer -g openshift-4.6 olm-bundle:rebase-and-build cluster-logging-operator-container-v4.6.0-202010201329.p0 2>/dev/null
cluster-logging-operator-metadata-container-v4.6.0.202010201329.p0-2
```