### PR TITLE
Update dev container configs

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -14,12 +14,10 @@ RUN dnf install -y \
     # provides en_US.UTF-8 locale required by tito
     glibc-langpack-en \
     # development dependencies
-    gcc krb5-devel openssl-devel \
+    gcc krb5-devel openssl-devel libgit2-devel \
     python3-devel python3-pip \
-    # Microsoft Python Language Server requires .NET Core 2.1 or later
-    dotnet-runtime-3.1 \
-    # other tools
-    bash-completion vim tmux procps-ng psmisc wget net-tools iproute \
+    # other tools for development and troubleshooting
+    bash-completion vim tmux procps-ng psmisc wget net-tools iproute socat \
     # install rcm-tools
     koji brewkoji rhpkg \
  && dnf clean all

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
 		"python.testing.nosetestsEnabled": false,
 		"python.testing.unittestEnabled": true,
 		"python.jediEnabled": false,  // false to use Microsoft Python Language Server. This requires .NET Core 2.1+
-		"python.languageServer": "Microsoft",
+		"python.languageServer": "Pylance",
 	},
 
 	// Uncomment the next line if you want to publish any ports.
@@ -42,8 +42,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
-		"ms-python.python",
-		"visualstudioexptteam.vscodeintellicode",
+		"ms-python.vscode-pylance",
 		"eamodio.gitlens"
 	]
 }


### PR DESCRIPTION
Pylance has replaced Microsoft Python Language Server as the recommended
Python language server for VSCode.