### PR TITLE
Archives for 4.7 image contained non-image btypes

### DIFF
--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -335,7 +335,12 @@ class ImageMetadata(Metadata):
             archives = koji_api.listArchives(image_build['id'])
 
             # Compare to the arches in runtime
-            build_arches = {a['extra']['image']['arch'] for a in archives}
+            build_arches = []
+            for a in archives:
+                # When running with cachito, not all archives returned are images. Filter out non-images.
+                if a['btype'] == 'image':
+                    build_arches.append(a['extra']['image']['arch'])
+
             target_arches = set(self.get_arches())
             if target_arches != build_arches:
                 # The latest brew build does not exactly match the required arches as specified in group.yml


### PR DESCRIPTION
I believe these were introduced by cachito testing.

Build:
```
INFO [containers/cluster-node-tuning-operator] Running an change assessment on cluster-node-tuning-operator-container-v4.7.0-9998.p0 built at event 35308575
{'build_id': 1367726,
 'completion_time': '2020-10-28 02:16:32.593668',
 'creation_event_id': 35308575,
 'creation_time': '2020-10-28 01:58:50.926876',
 'epoch': None,
 'id': 1367726,
 'name': 'cluster-node-tuning-operator-container',
 'nvr': 'cluster-node-tuning-operator-container-v4.7.0-9998.p0',
 'owner_id': 4078,
 'owner_name': 'ocp-build/buildvm.openshift.eng.bos.redhat.com',
 'package_id': 70742,
 'package_name': 'cluster-node-tuning-operator-container',
 'release': '9998.p0',
 'start_time': '2020-10-28 01:58:50.922522',
 'state': 1,
 'tag_id': 70115,
 'tag_name': 'rhaos-4.7-rhel-8-candidate',
 'task_id': None,
 'version': 'v4.7.0',
 'volume_id': 0,
 'volume_name': 'DEFAULT'}
```

Included archives:
```
{'btype': 'remote-sources',
  'btype_id': 7,
  'build_id': 1367726,
  'buildroot_id': 6607770,
  'checksum': 'bc7ce76552f8627104c0a4c9d3eda75d',
  'checksum_type': 0,
  'extra': {'typeinfo': {'remote-sources': {}}},
  'filename': 'remote-source.json',
  'id': 4364679,
  'metadata_only': False,
  'size': 521957,
  'type_description': 'JSON data',
  'type_extensions': 'json',
  'type_id': 49,
  'type_name': 'json'},
 {'btype': 'remote-sources',
  'btype_id': 7,
  'build_id': 1367726,
  'buildroot_id': 6607770,
  'checksum': '0fe55a8245eee70b1d1baedd3d2e5c67',
  'checksum_type': 0,
  'extra': {'typeinfo': {'remote-sources': {}}},
  'filename': 'remote-source.tar.gz',
  'id': 4364678,
  'metadata_only': False,
  'size': 225725857,
  'type_description': 'Tar file',
  'type_extensions': 'tar tar.gz tar.bz2 tar.xz tgz',
  'type_id': 4,
  'type_name': 'tar'},
```