### PR TITLE
Deprecate legacy CA

### DIFF
--- a/.devcontainer/brewkoji.conf
+++ b/.devcontainer/brewkoji.conf
@@ -10,4 +10,3 @@ weburl = https://brewweb.engineering.redhat.com/brew
 topurl = http://download.devel.redhat.com/brewroot
 use_fast_upload = yes
 anon_retry = yes
-serverca = /etc/pki/brew/legacy.crt

--- a/Installation.md
+++ b/Installation.md
@@ -17,7 +17,6 @@ You must have valid corporate IT certificates imported on your system:
 ```
 $ cd /etc/pki/ca-trust/source/anchors
 $ sudo curl -O https://password.corp.redhat.com/RH-IT-Root-CA.crt
-$ sudo curl -O https://password.corp.redhat.com/legacy.crt
 $ sudo curl -k -O https://engineering.redhat.com/Eng-CA.crt
 $ sudo update-ca-trust extract
 ```

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -540,7 +540,6 @@ RUN if cat /etc/redhat-release | grep "release 8"; then wget https://dl.fedorapr
 
 # Certs necessary to install from covscan repos
 RUN wget https://password.corp.redhat.com/RH-IT-Root-CA.crt -O /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --no-check-certificate
-RUN wget https://password.corp.redhat.com/legacy.crt -O /etc/pki/ca-trust/source/anchors/legacy.crt --no-check-certificate
 RUN wget https://engineering.redhat.com/Eng-CA.crt -O /etc/pki/ca-trust/source/anchors/Eng-CA.crt --no-check-certificate
 RUN update-ca-trust
 RUN update-ca-trust enable

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -394,7 +394,6 @@ class OLMBundle(object):
         if not hasattr(self, '_brew_session'):
             self._brew_session = brew.koji.ClientSession(
                 self.runtime.group_config.urls.brewhub,
-                opts={'serverca': '/etc/pki/brew/legacy.crt'}
             )
         return self._brew_session
 


### PR DESCRIPTION
It is not used in latest brew and broken on new brew installation.