### PR TITLE
py3.9: Fix obsolete encoding arg

### DIFF
--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -315,7 +315,7 @@ class ImageMetadata(Metadata):
 
                 if not builder_brew_build:
                     out, err = exectools.cmd_assert(f'oc image info {brew_image_url} --filter-by-os amd64 -o=json', retries=5, pollrate=10)
-                    latest_builder_image_info = Model(json.loads(out, encoding='utf-8'))
+                    latest_builder_image_info = Model(json.loads(out))
                     builder_info_labels = latest_builder_image_info.config.config.Labels
                     builder_nvr_list = [builder_info_labels['com.redhat.component'], builder_info_labels['version'], builder_info_labels['release']]
 


### PR DESCRIPTION
The keyword `encoding` has been deprecated from `json.loads` since
Python 3.1, and is removed with Python 3.9.

See https://bugs.python.org/issue39377

Fixes this exception:

```
Traceback (most recent call last):
  File "/home/jdelft/src/github.com/openshift/doozer/doozerlib/runtime.py", line 98, in wrapper
    return func(*args, **kwargs)
  File "/home/jdelft/src/github.com/openshift/doozer/doozerlib/runtime.py", line 110, in wrapper
    return func(*args)
  File "/home/jdelft/src/github.com/openshift/doozer/doozerlib/cli/scan_sources.py", line 143, in <lambda>
    f=lambda image_meta, terminate_event: image_meta.does_image_need_change(changing_rpm_packages, image_meta.build_root_tag(), newest_image_event_ts, oldest_image_event_ts),
  File "/home/jdelft/src/github.com/openshift/doozer/doozerlib/image.py", line 318, in does_image_need_change
    latest_builder_image_info = Model(json.loads(out, encoding='utf-8'))
  File "/usr/lib64/python3.9/json/__init__.py", line 359, in loads
    return cls(**kw).decode(s)
TypeError: __init__() got an unexpected keyword argument 'encoding'
```