### PR TITLE
Avoid serialization error calculate_config_digest

### DIFF
--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -683,7 +683,10 @@ RUN yum install -y cov-sa csmock csmock-plugin-coverity csdiff
         if referred_streams:
             message["streams"] = {stream: streams[stream] for stream in referred_streams}
 
-        digest = hashlib.sha256(json.dumps(message, sort_keys=True).encode("utf-8")).hexdigest()
+        # Avoid non serializable objects. Known to occur for PosixPath objects in content.source.modifications.
+        default = lambda o: f"<<non-serializable: {type(o).__qualname__}>>"
+
+        digest = hashlib.sha256(json.dumps(message, sort_keys=True, default=default).encode("utf-8")).hexdigest()
         return "sha256:" + digest
 
 


### PR DESCRIPTION
While calculating the digests of configuration, `modifications` cause
some problems. Entities are:
1. Passed in as PosixPath, which is not serializable
2. Dependent on what `DOOZER_WORKING` is set to

This PR runs around these problems, hands covering eyes and fingers
stuck deeply in ears: If an object is not serializable, a string
representation of its class is used as an approximation. The exact
content is ignored.

Fixes:
```
2020-12-13 18:43:43,012 INFO [containers/openshift-enterprise-console] Calculating config digest...
Traceback (most recent call last):
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4@9/art-tools/doozer/doozerlib/cli/__main__.py", line 575, in dgr_rebase
    (real_version, real_release) = dgr.rebase_dir(version, release, terminate_event)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4@9/art-tools/doozer/doozerlib/distgit.py", line 2115, in rebase_dir
    real_version, real_release = self.update_distgit_dir(version, release, prev_release)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4@9/art-tools/doozer/doozerlib/distgit.py", line 1292, in update_distgit_dir
    self._generate_config_digest()
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4@9/art-tools/doozer/doozerlib/distgit.py", line 1562, in _generate_config_digest
    digest = self.metadata.calculate_config_digest(self.runtime.group_config, self.runtime.streams)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4@9/art-tools/doozer/doozerlib/image.py", line 686, in calculate_config_digest
    digest = hashlib.sha256(json.dumps(message, sort_keys=True).encode("utf-8")).hexdigest()
  File "/usr/lib64/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib64/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib64/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'PosixPath' is not JSON serializable
```