### PR TITLE
ART-1812: support building rpms against multiple targets

### DIFF
--- a/doozerlib/constants.py
+++ b/doozerlib/constants.py
@@ -6,3 +6,5 @@ GIT_NO_PROMPTS = {
     "GIT_SSH_COMMAND": "ssh -oBatchMode=yes",
     "GIT_TERMINAL_PROMPT": "0",
 }
+
+BREWWEB_URL = "https://brewweb.engineering.redhat.com/brew"

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1064,7 +1064,7 @@ class ImageDistGitRepo(DistGitRepo):
             record["task_url"] = task_url
 
             # Now that we have the basics about the task, wait for it to complete
-            error = watch_task(self.runtime.group_config.urls.brewhub, self.logger.info, task_id, terminate_event)
+            error = watch_task(self.runtime.build_retrying_koji_client(), self.logger.info, task_id, terminate_event)
 
             # Looking for something like the following to conclude the image has already been built:
             # BuildError: Build for openshift-enterprise-base-v3.7.0-0.117.0.0 already exists, id 588961

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -251,7 +251,7 @@ class OLMBundle(object):
         """
         self.runtime.logger.info('Build running: {}'.format(self.task_url))
         error = brew.watch_task(
-            self.runtime.group_config.urls.brewhub,
+            self.runtime.build_retrying_koji_client(),
             self.runtime.logger.info,
             self.task_id,
             threading.Event()

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -535,7 +535,7 @@ class OperatorMetadataBuilder(object):
         :return: string with an error if an error happens, None otherwise
         """
         return brew.watch_task(
-            self.runtime.group_config.urls.brewhub, logger.info, task_id, threading.Event()
+            self.runtime.build_retrying_koji_client(), logger.info, task_id, threading.Event()
         )
 
     @property


### PR DESCRIPTION
The idea here is getting rid of the `el8-rebuilds` job and handling
multiple target builds in Doozer.

With this PR, you can add the following options to ocp-build-data rpm
config:

```yaml
targets:
- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate
- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
```

When running `doozer rpms:build`, Doozer will use tito to build an rpm
against the first target, then invoke Brew directly to build against
other targets using the same distgit commit.

Also added some unit tests (the existing unit test for RPMMetadata was
removed because it was broken and skipped for a long time).