### PR TITLE
Raise an error on PR creation failure

### DIFF
--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -799,6 +799,7 @@ If you have any questions about this pull request, please reach out to `@art-tea
                         pr_links[dgk] = pr_url
                         yellow_print('Issue attempting to find it, but a PR is already open requesting desired reconciliation with ART')
                         continue
+                    raise ge
 
                 try:
                     if alignment_prs_config.auto_label and add_auto_labels:


### PR DESCRIPTION
We see the following error on
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/scheduled-builds/job/sync-ci-images/12692/console:

```
UnboundLocalError: local variable 'new_pr' referenced before assignment
```

Do not silently ignore PR creation exceptions. Let's see what will
happen if we re-raise that exception.