### PR TITLE
Enable fast reclaimation of working_dir

### DIFF
--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -40,6 +40,8 @@ def print_version(ctx, param, value):
               help="Git repo or directory containing groups metadata")
 @click.option("--working-dir", metavar='PATH', default=None,
               help="Existing directory in which file operations should be performed.\n Env var: DOOZER_WORKING_DIR")
+@click.option("--upcycle", default=False, is_flag=True,
+              help="Reclaims working directory; deletes doozer metadata and updates git repos to latest upstream content.")
 @click.option("--registry-config-dir", metavar='PATH', default=None,
               help="Directory containing docker config.json authentication; defaults to DOCKER_CONFIG env var if set, or `~/.docker/` if not.\n Env var: DOCKER_CONFIG")
 @click.option("--user", metavar='USERNAME', default=None,

--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -661,7 +661,7 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
         with Dir(clone_dir):
             exectools.cmd_assert(f'git remote add public {public_repo_url}')
             exectools.cmd_assert(f'git remote add fork {convert_remote_git_to_ssh(fork_repo.git_url)}')
-            exectools.cmd_assert('git fetch --all')
+            exectools.cmd_assert('git fetch --all', retries=3)
 
             # The path to the Dockerfile in the target branch
             if image_meta.config.content.source.dockerfile is not Missing:

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -135,6 +135,11 @@ class DistGitRepo(object):
 
             if os.path.isdir(self.distgit_dir):
                 self.logger.info("Distgit directory already exists; skipping clone: %s" % self.distgit_dir)
+                if self.runtime.upcycle:
+                    self.logger.info("Refreshing source for '{}' due to --upcycle".format(self.distgit_dir))
+                    with Dir(self.distgit_dir):
+                        exectools.cmd_assert('git fetch --all', retries=3)
+                        exectools.cmd_assert('git reset --hard @{upstream}', retries=3)
             else:
 
                 # Make a directory for the distgit namespace if it does not already exist

--- a/doozerlib/gitdata.py
+++ b/doozerlib/gitdata.py
@@ -58,7 +58,7 @@ class DataObj(object):
 
 class GitData(object):
     def __init__(self, data_path=None, clone_dir='./', commitish='master',
-                 sub_dir=None, exts=['yaml', 'yml', 'json'], logger=None):
+                 sub_dir=None, exts=['yaml', 'yml', 'json'], reclone=False, logger=None):
         """
         Load structured data from a git source.
         :param str data_path: Git url (git/http/https) or local directory path
@@ -66,6 +66,7 @@ class GitData(object):
         :param str commitish: Repo branch (tag or sha also allowed) to checkout
         :param str sub_dir: Sub dir in data to treat as root
         :param list exts: List of valid extensions to search for in data, with out period
+        :param reclone: If a clone is already present, remove it and reclone latest.
         :param logger: Python logging object to use
         :raises GitDataException:
         """
@@ -82,6 +83,7 @@ class GitData(object):
         self.exts = ['.' + e.lower() for e in exts]
         self.commit_hash = None
         self.origin_url = None
+        self.reclone = reclone
         if data_path:
             self.clone_data(data_path)
 
@@ -97,6 +99,10 @@ class GitData(object):
             data_name = os.path.splitext(os.path.basename(data_url.path))[0]
             data_destination = os.path.join(self.clone_dir, data_name)
             clone_data = True
+
+            if self.reclone and os.path.isdir(data_destination):
+                shutil.rmtree(data_destination)
+
             if os.path.isdir(data_destination):
                 self.logger.info('Data clone directory already exists, checking commit sha')
                 with Dir(data_destination):

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -275,7 +275,6 @@ class Runtime(object):
         return tmp_config
 
     def init_state(self):
-        self.state_file = os.path.join(self.working_dir, 'state.yaml')
         self.state = dict(state.TEMPLATE_BASE_STATE)
         if os.path.isfile(self.state_file):
             with io.open(self.state_file, 'r', encoding='utf-8') as f:
@@ -321,14 +320,29 @@ class Runtime(object):
                 os.makedirs(self.working_dir)
 
         self.distgits_dir = os.path.join(self.working_dir, "distgits")
+        self.distgits_diff_dir = os.path.join(self.working_dir, "distgits-diffs")
+        self.sources_dir = os.path.join(self.working_dir, "sources")
+        self.record_log_path = os.path.join(self.working_dir, "record.log")
+        self.brew_logs_dir = os.path.join(self.working_dir, "brew-logs")
+        self.flags_dir = os.path.join(self.working_dir, "flags")
+        self.state_file = os.path.join(self.working_dir, 'state.yaml')
+        self.debug_log_path = os.path.join(self.working_dir, "debug.log")
+
+        if self.upcycle:
+            # A working directory may be upcycle'd numerous times.
+            # Don't let anything grow unbounded.
+            shutil.rmtree(self.brew_logs_dir, ignore_errors=True)
+            shutil.rmtree(self.flags_dir, ignore_errors=True)
+            for path in (self.record_log_path, self.state_file, self.debug_log_path):
+                if os.path.exists(path):
+                    os.unlink(path)
+
         if not os.path.isdir(self.distgits_dir):
             os.mkdir(self.distgits_dir)
 
-        self.distgits_diff_dir = os.path.join(self.working_dir, "distgits-diffs")
         if not os.path.isdir(self.distgits_diff_dir):
             os.mkdir(self.distgits_diff_dir)
 
-        self.sources_dir = os.path.join(self.working_dir, "sources")
         if not os.path.isdir(self.sources_dir):
             os.mkdir(self.sources_dir)
 
@@ -369,17 +383,14 @@ class Runtime(object):
 
         self.resolve_metadata()
 
-        self.record_log_path = os.path.join(self.working_dir, "record.log")
         self.record_log = io.open(self.record_log_path, 'a', encoding='utf-8')
         atexit.register(close_file, self.record_log)
 
         # Directory where brew-logs will be downloaded after a build
-        self.brew_logs_dir = os.path.join(self.working_dir, "brew-logs")
         if not os.path.isdir(self.brew_logs_dir):
             os.mkdir(self.brew_logs_dir)
 
         # Directory for flags between invocations in the same working-dir
-        self.flags_dir = os.path.join(self.working_dir, "flags")
         if not os.path.isdir(self.flags_dir):
             os.mkdir(self.flags_dir)
 
@@ -617,7 +628,6 @@ class Runtime(object):
         main_stream_handler.setLevel(log_level)
         self.logger.addHandler(main_stream_handler)
 
-        self.debug_log_path = os.path.join(self.working_dir, "debug.log")
         debug_log_handler = logging.FileHandler(self.debug_log_path)
         # Add thread information for debug log
         debug_log_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s (%(thread)d) %(message)s'))
@@ -1033,7 +1043,7 @@ class Runtime(object):
             # Pull content to update the cache. This should be safe for multiple doozer instances to perform.
             self.logger.info(f'Updating cache directory for git remote: {remote_url}')
             # Fire and forget this fetch -- just used to keep cache as fresh as possible
-            exectools.fire_and_forget(repo_dir, 'git fetch --all')
+            exectools.fire_and_forget(repo_dir, 'git fetch --all', retries=3)
             gitargs.extend(['--dissociate', '--reference-if-able', repo_dir])
 
         self.logger.info(f'Cloning to: {target_dir}')
@@ -1114,6 +1124,11 @@ class Runtime(object):
                 if self.group_config.public_upstreams:
                     _, _, _, meta.public_upstream_url, meta.public_upstream_branch = self.source_resolutions[alias]
                 self.logger.info("Source '{}' already exists in (skipping clone): {}".format(alias, source_dir))
+                if self.upcycle:
+                    self.logger.info("Refreshing source for '{}' due to --upcycle: {}".format(alias, source_dir))
+                    with Dir(source_dir):
+                        exectools.cmd_assert('git fetch --all', retries=3)
+                        exectools.cmd_assert('git reset --hard @{upstream}', retries=3)
                 return source_dir
 
             url = source_details["url"]
@@ -1384,5 +1399,5 @@ class Runtime(object):
                  ).format(self.cfg_obj.full_path))
 
         self.gitdata = gitdata.GitData(data_path=self.data_path, clone_dir=self.working_dir,
-                                       commitish=self.group_commitish, logger=self.logger)
+                                       commitish=self.group_commitish, reclone=self.upcycle, logger=self.logger)
         self.data_dir = self.gitdata.data_dir

--- a/tests/test_distgit/test_generic_distgit.py
+++ b/tests/test_distgit/test_generic_distgit.py
@@ -54,7 +54,7 @@ class TestGenericDistGit(TestDistgit):
 
         metadata = flexmock(namespace="my-namespace",
                             distgit_key="my-distgit-key",
-                            runtime=flexmock(local=False, branch="_irrelevant_"),
+                            runtime=flexmock(local=False, branch="_irrelevant_", upcycle=False),
                             config=MockConfig(),
                             logger=logger,
                             name="_irrelevant_")


### PR DESCRIPTION
Experiment to see if a new parameter --upcycle could be used to keep around and reuse 4.x specific working directories for jobs like scan-sources. This also avoids the long `rm -rf` runs associated with these workspaces.