### PR TITLE
scan-sources: Compare matching classes of image arches

### DIFF
--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -335,11 +335,11 @@ class ImageMetadata(Metadata):
             archives = koji_api.listArchives(image_build['id'])
 
             # Compare to the arches in runtime
-            build_arches = []
+            build_arches = set()
             for a in archives:
                 # When running with cachito, not all archives returned are images. Filter out non-images.
                 if a['btype'] == 'image':
-                    build_arches.append(a['extra']['image']['arch'])
+                    build_arches.add(a['extra']['image']['arch'])
 
             target_arches = set(self.get_arches())
             if target_arches != build_arches:


### PR DESCRIPTION
Ran into quite a few rebuilds:
```
-   changed: true
    name: logging-fluentd
    reason: 'Arches of logging-fluentd-container-v4.3.42-202010261640.p0: ([''ppc64le'', ''x86_64'', ''s390x''])
                  does not match target arches {''s390x'', ''x86_64'', ''ppc64le''}'
```
This ensures that the comparison is made between two sets.