### PR TITLE
ART-1080: update doozer:scan-sources to note config changes

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -2058,7 +2058,6 @@ def config_update_required(runtime, image_list):
                 break
         if not found:
             optional.append(img)
-            red_print('yuxzhu: {}'.format(name))
 
     missing = list(set(image_list) - set(resolved))
     if missing:

--- a/doozerlib/cli/scan_sources.py
+++ b/doozerlib/cli/scan_sources.py
@@ -109,9 +109,10 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
                     dgr = meta.distgit_repo()
                     path = Path(dgr.distgit_dir).joinpath(".oit", "config_digest")
                     if not path.exists():  # alway request a buiild if config_digest hasn't been stored
-                        runtime.logger.info('%s config_digest does not exist; request a build', dgk)
-                        needs_rebuild = True
-                        reason = '.oit/config_digest does not exist'
+                        pass  # TODO: uncomment the following after a week of natural rebuilds
+                        # runtime.logger.info('%s config_digest does not exist; request a build', dgk)
+                        # needs_rebuild = True
+                        # reason = '.oit/config_digest does not exist'
                     else:
                         with path.open('r') as f:
                             prev_digest = f.read()

--- a/doozerlib/cli/scan_sources.py
+++ b/doozerlib/cli/scan_sources.py
@@ -1,7 +1,9 @@
+from pathlib import Path
+
 import click
 import yaml
 
-from doozerlib import brew, rhcos, exectools
+from doozerlib import brew, exectools, rhcos
 from doozerlib.cli import cli, pass_runtime
 from doozerlib.cli import release_gen_payload as rgp
 from doozerlib.exceptions import DoozerFatalError
@@ -53,8 +55,15 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
         if key not in assessment_reason:
             assessment_reason[key] = reason
 
-    with runtime.shared_koji_client_session() as koji_api:
+    def add_image_meta_change(meta, msg):
+        nonlocal changing_image_metas
+        changing_image_metas.add(meta)
+        add_assessment_reason(meta, True, msg)
+        for descendant_meta in meta.get_descendants():
+            changing_image_metas.add(descendant_meta)
+            add_assessment_reason(descendant_meta, True, f'Ancestor {meta.distgit_key} is changing')
 
+    with runtime.shared_koji_client_session() as koji_api:
         runtime.logger.info(f'scan-sources coordinate: brew_event: {koji_api.getLastEvent(brew.KojiWrapperOpts(brew_event_aware=True))}')
         runtime.logger.info(f'scan-sources coordinate: emulated_brew_event: {runtime.brew_event}')
 
@@ -94,20 +103,27 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
                     else:
                         runtime.logger.warning(f"Appears that {dgk} has never been built before; can't determine package name")
             elif meta.meta_type == 'image':
-                if reason:
-                    add_assessment_reason(meta, needs_rebuild, reason=reason)
+                if not needs_rebuild:  # If no change has been detected, check configurations like image meta, repos, and streams to see if they have changed
+                    # We detect config changes by comparing their digest changes.
+                    # The config digest of the previous build is stored at .oit/config_digest on distgit repo.
+                    dgr = meta.distgit_repo()
+                    path = Path(dgr.distgit_dir).joinpath(".oit", "config_digest")
+                    if not path.exists():  # alway request a buiild if config_digest hasn't been stored
+                        runtime.logger.info('%s config_digest does not exist; request a build', dgk)
+                        needs_rebuild = True
+                        reason = '.oit/config_digest does not exist'
+                    else:
+                        with path.open('r') as f:
+                            prev_digest = f.read()
+                        current_digest = meta.calculate_config_digest(runtime.group_config, runtime.streams)
+                        if current_digest.strip() != prev_digest.strip():
+                            runtime.logger.info('%s config_digest %s is differing from %s', dgk, prev_digest, current_digest)
+                            needs_rebuild = True
+                            reason = 'Config changed'
                 if needs_rebuild:
-                    changing_image_metas.add(meta)
+                    add_image_meta_change(meta, reason)
             else:
                 raise IOError(f'Unsupported meta type: {meta.meta_type}')
-
-        def add_image_meta_change(meta, msg):
-            nonlocal changing_image_metas
-            changing_image_metas.add(meta)
-            add_assessment_reason(meta, True, msg)
-            for descendant_meta in meta.get_descendants():
-                changing_image_metas.add(descendant_meta)
-                add_assessment_reason(descendant_meta, True, f'Ancestor {meta.distgit_key} is changing')
 
         # To limit the size of the queries we are going to make, find the oldest and newest image
         oldest_image_event_ts = None
@@ -133,7 +149,7 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
         if changing:
             add_image_meta_change(meta, msg)
 
-    # does_image_name_change() checks whether its non-member builder images have changed
+    # does_image_need_change() checks whether its non-member builder images have changed
     # but cannot determine whether member builder images have changed until anticipated
     # changes have been calculated. The following loop does this. It uses while True,
     # because technically, we could keep finding changes in intermediate builder images

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -679,7 +679,7 @@ RUN yum install -y cov-sa csmock csmock-plugin-coverity csdiff
             message["streams"] = {stream: streams[stream] for stream in referred_streams}
 
         message = util.sort_dict(message)
-        digest = hashlib.sha256(json.dumps(message).encode("utf-8")).hexdigest()
+        digest = hashlib.sha256(json.dumps(message, sort_keys=True).encode("utf-8")).hexdigest()
         return "sha256:" + digest
 
 

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -661,7 +661,8 @@ RUN yum install -y cov-sa csmock csmock-plugin-coverity csdiff
         image_config: Dict[str, Any] = self.config.primitive()  # primitive() should create a shallow clone for the underlying dict
         group_config: Dict[str, Any] = group_config.primitive()
         streams: Dict[str, Any] = streams.primitive()
-        del image_config["owners"]  # ignore the owners entry for the digest: https://issues.redhat.com/browse/ART-1080
+        if "owners" in image_config:
+            del image_config["owners"]  # ignore the owners entry for the digest: https://issues.redhat.com/browse/ART-1080
         message = {
             "config": image_config,
         }

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -678,7 +678,6 @@ RUN yum install -y cov-sa csmock csmock-plugin-coverity csdiff
         if referred_streams:
             message["streams"] = {stream: streams[stream] for stream in referred_streams}
 
-        message = util.sort_dict(message)
         digest = hashlib.sha256(json.dumps(message, sort_keys=True).encode("utf-8")).hexdigest()
         return "sha256:" + digest
 

--- a/doozerlib/model.py
+++ b/doozerlib/model.py
@@ -109,6 +109,8 @@ class ListModel(list):
     def primitive(self):
         lst = []
         for e in self:
+            if isinstance(e, Model) or isinstance(e, ListModel):
+                e = e.primitive()
             lst.append(e)
         return lst
 

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -393,3 +393,15 @@ def total_size(o, handlers={}, verbose=False):
         return s
 
     return sizeof(o)
+
+
+def sort_dict(item: Dict):
+    """
+    Sort nested dict
+    Example:
+         Input: {'a': 1, 'c': 3, 'b': {'b2': 2, 'b1': 1}}
+         Output: {'a': 1, 'b': {'b1': 1, 'b2': 2}, 'c': 3}
+    """
+    # from Python 3.6, dictionary keeps the insertion order
+    # https://gist.github.com/gyli/f60f0374defc383aa098d44cfbd318eb
+    return {k: sort_dict(v) if isinstance(v, dict) else v for k, v in sorted(item.items())}

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -393,15 +393,3 @@ def total_size(o, handlers={}, verbose=False):
         return s
 
     return sizeof(o)
-
-
-def sort_dict(item: Dict):
-    """
-    Sort nested dict
-    Example:
-         Input: {'a': 1, 'c': 3, 'b': {'b2': 2, 'b1': 1}}
-         Output: {'a': 1, 'b': {'b1': 1, 'b2': 2}, 'c': 3}
-    """
-    # from Python 3.6, dictionary keeps the insertion order
-    # https://gist.github.com/gyli/f60f0374defc383aa098d44cfbd318eb
-    return {k: sort_dict(v) if isinstance(v, dict) else v for k, v in sorted(item.items())}


### PR DESCRIPTION
For each image metadata, generate a digest that captures all relevant config. The current relevant items for images are:

- the metadata config itself (remove owners: though)
- the entries in group.yml attr repos: corresponding to the image's enabled_repos and non_shipping_repos attrs
- the entries in streams.yml corresponding to any stream: entries in the image from and from.builder attrs

When rebasing, create a dict with these entries, serialize it as json (with ordered keys so it's consistent), and store a digest of that in new distgit file .oit/config_digest.

When scan-sources runs, generate the digest the same way and compare with the distgit. If the distgit digest is different or missing, the image should be rebuilt.