### PR TITLE
ART-2624: Fix scan-sources gets a different config digest than rebase

### DIFF
--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -299,7 +299,7 @@ class Metadata(object):
         source_dir = self.runtime.resolve_source(self)
 
         # Maintainer info can be defined in metadata, so try there first.
-        maintainer = self.config.maintainer or dict()
+        maintainer = self.config.maintainer.copy() or dict()
 
         # This tuple will also define key ordering in the returned OrderedDict
         known_fields = ('product', 'component', 'subcomponent')


### PR DESCRIPTION
Some maintainer information is injected at runtime if not complete: https://github.com/openshift/doozer/blob/afc1bdb113935e30424ae06313524d2a974245a6/doozerlib/metadata.py#L330

By reading code calling get_maintainer_info, I think the maintainer
information is only retrieved from the return value and the changed
config meta is more like a side effect. So a simply fix could be copying
the dict before injecting into it.