### PR TITLE
ART-1668: support validating yaml files created by ocp-build-data mod…

### DIFF
--- a/tests/test_source_modifications.py
+++ b/tests/test_source_modifications.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-import unittest
-import tempfile
 import os
-import shutil
-import mock
 import pathlib
+import shutil
+import tempfile
+import unittest
 
-from doozerlib.source_modifications import SourceModifierFactory, AddModifier
+import mock
+import yaml.scanner
+
+from doozerlib.source_modifications import AddModifier, SourceModifierFactory
 
 
 class SourceModifierFactoryTestCase(unittest.TestCase):
@@ -56,7 +58,7 @@ class AddModifierTestCase(unittest.TestCase):
             "path": os.path.join(self.temp_dir, "gating.yaml"),
             "overwriting": False,
         }
-        expected_content = "some\ncontent"
+        expected_content = b"some\ncontent"
         modifier = AddModifier(**params)
         with open(params["path"], "w") as f:
             f.write("some existing file")
@@ -68,6 +70,25 @@ class AddModifierTestCase(unittest.TestCase):
                 context = {"distgit_path": pathlib.Path(self.temp_dir)}
                 modifier.act(ceiling_dir=self.temp_dir, session=session, context=context)
             self.assertIn("overwrite", repr(cm.exception))
+
+    def test_act_failed_with_invalid_yaml(self):
+        params = {
+            "source": "http://example.com/gating_yaml",
+            "path": os.path.join(self.temp_dir, "gating.yaml"),
+            "overwriting": True,
+            "validate": "yaml"
+        }
+        expected_content = b"@!abc123"
+        modifier = AddModifier(**params)
+        with open(params["path"], "w") as f:
+            f.write("some existing file")
+        with mock.patch("requests.Session") as MockSession:
+            session = MockSession()
+            response = session.get.return_value
+            response.content = expected_content
+            with self.assertRaises(yaml.scanner.ScannerError):
+                context = {"distgit_path": pathlib.Path(self.temp_dir)}
+                modifier.act(ceiling_dir=self.temp_dir, session=session, context=context)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ification

Raise an error if the downloaded file is not YAML. See example at
https://github.com/openshift/ocp-build-data/pull/791.