### PR TITLE
Fix Doozer crash with `'tuple' object does not support item assignment`

### DIFF
--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -487,6 +487,7 @@ class KojiWrapper(koji.ClientSession):
                 method_name = call_dict['methodName']
                 params = self.modify_koji_call_params(method_name, call_dict['params'], aggregate_kw_opts)
                 if params:
+                    params = list(params)
                     # Assess whether we need to inject event of beforeEvent into the koji call kwargs
                     possible_kwargs = params[-1]  # last element could be normal arg or kwargs dict
                     if isinstance(possible_kwargs, dict) and possible_kwargs.get('__starstar', None):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "./doozerlib/runtime.py", line 98, in wrapper
    return func(*args, **kwargs)
  File "./doozerlib/runtime.py", line 110, in wrapper
    return func(*args)
  File "./doozerlib/cli/__main__.py", line 180, in <lambda>
    lambda rpm, terminate_event: rpm.build_rpm(
  File "./doozerlib/rpmcfg.py", line 486, in build_rpm
    self.assert_golang_versions()
  File "./doozerlib/rpmcfg.py", line 544, in assert_golang_versions
    latest_builds = brew.get_latest_builds([(buildroot, component) for component in golang_components], "rpm", None, brew_session)
  File "./doozerlib/brew.py", line 184, in get_latest_builds
    for tag, component_name in tag_component_tuples:
  File "/home/dev/.local/lib/python3.8/site-packages/koji/__init__.py", line 3215, in __exit__
    self.call_all()
  File "/home/dev/.local/lib/python3.8/site-packages/koji/__init__.py", line 3187, in call_all
    _results = self._session._callMethod('multiCall', args, {})
  File "./doozerlib/brew.py", line 564, in _callMethod
    params[-1] = self.modify_koji_call_kwargs(method_name, possible_kwargs, aggregate_kw_opts)
TypeError: 'tuple' object does not support item assignment

```

This issue was introduced by
https://github.com/openshift/doozer/pull/311 to speed up scan-sources.

Simply converting the tuple to list should fix it.