### PR TITLE
Fix image:push in case of failed images

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1180,7 +1180,7 @@ def images_push(runtime, tag, version_release, to_defaults, late_only, to, filte
         failed = runtime.filter_failed_image_trees(pre_failed)
         yellow_print('The following images failed the last step (or are children of failed images) and will be skipped:\n{}'.format('\n'.join(failed)))
         # reload after fail filtered
-        items = [m.distgit_repo() for m in runtime.ordered_image_metas()]
+        items = runtime.ordered_image_metas()
 
         if not items:
             runtime.logger.info("No images left to build after failures and children filtered out.")


### PR DESCRIPTION
The ocp4 job fails after not all images have been built succesfully:
```
The following images failed the last step (or are children of failed images) and will be skipped:
openshift-enterprise-console
Traceback (most recent call last):
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4@2/art-tools/doozer/doozerlib/runtime.py", line 98, in wrapper
    return func(*args, **kwargs)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4@2/art-tools/doozer/doozerlib/runtime.py", line 110, in wrapper
    return func(*args)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4@2/art-tools/doozer/doozerlib/cli/__main__.py", line 1230, in <lambda>
    img.distgit_repo().push_image(tag, to_defaults, additional_registries,
AttributeError: 'ImageDistGitRepo' object has no attribute 'distgit_repo'
```

Ensuring the objects do not change type after failure should prevent the
attribute error.