### PR TITLE
ART-1812: Assert multi-target rpm builds have correct golang compilers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,11 @@ pipeline {
             steps {
                 script {
                     catchError(stageResult: 'FAILURE') {
-                        sh "tox > results.txt 2>&1"
+                        // Rebuild tox environment after change requirements. https://github.com/openshift/elliott/pull/149
+                        sh """
+                            tox_args="\$(git diff --name-only HEAD~5 | grep -Fxq -e requirements.txt -e requirements-dev.txt -e MANIFEST.in -e setup.py && echo '--recreate')"
+                            tox \$tox_args > results.txt 2>&1
+                        """
                     }
                     results = readFile("results.txt").trim()
                     echo results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bashlex
+boto3
 click >= 6.7
 dockerfile-parse >= 0.0.13
 future
@@ -6,10 +7,10 @@ koji
 mock
 PyGitHub >= 1.46
 pyyaml >= 5.1
-retry
 requests
 requests_kerberos
+retry
+rpm-py-installer
 semver
-boto3
-wrapt
 tenacity
+wrapt

--- a/tests/test_rpmcfg.py
+++ b/tests/test_rpmcfg.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
+from unittest.mock import MagicMock
 from doozerlib.rpmcfg import RPMMetadata
+from doozerlib.exceptions import DoozerFatalError
 import yaml
 
 
@@ -58,3 +60,79 @@ targets:
             koji_session.getTaskRequest.assert_called()
             koji_session.build.assert_called()
             mock_watch_tasks.assert_called()
+
+    @mock.patch("doozerlib.logutil.EntityLoggingAdapter")
+    @mock.patch("doozerlib.rpmcfg.Dir")
+    def test_assert_golang_versions(self, MockDir, MockEntityLoggingAdapter):
+        runtime = mock.MagicMock(brew_logs_dir="/path/to/brew/logs")
+        koji_session = runtime.build_retrying_koji_client.return_value
+        data_obj = mock.MagicMock(
+            key="foo",
+            filename="foo.yml",
+            path="/path/to/ocp-build-data/rpms/foo.yml",
+            data=yaml.safe_load(TestRPMMetadata.FOO_RPM_CONFIG)
+        )
+        koji_session.multicall.return_value.__enter__.return_value.getBuildTarget.side_effect = lambda target: MagicMock(result={"build_tag_name": target.replace("-candidate", "-build")})
+        metadata = RPMMetadata(runtime, data_obj, clone_source=False)
+
+        runtime.group_config.check_golang_versions = "exact"
+        with mock.patch("doozerlib.rpmcfg.brew.get_latest_builds") as get_latest_builds:
+            def fake_get_latest_builds(tag_component_tuples, build_type, event, session):
+                results = {
+                    ('rhaos-4.7-rhel-7-build', 'golang'): [{"name": "golang", "version": "1.2.3", "release": "1.el7", "epoch": None}],
+                    ('rhaos-4.7-rhel-7-build', 'golang-scl-shim'): [{"name": "golang-scl-shim", "version": "1.4.0", "release": "2.el7", "epoch": None}],
+                    ('rhaos-4.7-rhel-8-build', 'golang'): [{"name": "golang", "version": "1.4.5", "release": "3.el8", "epoch": None}],
+                    ('rhaos-4.7-rhel-8-build', 'golang-scl-shim'): [],
+                }
+                return [results[tag_component] for tag_component in tag_component_tuples]
+            get_latest_builds.side_effect = fake_get_latest_builds
+            koji_session.getLatestBuilds.return_value = [{"name": "go-toolset-1.4", "version": "1.4.5", "release": "4.el7", "epoch": None}]
+            metadata.assert_golang_versions()
+            koji_session.getLatestBuilds.assert_called_with('rhaos-4.7-rhel-7-build', package="go-toolset-1.4", type="rpm")
+
+        runtime.group_config.check_golang_versions = "exact"
+        RPMMetadata.target_golangs = {}
+        with mock.patch("doozerlib.rpmcfg.brew.get_latest_builds") as get_latest_builds:
+            def fake_get_latest_builds(tag_component_tuples, build_type, event, session):
+                results = {
+                    ('rhaos-4.7-rhel-7-build', 'golang'): [{"name": "golang", "version": "1.2.3", "release": "1.el7", "epoch": None}],
+                    ('rhaos-4.7-rhel-7-build', 'golang-scl-shim'): [{"name": "golang-scl-shim", "version": "1.4.6", "release": "2.el7", "epoch": None}],
+                    ('rhaos-4.7-rhel-8-build', 'golang'): [{"name": "golang", "version": "1.4.6", "release": "3.el8", "epoch": None}],
+                    ('rhaos-4.7-rhel-8-build', 'golang-scl-shim'): [],
+                }
+                return [results[tag_component] for tag_component in tag_component_tuples]
+            get_latest_builds.side_effect = fake_get_latest_builds
+            koji_session.getLatestBuilds.return_value = [{"name": "go-toolset-1.4", "version": "1.4.5", "release": "4.el7", "epoch": None}]
+            with self.assertRaises(DoozerFatalError):
+                metadata.assert_golang_versions()
+
+        runtime.group_config.check_golang_versions = "x.y"
+        RPMMetadata.target_golangs = {}
+        with mock.patch("doozerlib.rpmcfg.brew.get_latest_builds") as get_latest_builds:
+            def fake_get_latest_builds(tag_component_tuples, build_type, event, session):
+                results = {
+                    ('rhaos-4.7-rhel-7-build', 'golang'): [{"name": "golang", "version": "1.2.3", "release": "1.el7", "epoch": None}],
+                    ('rhaos-4.7-rhel-7-build', 'golang-scl-shim'): [{"name": "golang-scl-shim", "version": "1.4.5", "release": "2.el7", "epoch": None}],
+                    ('rhaos-4.7-rhel-8-build', 'golang'): [{"name": "golang", "version": "1.4.6", "release": "3.el8", "epoch": None}],
+                    ('rhaos-4.7-rhel-8-build', 'golang-scl-shim'): [],
+                }
+                return [results[tag_component] for tag_component in tag_component_tuples]
+            get_latest_builds.side_effect = fake_get_latest_builds
+            koji_session.getLatestBuilds.return_value = [{"name": "go-toolset-1.4", "version": "1.4.5", "release": "4.el7", "epoch": None}]
+            metadata.assert_golang_versions()
+
+        runtime.group_config.check_golang_versions = "x.y"
+        RPMMetadata.target_golangs = {}
+        with mock.patch("doozerlib.rpmcfg.brew.get_latest_builds") as get_latest_builds:
+            def fake_get_latest_builds(tag_component_tuples, build_type, event, session):
+                results = {
+                    ('rhaos-4.7-rhel-7-build', 'golang'): [{"name": "golang", "version": "1.2.3", "release": "1.el7", "epoch": None}],
+                    ('rhaos-4.7-rhel-7-build', 'golang-scl-shim'): [{"name": "golang-scl-shim", "version": "1.4.5", "release": "2.el7", "epoch": None}],
+                    ('rhaos-4.7-rhel-8-build', 'golang'): [{"name": "golang", "version": "1.5.6", "release": "3.el8", "epoch": None}],
+                    ('rhaos-4.7-rhel-8-build', 'golang-scl-shim'): [],
+                }
+                return [results[tag_component] for tag_component in tag_component_tuples]
+            get_latest_builds.side_effect = fake_get_latest_builds
+            koji_session.getLatestBuilds.return_value = [{"name": "go-toolset-1.4", "version": "1.4.5", "release": "4.el7", "epoch": None}]
+            with self.assertRaises(DoozerFatalError):
+                metadata.assert_golang_versions()


### PR DESCRIPTION
Includes https://github.com/openshift/doozer/pull/320

Use `check_golang_versions` option in ocp-build-data group.yml to
    specify how you would like to check them:
    
    - "x.y" (default): only major and minor version
    - "exact": the z-version must be the same
    - "no": do not check
    
    The default is `x.y` because our 4.6 and 4.7 targets currently have
    different z versions in their buildroots. We should change the check
    mode to `exact` once this is corrected.