### PR TITLE
WIP: Always fetch the latest code and switch branches

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -139,8 +139,18 @@ class DistGitRepo(object):
 
             if os.path.isdir(self.distgit_dir):
                 self.logger.info("Distgit directory already exists; skipping clone: %s" % self.distgit_dir)
+                with Dir(self.distgit_dir):
+                    self.logger.debug(f"Checking out branch {distgit_branch}")
+                    # discard untracked files
+                    cmd = ["git", "-C", self.distgit_dir, "clean", "-fdx"]
+                    exectools.cmd_assert(cmd)
+                    # discard staged files
+                    cmd = ["git", "-C", self.distgit_dir, "checkout", "--force", "HEAD"]
+                    exectools.cmd_assert(cmd)
+                    # fetch and switch branch
+                    cmd = ["rhpkg", "switch-branch", "--fetch", distgit_branch]
+                    exectools.cmd_assert(cmd)
             else:
-
                 # Make a directory for the distgit namespace if it does not already exist
                 try:
                     os.mkdir(namespace_dir)

--- a/tests/test_distgit/test_generic_distgit.py
+++ b/tests/test_distgit/test_generic_distgit.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import errno
 import os
 import unittest
+from unittest import mock
 from datetime import datetime, timedelta
 
 import flexmock
@@ -51,6 +52,7 @@ class TestGenericDistGit(TestDistgit):
                             "skipping clone: my-root-dir/my-namespace/my-distgit-key")
         logger = flexmock()
         logger.should_receive("info").with_args(expected_log_msg).once()
+        logger.should_receive("debug")
 
         metadata = flexmock(namespace="my-namespace",
                             distgit_key="my-distgit-key",
@@ -59,7 +61,8 @@ class TestGenericDistGit(TestDistgit):
                             logger=logger,
                             name="_irrelevant_")
 
-        distgit.DistGitRepo(metadata, autoclone=False).clone("my-root-dir", "my-branch")
+        with mock.patch("doozerlib.distgit.exectools.cmd_assert", return_value=('', '')):
+            distgit.DistGitRepo(metadata, autoclone=False).clone("my-root-dir", "my-branch")
 
     def test_clone_fails_to_create_namespace_dir(self):
         # preventing tests from interacting with the real filesystem


### PR DESCRIPTION
So you don't need to run `doozer cleanup` before start a new build.