### PR TITLE
add new field 'for_release' to individual files

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1348,7 +1348,7 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
         images = list(runtime.image_metas())
     else:
         for i in runtime.image_metas():
-            if i.is_release:
+            if i.for_release:
                 images.append(i)
             else:
                 non_release_images.append(i.distgit_key)

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1348,10 +1348,10 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
         images = list(runtime.image_metas())
     else:
         for i in runtime.image_metas():
-            if not i.is_release:
-                non_release_images.append(i.distgit_key)
-            else:
+            if i.is_release:
                 images.append(i)
+            else:
+                non_release_images.append(i.distgit_key)
 
     for image in images:
         # skip base images unless requested

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1342,13 +1342,16 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
     else:
         green_print("Writing image list to {}".format(output))
 
+    non_release_images = []
+    images = []
     if show_non_release:
         images = list(runtime.image_metas())
     else:
-        non_release_images = runtime.group_config.non_release.images
-        if non_release_images is Missing:
-            non_release_images = []
-        images = [i for i in runtime.image_metas() if i.is_release and i.distgit_key not in non_release_images]
+        for i in runtime.image_metas():
+            if not i.is_release:
+                non_release_images.append(i.distgit_key)
+            else:
+                images.append(i)
 
     for image in images:
         # skip base images unless requested

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1348,7 +1348,7 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
         non_release_images = runtime.group_config.non_release.images
         if non_release_images is Missing:
             non_release_images = []
-        images = [i for i in runtime.image_metas() if i.distgit_key not in non_release_images]
+        images = [i for i in runtime.image_metas() if i.is_release and i.distgit_key not in non_release_images]
 
     for image in images:
         # skip base images unless requested

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -134,7 +134,7 @@ class PayloadGenerator:
 
         self.runtime.logger.info("Fetching latest image builds from Brew...")
         payload_images, invalid_name_items = self._get_payload_images(images)
-        release_payload_images, non_release_items = self._get_non_release_images(payload_images)
+        release_payload_images, non_release_items = self._get_payload_and_non_release_images(payload_images)
         self.state['payload_images'] = len(release_payload_images)
         latest_builds, images_missing_builds = self._get_latest_builds(release_payload_images)
         self._designate_privacy(latest_builds)
@@ -142,11 +142,11 @@ class PayloadGenerator:
 
         return latest_builds, invalid_name_items, images_missing_builds, mismatched_siblings, non_release_items
 
-    def _get_non_release_images(self, images):
+    def _get_payload_and_non_release_images(self, images):
         payload_images = []
         non_release_items = []
         for image in images:
-            if image.is_release:
+            if image.for_release:
                 payload_images.append(image)
                 continue
             non_release_items.append(image.image_name_short)

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -85,7 +85,7 @@ relevant image istag (these are publicly visible; ref. https://bit.ly/37cseC1)
 and in more detail in state.yaml. The release-controller, per ART-2195, will
 read and propagate/expose this annotation in its display of the release image.
     """
-    runtime.initialize(clone_distgits=False, config_excludes='non_release')
+    runtime.initialize(clone_distgits=False)
     brew_session = runtime.build_retrying_koji_client()
     base_target = SyncTarget(  # where we will mirror and record the tags
         orgrepo=f"{organization}/{repository}",

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -95,7 +95,7 @@ class ImageMetadata(Metadata):
         return self.config.get('for_payload', False)
 
     @property
-    def is_release(self):
+    def for_release(self):
         return self.config.get('for_release', True)
 
     def get_component_name(self, default=-1):

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -94,6 +94,10 @@ class ImageMetadata(Metadata):
     def is_payload(self):
         return self.config.get('for_payload', False)
 
+    @property
+    def is_release(self):
+        return self.config.get('for_release', True)
+    
     def get_component_name(self, default=-1):
         """
         :param default: Not used. Here to stay consistent with similar rpmcfg.get_component_name

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -97,7 +97,7 @@ class ImageMetadata(Metadata):
     @property
     def is_release(self):
         return self.config.get('for_release', True)
-    
+
     def get_component_name(self, default=-1):
         """
         :param default: Not used. Here to stay consistent with similar rpmcfg.get_component_name

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -342,10 +342,6 @@ class Metadata(object):
 
         return sorted_maintainer
 
-    @property
-    def is_release(self):
-        return self.config.get('for_release', True)
-
     def extract_kube_env_vars(self) -> Dict[str, str]:
         """
         Analyzes the source_base_dir for either Godeps or go.mod and looks for information about

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -342,6 +342,10 @@ class Metadata(object):
 
         return sorted_maintainer
 
+    @property
+    def is_release(self):
+        return self.config.get('for_release', True)
+
     def extract_kube_env_vars(self) -> Dict[str, str]:
         """
         Analyzes the source_base_dir for either Godeps or go.mod and looks for information about

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -288,8 +288,7 @@ class Runtime(object):
 
     def initialize(self, mode='images', clone_distgits=True,
                    validate_content_sets=False,
-                   no_group=False, clone_source=None, disabled=None,
-                   config_excludes=None):
+                   no_group=False, clone_source=None, disabled=None):
 
         if self.initialized:
             return
@@ -493,11 +492,6 @@ class Runtime(object):
             replace_vars = {}
             if self.group_config.vars:
                 replace_vars = self.group_config.vars.primitive()
-
-            if config_excludes:
-                excludes = self.group_config.get(config_excludes, {})
-                image_ex.extend(excludes.get('images', []))
-                rpm_ex.extend(excludes.get('rpms', []))
 
             # pre-load the image data to get the names for all images
             # eventually we can use this to allow loading images by


### PR DESCRIPTION
ocp-build-data updates:
4.6: https://github.com/openshift/ocp-build-data/pull/779
4.5: https://github.com/openshift/ocp-build-data/pull/780
4.4: https://github.com/openshift/ocp-build-data/pull/781
4.3: https://github.com/openshift/ocp-build-data/pull/782
```
[shiywang@buildvm doozer]$ python3 ./doozer -g openshift-4.6 --data-path ./ocp-build-data/ images:print
2020-11-25 09:48:16,948 INFO Initial execution (cwd) directory: /home/nay/shiywang/doozer
2020-11-25 09:48:17,061 INFO $0: ['git', '-C', '/home/nay/shiywang/doozer/ocp-build-data', 'remote', 'get-url', 'origin'] - [cwd=None]: Executing:cmd_gather
2020-11-25 09:48:17,065 INFO Time elapsed (hh:mm:ss.ms) 0:00:00.004289 in /home/nay/shiywang/doozer/doozerlib/exectools.py:159 from /home/nay/shiywang/doozer/doozerlib/exectools.py:101:log_stdout=log_stdout, log_stderr=log_stderr) : $0: ['git', '-C', '/home/nay/shiywang/doozer/ocp-build-data', 'remote', 'get-url', 'origin'] - [cwd=None]: Executed:cmd_gather
2020-11-25 09:48:17,067 INFO $1: ['git', '-C', '/home/nay/shiywang/doozer/ocp-build-data', 'rev-parse', 'HEAD'] - [cwd=None]: Executing:cmd_gather
2020-11-25 09:48:17,070 INFO Time elapsed (hh:mm:ss.ms) 0:00:00.003291 in /home/nay/shiywang/doozer/doozerlib/exectools.py:159 from /home/nay/shiywang/doozer/doozerlib/exectools.py:101:log_stdout=log_stdout, log_stderr=log_stderr) : $1: ['git', '-C', '/home/nay/shiywang/doozer/ocp-build-data', 'rev-parse', 'HEAD'] - [cwd=None]: Executed:cmd_gather
2020-11-25 09:48:17,143 INFO Using branch from group.yml: rhaos-4.6-rhel-8

------------------------------------------
openshift-enterprise-pod-container-v4.6.0-202011181111.p0
ose-metering-ansible-operator-container-v4.6.0-202011221454.p0
hadoop-container-v4.6.0-202011210152.p0
csi-provisioner-container-v4.6.0-202011181111.p0
atomic-openshift-cluster-autoscaler-container-v4.6.0-202011181111.p0
golang-github-prometheus-prometheus-container-v4.6.0-202011202329.p0
openshift-enterprise-service-idler-container-v4.6.0-202011181111.p0
csi-node-driver-registrar-container-v4.6.0-202011181111.p0
csi-driver-nfs-container-v4.6.0-202011181111.p0
ose-etcd-container-v4.6.0-202011181111.p0
ose-cluster-kube-scheduler-operator-container-v4.6.0-202011181111.p0
elasticsearch-operator-container-v4.6.0-202011221454.p0
operator-lifecycle-manager-container-v4.6.0-202011202329.p0
cluster-network-operator-container-v4.6.0-202011202329.p0
ose-kube-storage-version-migrator-container-v4.6.0-202011181111.p0
golang-github-openshift-oauth-proxy-container-v4.6.0-202011181111.p0
sriov-network-operator-container-v4.6.0-202011202329.p0
sriov-dp-admission-controller-container-v4.6.0-202011181111.p0
ose-cluster-ovirt-csi-operator-container-v4.6.0-202011181111.p0
ose-cluster-bootstrap-container-v4.6.0-202011181111.p0
openshift-enterprise-egress-router-container-v4.6.0-202011181111.p0
ose-metering-reporting-operator-container-v4.6.0-202011202329.p0
openshift-enterprise-cluster-capacity-container-v4.6.0-202011181111.p0
ironic-ipa-downloader-container-v4.6.0-202011210152.p0
ose-cluster-machine-approver-container-v4.6.0-202011181111.p0
ose-cloud-credential-operator-container-v4.6.0-202011181111.p0
ose-metering-helm-container-v4.6.0-202011181111.p0
ose-openshift-apiserver-container-v4.6.0-202011181111.p0
operator-registry-container-v4.6.0-202011202329.p0
ose-installer-artifacts-container-v4.6.0-202011181111.p0
ose-cluster-csi-snapshot-controller-operator-container-v4.6.0-202011181111.p0
openshift-enterprise-tests-container-v4.6.0-202011221454.p0
ose-jenkins-agent-nodejs-10-container-v4.6.0-202011221454.p0
cluster-monitoring-operator-container-v4.6.0-202011181111.p0
cluster-nfd-operator-container-v4.6.0-202011181111.p0
node-feature-discovery-container-v4.6.0-202011181111.p0
ose-openstack-machine-controllers-container-v4.6.0-202011181111.p0
ose-cluster-kube-apiserver-operator-container-v4.6.0-202011181111.p0
ironic-container-v4.6.0-202011221454.p0
cluster-version-operator-container-v4.6.0-202011181111.p0
ose-jenkins-agent-maven-container-v4.6.0-202011221454.p0
prometheus-config-reloader-container-v4.6.0-202011181111.p0
kube-proxy-container-v4.6.0-202011181111.p0
telemeter-container-v4.6.0-202011181111.p0
logging-eventrouter-container-v4.6.0-202011181111.p0
ose-installer-container-v4.6.0-202011181111.p0
ose-aws-ebs-csi-driver-operator-container-v4.6.0-202011181111.p0
csi-driver-manila-container-v4.6.0-202011181111.p0
ose-baremetal-operator-container-v4.6.0-202011181111.p0
prom-label-proxy-container-v4.6.0-202011181111.p0
local-storage-operator-container-v4.6.0-202011181111.p0
local-storage-diskmaker-container-v4.6.0-202011181111.p0
baremetal-machine-controller-container-v4.6.0-202011181111.p0
openshift-enterprise-haproxy-router-container-v4.6.0-202011202329.p0
ose-network-metrics-daemon-container-v4.6.0-202011181111.p0
coredns-container-v4.6.0-202011181111.p0
presto-container-v4.6.0-202011210152.p0
ose-csi-external-snapshotter-container-v4.6.0-202011181111.p0
ose-baremetal-installer-container-v4.6.0-202011181111.p0
ose-ptp-operator-container-v4.6.0-202011181111.p0
ose-thanos-container-v4.6.0-202011181111.p0
openshift-enterprise-helm-operator-container-v4.6.0-202011181111.p0
ose-cluster-kube-storage-version-migrator-operator-container-v4.6.0-202011181111.p0
sriov-network-must-gather-container-v4.6.0-202011202329.p0
ose-prometheus-adapter-container-v4.6.0-202011181111.p0
configmap-reload-container-v4.6.0-202011181111.p0
ose-jenkins-agent-base-container-v4.6.0-202011221454.p0
ose-cluster-kube-controller-manager-operator-container-v4.6.0-202011181111.p0
openshift-jenkins-2-container-v4.6.0-202011221454.p0
ose-vertical-pod-autoscaler-operator-container-v4.6.0-202011181111.p0
ose-vertical-pod-autoscaler-container-v4.6.0-202011181111.p0
ose-csi-snapshot-controller-container-v4.6.0-202011181111.p0
ose-linuxptp-daemon-container-v4.6.0-202011181111.p0
ose-cluster-openshift-apiserver-operator-container-v4.6.0-202011181111.p0
ose-machine-api-operator-container-v4.6.0-202011202329.p0
ose-clusterresourceoverride-operator-container-v4.6.0-202011181111.p0
ose-clusterresourceoverride-container-v4.6.0-202011181111.p0
openshift-enterprise-builder-container-v4.6.0-202011221454.p0
ose-network-interface-bond-cni-container-v4.6.0-202011181111.p0
ironic-inspector-container-v4.6.0-202011181111.p0
openshift-enterprise-keepalived-ipfailover-container-v4.6.0-202011221454.p0
ose-gcp-machine-controllers-container-v4.6.0-202011181111.p0
ose-cli-artifacts-container-v4.6.0-202011181111.p0
sriov-cni-container-v4.6.0-202011181111.p0
openshift-enterprise-cli-container-v4.6.0-202011181111.p0
cluster-etcd-operator-container-v4.6.0-202011210152.p0
ose-oauth-apiserver-container-v4.6.0-202011181111.p0
ose-jenkins-agent-nodejs-12-container-v4.6.0-202011221454.p0
ose-cluster-ingress-operator-container-v4.6.0-202011202329.p0
cluster-logging-operator-container-v4.6.0-202011221454.p0
logging-fluentd-container-v4.6.0-202011221454.p0
ose-cluster-autoscaler-operator-container-v4.6.0-202011181111.p0
ose-tools-container-v4.6.0-202011221454.p0
logging-kibana6-container-v4.6.0-202011221454.p0
ose-service-ca-operator-container-v4.6.0-202011181111.p0
ose-csi-external-resizer-container-v4.6.0-202011181111.p0
ose-libvirt-machine-controllers-container-v4.6.0-202011181111.p0
ose-multus-whereabouts-ipam-cni-container-v4.6.0-202011181111.p0
ose-containernetworking-plugins-container-v4.6.0-202011181111.p0
ose-cluster-image-registry-operator-container-v4.6.0-202011211906.p0
kuryr-controller-container-v4.6.0-202011202329.p0
csi-driver-manila-operator-container-v4.6.0-202011181111.p0
ose-cluster-dns-operator-container-v4.6.0-202011181111.p0
grafana-container-v4.6.0-202011181111.p0
ironic-static-ip-manager-container-v4.6.0-202011181111.p0
openshift-enterprise-registry-container-v4.6.0-202011181111.p0
ose-azure-machine-controllers-container-v4.6.0-202011202329.p0
kube-state-metrics-container-v4.6.0-202011181111.p0
oauth-server-container-v4.6.0-202011181111.p0
openshift-state-metrics-container-v4.6.0-202011181111.p0
ose-machine-config-operator-container-v4.6.0-202011202329.p0
sriov-network-device-plugin-container-v4.6.0-202011181111.p0
openshift-enterprise-ansible-operator-container-v4.6.0-202011181111.p0
openshift-enterprise-console-container-v4.6.0-202011202329.p0
ose-openshift-controller-manager-container-v4.6.0-202011181111.p0
prometheus-operator-container-v4.6.0-202011181111.p0
csi-attacher-container-v4.6.0-202011181111.p0
hive-container-v4.6.0-202011221454.p0
sriov-network-config-daemon-container-v4.6.0-202011202329.p0
openshift-enterprise-deployer-container-v4.6.0-202011181111.p0
ose-aws-machine-controllers-container-v4.6.0-202011181111.p0
openshift-enterprise-egress-dns-proxy-container-v4.6.0-202011181111.p0
ose-cluster-policy-controller-container-v4.6.0-202011181111.p0
ose-baremetal-runtimecfg-container-v4.6.0-202011181111.p0
ose-cluster-openshift-controller-manager-operator-container-v4.6.0-202011181111.p0
ose-ovirt-csi-driver-container-v4.6.0-202011181111.p0
golang-github-prometheus-alertmanager-container-v4.6.0-202011181111.p0
openshift-enterprise-console-operator-container-v4.6.0-202011181111.p0
ose-cluster-storage-operator-container-v4.6.0-202011181111.p0
ose-cluster-authentication-operator-container-v4.6.0-202011181111.p0
sriov-network-webhook-container-v4.6.0-202011202329.p0
ose-node-container-v4.6.0-202011181111.p0
ose-multus-route-override-cni-container-v4.6.0-202011181111.p0
logging-curator5-container-v4.6.0-202011221454.p0
ose-aws-ebs-csi-driver-container-v4.6.0-202011181111.p0
openshift-enterprise-hyperkube-container-v4.6.0-202011202329.p0
ose-must-gather-container-v4.6.0-202011181111.p0
cluster-node-tuning-operator-container-v4.6.0-202011202329.p0
ose-cluster-kube-descheduler-operator-container-v4.6.0-202011181111.p0
ironic-hardware-inventory-recorder-image-container-v4.6.0-202011221454.p0
kube-rbac-proxy-container-v4.6.0-202011181111.p0
ose-ovirt-machine-controllers-container-v4.6.0-202011181111.p0
ose-ovn-kubernetes-container-v4.6.0-202011221454.p0
ose-multus-admission-controller-container-v4.6.0-202011181111.p0
multus-cni-container-v4.6.0-202011181111.p0
ose-leader-elector-container-v4.6.0-202011181111.p0
kuryr-cni-container-v4.6.0-202011202329.p0
marketplace-operator-container-v4.6.0-202011202329.p0
logging-elasticsearch6-container-v4.6.0-202011181736.p0
local-storage-static-provisioner-container-v4.6.0-202011181111.p0
atomic-openshift-descheduler-container-v4.6.0-202011181111.p0
ib-sriov-cni-container-v4.6.0-202011181111.p0
ose-elasticsearch-proxy-container-v4.6.0-202011202329.p0
ghostunnel-container-v4.6.0-202011181111.p0
ose-cluster-samples-operator-container-v4.6.0-202011181111.p0
ose-egress-http-proxy-container-v4.6.0-202011221454.p0
ose-insights-operator-container-v4.6.0-202011181111.p0
ose-cluster-update-keys-container-v4.6.0-202011181111.p0
golang-github-prometheus-node_exporter-container-v4.6.0-202011181111.p0
ose-cluster-config-operator-container-v4.6.0-202011181111.p0
atomic-openshift-node-problem-detector-container-v4.6.0-202011181111.p0
ose-aws-pod-identity-webhook-container-v4.6.0-202011181111.p0
ose-mdns-publisher-container-v4.6.0-202011181111.p0
csi-livenessprobe-container-v4.6.0-202011181111.p0
ironic-rhcos-downloader-container-v4.6.0-202011181111.p0
------------------------------------------
165 images

The following 2 non-release images were excluded; use --show-non-release to include them:
    openshift-enterprise-base
    ose-haproxy-router-base
```

```
python3 ./doozer -g openshift-4.6 --data-path ./ocp-build-data/  release:gen-payload --is-name=4.6-art-latest
```