### PR TITLE
ART-1812: scan-sources checks latest builds for multiple targets

### DIFF
--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -507,3 +507,9 @@ class RPMMetadata(Metadata):
 
     def get_component_name(self, default=-1):
         return self.get_package_name(default=default)
+
+    def candidate_brew_tag(self):
+        return self.targets[0]
+
+    def candidate_brew_tags(self):
+        return self.targets.copy()


### PR DESCRIPTION
If multiple Brew targets (e.g. `rhaos-4.7-rhel-7-candidate` and
`rhaos-4.7-rhel-8-candidate`) are defined in ocp-build-data rpm config,
`doozer scan-sources` should check the latest builds of that rpm for
each target. If any build for a target doesn't exist or the eldest build among those latest builds is behind
distgit, it will request a rebuild.