### PR TITLE
Pin target release for all operator builds:

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -482,7 +482,7 @@ class OLMBundle(object):
 
     @property
     def redhat_delivery_tags(self):
-        versions = 'v{MAJOR}.{MINOR}'.format(**self.runtime.group_config.vars)
+        versions = '=v{MAJOR}.{MINOR}'.format(**self.runtime.group_config.vars)
 
         return {
             # 'com.redhat.delivery.backport': 'true',


### PR DESCRIPTION
https://docs.engineering.redhat.com/display/CFC/Delivery describes
that 'v4.6' is actually interpreted as 'v4.6+'. To pin to an
exact release, we must use `=<version>`.