### PR TITLE
Ensure fork is rebased if upstream Dockerfile change is introduced

### DIFF
--- a/doozerlib/dblib.py
+++ b/doozerlib/dblib.py
@@ -4,11 +4,16 @@ import time
 import os
 import threading
 import traceback
-import mysql.connector as mysql_connector
 from doozerlib import constants
 import functools
 from .model import Missing
 import datetime
+
+try:
+    import mysql.connector as mysql_connector
+except:
+    # Allow this module to be missing
+    pass
 
 
 class DBLibException(Exception):
@@ -105,6 +110,8 @@ class DB(object):
             self.runtime.logger.error("Environment variables required for db operation missing. Doozer will be running"
                                       "in no DB use mode.")
             return False
+
+        import mysql.connector as mysql_connector
 
         # if required configuration parameters are found, set instance attributes to configuration values
         self.host = os.getenv(constants.DB_HOST, constants.default_db_params[constants.DB_HOST])


### PR DESCRIPTION
1. PR opening logic detects the need for a change upstream and opens a PR.
2. Upstream team makes a change to the Dockerfile.
3. The change from (2) conflicts with the change from (1) and the PR needs to be rebased.

The new logic will detect a Dockerfile change and reset the fork to the desired state atop the new Dockerfile.