### PR TITLE
[ART-2816]: New implementation for building rpms

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -10,12 +10,13 @@ from doozerlib.model import Missing
 from doozerlib.brew import get_watch_task_info_copy
 from doozerlib import metadata
 from doozerlib.config import MetaDataConfig as mdc
-from doozerlib.cli import cli, pass_runtime
+from doozerlib.cli import cli, pass_runtime, validate_semver_major_minor_patch
 from doozerlib.cli.release_gen_payload import release_gen_payload
 from doozerlib.cli.detect_embargo import detect_embargo
 from doozerlib.cli.images_health import images_health
 from doozerlib.cli.images_streams import images_streams, images_streams_mirror, images_streams_gen_buildconfigs
 from doozerlib.cli.scan_sources import config_scan_source_changes
+from doozerlib.cli.rpms_build import rpms_build
 
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib import exectools
@@ -72,33 +73,6 @@ class RemoteRequired(click.Option):
 
         return super(RemoteRequired, self).handle_parse_result(
             ctx, opts, args)
-
-
-def validate_semver_major_minor_patch(ctx, param, version):
-    """
-    For non-None, non-auto values, ensures that the incoming parameter meets the criteria vX.Y.Z or X.Y.Z.
-    If minor or patch is not supplied, the value is modified to possess
-    minor.major to meet semver requirements.
-    :param ctx: Click context
-    :param param: The parameter specified on the command line
-    :param version: The version specified on the command line
-    :return:
-    """
-    if version == 'auto' or version is None:
-        return version
-
-    vsplit = version.split(".")
-    try:
-        int(vsplit[0].lstrip('v'))
-        minor_version = int('0' if len(vsplit) < 2 else vsplit[1])
-        patch_version = int('0' if len(vsplit) < 3 else vsplit[2])
-    except ValueError:
-        raise click.BadParameter('Expected integers in version fields')
-
-    if len(vsplit) > 3:
-        raise click.BadParameter('Expected X, X.Y, or X.Y.Z (with optional "v" prefix)')
-
-    return f'{vsplit[0]}.{minor_version}.{patch_version}'
 
 
 option_commit_message = click.option("--message", "-m", cls=RemoteRequired, metavar='MSG', help="Commit message for dist-git.")

--- a/doozerlib/cli/rpms_build.py
+++ b/doozerlib/cli/rpms_build.py
@@ -1,0 +1,109 @@
+import asyncio
+import traceback
+from typing import List
+
+import click
+
+from doozerlib import exectools
+from doozerlib.cli import (cli, click_coroutine, pass_runtime,
+                           validate_semver_major_minor_patch)
+from doozerlib.exceptions import DoozerFatalError
+from doozerlib.rpm_builder import RPMBuilder
+from doozerlib.rpmcfg import RPMMetadata
+from doozerlib.runtime import Runtime
+
+
+# This command is reimplementated command `rpms:build` without tito. Rename it to `rpms:build` when getting to prod.
+@cli.command("beta:rpms:build", help="Build rpms in the group or given by --rpms.")
+@click.option("--version", metavar='VERSION', default=None, callback=validate_semver_major_minor_patch,
+              help="Version string to populate in specfile.", required=True)
+@click.option("--release", metavar='RELEASE', default=None,
+              help="Release label to populate in specfile.", required=True)
+@click.option("--embargoed", default=False, is_flag=True, help="Add .p1 to the release string for all rpms, which indicates those rpms have embargoed fixes")
+@click.option('--scratch', default=False, is_flag=True, help='Perform a scratch build.')
+@click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
+@pass_runtime
+@click_coroutine
+async def rpms_build(runtime: Runtime, version: str, release: str, embargoed: bool, scratch: bool, dry_run: bool):
+    """
+    Attempts to build rpms for all of the defined rpms
+    in a group. If an rpm has already been built, it will be treated as
+    a successful operation.
+    """
+    exit_code = await _rpms_build(runtime, version=version, release=release, embargoed=embargoed, scratch=scratch, dry_run=dry_run)
+    exit(exit_code)
+
+
+async def _rpms_build(runtime: Runtime, version: str, release: str, embargoed: bool, scratch: bool, dry_run: bool):
+    if version.startswith('v'):
+        version = version[1:]
+
+    runtime.initialize(mode='rpms', clone_source=False, clone_distgits=False)  # We will clone distgits later.
+    if runtime.local:
+        raise DoozerFatalError("Local RPM build is not currently supported.")
+    if runtime.group_config.public_upstreams and (release is None or not release.endswith(".p?")):
+        raise click.BadParameter("You must explicitly specify a `release` ending with `.p?` when there is a public upstream mapping in ocp-build-data.")
+
+    runtime.assert_mutation_is_permitted()
+
+    rpms: List[RPMMetadata] = runtime.rpm_metas()
+    if not rpms:
+        runtime.logger.error("No RPMs found. Check the arguments.")
+        exit(0)
+
+    if embargoed:
+        for rpm in rpms:
+            rpm.private_fix = True
+
+    builder = RPMBuilder(runtime, dry_run=dry_run, scratch=scratch)
+
+    async def _rebase_and_build(rpm: RPMMetadata):
+        logger = rpm.logger
+        action = "build_rpm"
+        record = {
+            "distgit_key": rpm.distgit_key,
+            "rpm": rpm.rpm_name,
+            "version": version,
+            "release": release,
+            "message": "Unknown failure",
+            "targets": rpm.targets,
+            "status": -1,
+            # Status defaults to failure until explicitly set by succcess. This handles raised exceptions.
+        }
+        task_ids = []
+        task_urls = []
+        try:
+            await builder.rebase(rpm, version, release)
+            record["version"] = rpm.version
+            record["release"] = rpm.release
+            record["specfile"] = rpm.specfile
+            record["source_head"] = rpm.source_head
+            logger.info("rpm rebased: %s", rpm.distgit_key)
+            task_ids, task_urls = await builder.build(rpm)
+            record["status"] = 0
+            record["message"] = "Success"
+            logger.info("Successfully built rpm: %s ; Task URLs: %s", rpm.distgit_key, [url for url in task_urls])
+        except (Exception, KeyboardInterrupt) as e:
+            tb = traceback.format_exc()
+            record["message"] = "Exception occurred:\n{}".format(tb)
+            logger.error("Exception occurred when building %s:\n%s", rpm.distgit_key, tb)
+            if isinstance(e, exectools.RetryException):
+                task_ids, task_urls = e.args[1]
+        finally:
+            if task_ids:
+                record["task_ids"] = task_ids
+                record["task_urls"] = task_urls
+                record["task_id"] = task_ids[0]
+                record["task_url"] = task_urls[0]
+            runtime.add_record(action, **record)
+        return rpm.distgit_key, record["status"]
+    tasks = [asyncio.ensure_future(_rebase_and_build(rpm)) for rpm in rpms]
+    failed = []
+    for task in asyncio.as_completed(tasks):
+        dg_key, status = await task
+        if status != 0:
+            failed.append(dg_key)
+    if failed:
+        runtime.logger.error("\n".join(["Build/push failures:"] + sorted(failed)))
+        return 1
+    return 0

--- a/doozerlib/cli/rpms_build.py
+++ b/doozerlib/cli/rpms_build.py
@@ -13,8 +13,8 @@ from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.runtime import Runtime
 
 
-# This command is reimplementated command `rpms:build` without tito. Rename it to `rpms:build` when getting to prod.
-@cli.command("beta:rpms:build", help="Build rpms in the group or given by --rpms.")
+# This command reimplements `rpms:build` without tito. Rename it to `rpms:build` when getting to prod.
+@cli.command("beta:rpms:rebase-and-build", help="Build rpms in the group or given by --rpms.")
 @click.option("--version", metavar='VERSION', default=None, callback=validate_semver_major_minor_patch,
               help="Version string to populate in specfile.", required=True)
 @click.option("--release", metavar='RELEASE', default=None,
@@ -24,17 +24,17 @@ from doozerlib.runtime import Runtime
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @pass_runtime
 @click_coroutine
-async def rpms_build(runtime: Runtime, version: str, release: str, embargoed: bool, scratch: bool, dry_run: bool):
+async def rpms_rebase_and_build(runtime: Runtime, version: str, release: str, embargoed: bool, scratch: bool, dry_run: bool):
     """
-    Attempts to build rpms for all of the defined rpms
+    Attempts to rebase and build rpms for all of the defined rpms
     in a group. If an rpm has already been built, it will be treated as
     a successful operation.
     """
-    exit_code = await _rpms_build(runtime, version=version, release=release, embargoed=embargoed, scratch=scratch, dry_run=dry_run)
+    exit_code = await _rpms_rebase_and_build(runtime, version=version, release=release, embargoed=embargoed, scratch=scratch, dry_run=dry_run)
     exit(exit_code)
 
 
-async def _rpms_build(runtime: Runtime, version: str, release: str, embargoed: bool, scratch: bool, dry_run: bool):
+async def _rpms_rebase_and_build(runtime: Runtime, version: str, release: str, embargoed: bool, scratch: bool, dry_run: bool):
     if version.startswith('v'):
         version = version[1:]
 
@@ -58,52 +58,179 @@ async def _rpms_build(runtime: Runtime, version: str, release: str, embargoed: b
     builder = RPMBuilder(runtime, dry_run=dry_run, scratch=scratch)
 
     async def _rebase_and_build(rpm: RPMMetadata):
-        logger = rpm.logger
-        action = "build_rpm"
-        record = {
-            "distgit_key": rpm.distgit_key,
-            "rpm": rpm.rpm_name,
-            "version": version,
-            "release": release,
-            "message": "Unknown failure",
-            "targets": rpm.targets,
-            "status": -1,
-            # Status defaults to failure until explicitly set by succcess. This handles raised exceptions.
-        }
-        task_ids = []
-        task_urls = []
-        try:
-            await builder.rebase(rpm, version, release)
-            record["version"] = rpm.version
-            record["release"] = rpm.release
-            record["specfile"] = rpm.specfile
-            record["source_head"] = rpm.source_head
-            logger.info("rpm rebased: %s", rpm.distgit_key)
-            task_ids, task_urls = await builder.build(rpm)
-            record["status"] = 0
-            record["message"] = "Success"
-            logger.info("Successfully built rpm: %s ; Task URLs: %s", rpm.distgit_key, [url for url in task_urls])
-        except (Exception, KeyboardInterrupt) as e:
-            tb = traceback.format_exc()
-            record["message"] = "Exception occurred:\n{}".format(tb)
-            logger.error("Exception occurred when building %s:\n%s", rpm.distgit_key, tb)
-            if isinstance(e, exectools.RetryException):
-                task_ids, task_urls = e.args[1]
-        finally:
-            if task_ids:
-                record["task_ids"] = task_ids
-                record["task_urls"] = task_urls
-                record["task_id"] = task_ids[0]
-                record["task_url"] = task_urls[0]
-            runtime.add_record(action, **record)
-        return rpm.distgit_key, record["status"]
-    tasks = [asyncio.ensure_future(_rebase_and_build(rpm)) for rpm in rpms]
-    failed = []
-    for task in asyncio.as_completed(tasks):
-        dg_key, status = await task
+        status = await _rebase_rpm(runtime, builder, rpm, version, release)
         if status != 0:
-            failed.append(dg_key)
+            return status
+        status = await _build_rpm(runtime, builder, rpm)
+        return status
+    tasks = [asyncio.ensure_future(_rebase_and_build(rpm)) for rpm in rpms]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    failed = [rpms[i].distgit_key for i, r in enumerate(results) if r != 0]
     if failed:
-        runtime.logger.error("\n".join(["Build/push failures:"] + sorted(failed)))
+        runtime.logger.error("\n".join(["Build failures:"] + sorted(failed)))
         return 1
     return 0
+
+
+@cli.command("beta:rpms:rebase", help="Build rpms in the group or given by --rpms.")
+@click.option("--version", metavar='VERSION', default=None, callback=validate_semver_major_minor_patch,
+              help="Version string to populate in specfile.", required=True)
+@click.option("--release", metavar='RELEASE', default=None,
+              help="Release label to populate in specfile.", required=True)
+@click.option("--embargoed", default=False, is_flag=True, help="Add .p1 to the release string for all rpms, which indicates those rpms have embargoed fixes")
+@click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
+@pass_runtime
+@click_coroutine
+async def rpms_build(runtime: Runtime, version: str, release: str, embargoed: bool, dry_run: bool):
+    """
+    Attempts to rebase rpms for all of the defined rpms in a group.
+
+    For each rpm, uploads the source tarball to distgit lookaside cache and pulls the current source rpm spec file (and potentially other supporting
+    files) into distgit with transformations defined in the config yaml applied.
+
+    This operation will also set the version and release in the file according to the
+    command line arguments provided.
+    """
+    exit_code = await _rpms_rebase(runtime, version=version, release=release, embargoed=embargoed, dry_run=dry_run)
+    exit(exit_code)
+
+
+async def _rpms_rebase(runtime: Runtime, version: str, release: str, embargoed: bool, dry_run: bool):
+    if version.startswith('v'):
+        version = version[1:]
+
+    runtime.initialize(mode='rpms', clone_source=False, clone_distgits=False)  # We will clone distgits later.
+    if runtime.local:
+        raise DoozerFatalError("Local RPM build is not currently supported.")
+    if runtime.group_config.public_upstreams and (release is None or not release.endswith(".p?")):
+        raise click.BadParameter("You must explicitly specify a `release` ending with `.p?` when there is a public upstream mapping in ocp-build-data.")
+
+    runtime.assert_mutation_is_permitted()
+
+    rpms: List[RPMMetadata] = runtime.rpm_metas()
+    if not rpms:
+        runtime.logger.error("No RPMs found. Check the arguments.")
+        exit(0)
+
+    if embargoed:
+        for rpm in rpms:
+            rpm.private_fix = True
+
+    builder = RPMBuilder(runtime, dry_run=dry_run)
+    tasks = [asyncio.ensure_future(_rebase_rpm(runtime, builder, rpm, version, release)) for rpm in rpms]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    failed = [rpms[i].distgit_key for i, r in enumerate(results) if r != 0]
+    if failed:
+        runtime.logger.error("\n".join(["Build failures:"] + sorted(failed)))
+        return 1
+    return 0
+
+
+async def _rebase_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata, version, release):
+    logger = rpm.logger
+    action = "rebase_rpm"
+    record = {
+        "distgit_key": rpm.distgit_key,
+        "rpm": rpm.rpm_name,
+        "version": version,
+        "release": release,
+        "message": "Unknown failure",
+        "status": -1,
+        # Status defaults to failure until explicitly set by succcess. This handles raised exceptions.
+    }
+    try:
+        await builder.rebase(rpm, version, release)
+        record["version"] = rpm.version
+        record["release"] = rpm.release
+        record["specfile"] = rpm.specfile
+        record["private_fix"] = rpm.private_fix
+        record["source_head"] = rpm.source_head
+        record["source_commit"] = rpm.pre_init_sha or ""
+        record["dg_branch"] = rpm.distgit_repo().branch
+        record["status"] = 0
+        record["message"] = "Success"
+        logger.info("Successfully rebased rpm: %s", rpm.distgit_key)
+    except Exception:
+        tb = traceback.format_exc()
+        record["message"] = "Exception occurred:\n{}".format(tb)
+        logger.error("Exception occurred when rebasing %s:\n%s", rpm.distgit_key, tb)
+    finally:
+        runtime.add_record(action, **record)
+    return record["status"]
+
+
+# This command reimplements `rpms:build` without tito. Rename it to `rpms:build` when getting to prod.
+@cli.command("beta:rpms:build", help="Build rpms in the group or given by --rpms.")
+@click.option('--scratch', default=False, is_flag=True, help='Perform a scratch build.')
+@click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
+@pass_runtime
+@click_coroutine
+async def rpms_build(runtime: Runtime, scratch: bool, dry_run: bool):
+    """
+    Attempts to build rpms for all of the defined rpms
+    in a group. If an rpm has already been built, it will be treated as
+    a successful operation.
+    """
+    exit_code = await _rpms_build(runtime, scratch=scratch, dry_run=dry_run)
+    exit(exit_code)
+
+
+async def _rpms_build(runtime: Runtime, scratch: bool, dry_run: bool):
+    runtime.initialize(mode='rpms', clone_source=False, clone_distgits=False)  # We will clone distgits later.
+    if runtime.local:
+        raise DoozerFatalError("Local RPM build is not currently supported.")
+
+    runtime.assert_mutation_is_permitted()
+
+    rpms: List[RPMMetadata] = runtime.rpm_metas()
+    if not rpms:
+        runtime.logger.error("No RPMs found. Check the arguments.")
+        exit(0)
+
+    builder = RPMBuilder(runtime, dry_run=dry_run, scratch=scratch)
+    tasks = [asyncio.ensure_future(_build_rpm(runtime, builder, rpm)) for rpm in rpms]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    failed = [rpms[i].distgit_key for i, r in enumerate(results) if r != 0]
+    if failed:
+        runtime.logger.error("\n".join(["Build failures:"] + sorted(failed)))
+        return 1
+    return 0
+
+
+async def _build_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata):
+    logger = rpm.logger
+    action = "build_rpm"
+    record = {
+        "distgit_key": rpm.distgit_key,
+        "rpm": rpm.rpm_name,
+        "message": "Unknown failure",
+        "targets": rpm.targets,
+        "status": -1,
+        # Status defaults to failure until explicitly set by succcess. This handles raised exceptions.
+    }
+    task_ids = []
+    task_urls = []
+    try:
+        task_ids, task_urls = await builder.build(rpm)
+        record["version"] = rpm.version
+        record["release"] = rpm.release
+        record["specfile"] = rpm.specfile
+        record["status"] = 0
+        record["message"] = "Success"
+        logger.info("Successfully built rpm: %s ; Task URLs: %s", rpm.distgit_key, [url for url in task_urls])
+    except (Exception, KeyboardInterrupt) as e:
+        tb = traceback.format_exc()
+        record["message"] = "Exception occurred:\n{}".format(tb)
+        logger.error("Exception occurred when building %s:\n%s", rpm.distgit_key, tb)
+        if isinstance(e, exectools.RetryException):
+            task_ids, task_urls = e.args[1]
+    finally:
+        if task_ids:
+            record["task_ids"] = task_ids
+            record["task_urls"] = task_urls
+            record["task_id"] = task_ids[0]
+            record["task_url"] = task_urls[0]
+        runtime.add_record(action, **record)
+    return record["status"]

--- a/doozerlib/dblib.py
+++ b/doozerlib/dblib.py
@@ -107,8 +107,8 @@ class DB(object):
         """
 
         if not (constants.DB_USER in os.environ and constants.DB_PWD in os.environ):
-            self.runtime.logger.error("Environment variables required for db operation missing. Doozer will be running"
-                                      "in no DB use mode.")
+            self.runtime.logger.warning("Environment variables required for db operation missing. Doozer will be running"
+                                        "in no DB use mode.")
             return False
 
         import mysql.connector as mysql_connector

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -290,7 +290,7 @@ class DistGitRepo(object):
         with Dir(self.distgit_dir):
             self.logger.info("Pushing distgit repository %s", self.name)
             try:
-                # When initializing new release branches, an large amount of data needs to
+                # When initializing new release branches, a large amount of data needs to
                 # be pushed. If every distgit within a release is being pushed at the same
                 # time, a single push invocation can take hours to complete -- making the
                 # timeout value counterproductive. Limit to 5 simultaneous pushes.

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -12,7 +12,7 @@ import time
 import traceback
 from datetime import date
 from multiprocessing import Event, Lock
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import bashlex
 import yaml
@@ -259,6 +259,9 @@ class DistGitRepo(object):
         assertion.isdir(path, "Unable to find path for source [%s] for config: %s" % (path, self.metadata.config_filename))
         return path
 
+    def _get_diff(self):
+        return None  # to actually record a diff, child classes must override this function
+
     def commit(self, commit_message, log_diff=False):
         if self.runtime.local:
             return ''  # no commits if local
@@ -266,9 +269,9 @@ class DistGitRepo(object):
         with Dir(self.distgit_dir):
             self.logger.info("Adding commit to local repo: {}".format(commit_message))
             if log_diff:
-                rc, out, err = exectools.cmd_gather(["git", "diff", "Dockerfile"])
-                assertion.success(rc, 'Failed fetching distgit diff')
-                self.runtime.add_distgits_diff(self.metadata.distgit_key, out)
+                diff = self._get_diff()
+                if diff and diff.strip():
+                    self.runtime.add_distgits_diff(self.metadata.distgit_key, diff)
             if self.source_sha:
                 # add short sha of source for audit trail
                 commit_message += " - {}".format(self.source_sha)
@@ -279,6 +282,35 @@ class DistGitRepo(object):
             rc, sha, err = exectools.cmd_gather(["git", "rev-parse", "HEAD"])
             assertion.success(rc, "Failure fetching commit SHA for {}".format(self.distgit_dir))
         return sha.strip()
+
+    def push(self):
+        with Dir(self.distgit_dir):
+            self.logger.info("Pushing distgit repository %s", self.name)
+            try:
+                # When initializing new release branches, an large amount of data needs to
+                # be pushed. If every distgit within a release is being pushed at the same
+                # time, a single push invocation can take hours to complete -- making the
+                # timeout value counterproductive. Limit to 5 simultaneous pushes.
+                with self.runtime.get_named_semaphore('rhpkg::push', count=5):
+                    timeout = str(self.runtime.global_opts['rhpkg_push_timeout'])
+                    exectools.cmd_assert("timeout {} rhpkg push".format(timeout), retries=3)
+                    # rhpkg will create but not push tags :(
+                    # Not asserting this exec since this is non-fatal if a tag already exists,
+                    # and tags in dist-git can't be --force overwritten
+                    exectools.cmd_gather(['timeout', '60', 'git', 'push', '--tags'])
+            except IOError as e:
+                return (self.metadata, repr(e))
+            return (self.metadata, True)
+
+    @exectools.limit_concurrency(limit=5)
+    async def push_async(self):
+        self.logger.info("Pushing distgit repository %s", self.name)
+        # When initializing new release branches, an large amount of data needs to
+        # be pushed. If every distgit within a release is being pushed at the same
+        # time, a single push invocation can take hours to complete -- making the
+        # timeout value counterproductive. Limit to 5 simultaneous pushes.
+        timeout = str(self.runtime.global_opts['rhpkg_push_timeout'])
+        await exectools.cmd_assert_async(["timeout", f"{timeout}", "git", "push", "--follow-tags"], cwd=self.distgit_dir, retries=3)
 
     def tag(self, version, release):
         if self.runtime.local:
@@ -325,6 +357,11 @@ class ImageDistGitRepo(DistGitRepo):
     def clone(self, distgits_root_dir, distgit_branch):
         super(ImageDistGitRepo, self).clone(distgits_root_dir, distgit_branch)
         self._read_master_data()
+
+    def _get_diff(self):
+        rc, out, _ = exectools.cmd_gather(["git", "-C", self.distgit_dir, "diff", "Dockerfile"])
+        assertion.success(rc, 'Failed fetching distgit diff')
+        return out
 
     @property
     def image_build_method(self):
@@ -1195,25 +1232,6 @@ class ImageDistGitRepo(DistGitRepo):
         except OSError as e:
             self.logger.warning("Exception while trying to analyze build logs in {}: {}".format(logs_dir, e))
 
-    def push(self):
-        with Dir(self.distgit_dir):
-            self.logger.info("Pushing repository")
-            try:
-                # When initializing new release branches, an large amount of data needs to
-                # be pushed. If every distgit within a release is being pushed at the same
-                # time, a single push invocation can take hours to complete -- making the
-                # timeout value counterproductive. Limit to 5 simultaneous pushes.
-                with self.runtime.get_named_semaphore('rhpkg::push', count=5):
-                    timeout = str(self.runtime.global_opts['rhpkg_push_timeout'])
-                    exectools.cmd_assert("timeout {} rhpkg push".format(timeout), retries=3)
-                    # rhpkg will create but not push tags :(
-                    # Not asserting this exec since this is non-fatal if a tag already exists,
-                    # and tags in dist-git can't be --force overwritten
-                    exectools.cmd_gather(['timeout', '60', 'git', 'push', '--tags'])
-            except IOError as e:
-                return (self.metadata, repr(e))
-            return (self.metadata, True)
-
     @staticmethod
     def _mangle_yum(cmd):
         # alter the arg by splicing its content
@@ -2029,7 +2047,6 @@ class ImageDistGitRepo(DistGitRepo):
         """
         Interprets and applies content.source.modify steps in the image metadata.
         """
-
         dg_path = self.dg_path
         df_path = dg_path.joinpath('Dockerfile')
         with df_path.open('r', encoding="utf-8") as df:
@@ -2058,14 +2075,14 @@ class ImageDistGitRepo(DistGitRepo):
                     "distgit_path": self.dg_path,
                 }
                 modifier.act(context=context, ceiling_dir=str(dg_path))
-                dockerfile_data = context["content"]
+                new_dockerfile_data = context.get("result")
             else:
                 raise IOError("Don't know how to perform modification action: %s" % modification.action)
+        if new_dockerfile_data is not None and new_dockerfile_data != dockerfile_data:
+            with df_path.open('w', encoding="utf-8") as df:
+                df.write(new_dockerfile_data)
 
-        with df_path.open('w', encoding="utf-8") as df:
-            df.write(dockerfile_data)
-
-    def extract_version_release_private_fix(self) -> (str, str, str):
+    def extract_version_release_private_fix(self) -> Tuple[str, str, str]:
         """
         Extract version, release, and private_fix fields from Dockerfile.
         """
@@ -2142,10 +2159,3 @@ class RPMDistGitRepo(DistGitRepo):
         self.source = self.config.content.source
         if self.source.specfile is Missing:
             raise ValueError('Must specify spec file name for RPMs.')
-
-    def _find_in_spec(self, spec, regex, desc):
-        match = re.search(regex, spec)
-        if match:
-            return match.group(1)
-        self.logger.error("No {} found in specfile '{}'".format(desc, self.source.specfile))
-        return ""

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -8,7 +8,7 @@ import json
 import traceback
 
 from .pushd import Dir
-from .distgit import ImageDistGitRepo, RPMDistGitRepo, DistGitRepo
+from .distgit import ImageDistGitRepo, RPMDistGitRepo
 from . import exectools
 from . import logutil
 from . import brew
@@ -106,7 +106,7 @@ class Metadata(object):
             return f'ssh://{self.runtime.user}@{pkgs_host}/{self.qualified_name}'
         return f'ssh://{pkgs_host}/{self.qualified_name}'
 
-    def distgit_repo(self, autoclone=True) -> DistGitRepo:
+    def distgit_repo(self, autoclone=True) -> RPMDistGitRepo:
         if self._distgit_repo is None:
             self._distgit_repo = DISTGIT_TYPES[self.meta_type](self, autoclone=autoclone)
         return self._distgit_repo

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -1,0 +1,386 @@
+import asyncio
+import logging
+import re
+import shutil
+import threading
+from os import PathLike
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import aiofiles
+import aiofiles.os
+
+from doozerlib import brew, exectools
+from doozerlib.distgit import DistGitRepo, RPMDistGitRepo
+from doozerlib.model import Missing
+from doozerlib.rpmcfg import RPMMetadata
+from doozerlib.runtime import Runtime
+from doozerlib.util import is_in_directory
+
+
+class RPMBuilder:
+    """ It builds RPMs!
+    """
+
+    def __init__(
+        self, runtime: Runtime, *, scratch: bool = False, dry_run: bool = False
+    ) -> None:
+        """ Create a RPMBuilder instance.
+        :param runtime: Doozer runtime
+        :param scratch: Whether to create a scratch build
+        :param dry_run: Don't build anything but just exercise the code
+        """
+        self._runtime = runtime
+        self._scratch = scratch
+        self._dry_run = dry_run
+
+    async def rebase(self, rpm: RPMMetadata, version: str, release: str) -> str:
+        """ Rebases and pushes the distgit repo for an rpm
+        :param rpm: Metadata of the rpm
+        :param version: Set rpm version
+        :param release: Set rpm release
+        :return: Hash of the new distgit commit
+        """
+        logger = rpm.logger
+        # clone source and distgit
+        logger.info("Cloning source and distgit repos...")
+        dg: RPMDistGitRepo
+        _, dg = await asyncio.gather(
+            exectools.to_thread(rpm.clone_source),
+            exectools.to_thread(rpm.distgit_repo, autoclone=True),
+        )
+        # cleanup distgit dir
+        logger.info("Cleaning up distgit repo...")
+        await exectools.cmd_assert_async(
+            ["git", "reset", "--hard", "origin/" + dg.branch], cwd=dg.distgit_dir
+        )
+        await exectools.cmd_assert_async(
+            ["git", "rm", "--ignore-unmatch", "-rf", "."], cwd=dg.distgit_dir
+        )
+
+        # set .p0/.p1 flag
+        if self._runtime.group_config.public_upstreams:
+            if not release.endswith(".p?"):
+                raise ValueError(
+                    f"'release' must end with '.p?' for an rpm with a public upstream but its actual value is {release}"
+                )
+            if rpm.private_fix is None:
+                raise AssertionError("rpm.private_fix flag should already be set")
+            if rpm.private_fix:
+                logger.warning("Source contains embargoed fixes.")
+                pval = ".p1"
+            else:
+                pval = ".p0"
+            release = release[:-3] + pval
+
+        # include commit hash in release field
+        release += ".git." + rpm.pre_init_sha[:7]
+        rpm.set_nvr(version, release)
+
+        # generate new specfile
+        tarball_name = f"{rpm.config.name}-{rpm.version}-{rpm.release}.tar.gz"
+        logger.info("Creating rpm spec file...")
+        specfile = await self._populate_specfile_async(rpm, tarball_name)
+        dg_specfile_path = dg.dg_path / Path(rpm.specfile).name
+        async with aiofiles.open(dg_specfile_path, "w") as f:
+            await f.writelines(specfile)
+
+        # create tarball source as Source0
+        logger.info("Creating tarball source...")
+        tarball_path = dg.dg_path / tarball_name
+        await exectools.cmd_assert_async(
+            [
+                "tar",
+                "-czf",
+                tarball_path,
+                "--exclude=.git",
+                fr"--transform=s,^\./,{rpm.config.name}-{rpm.version}/,",
+                ".",
+            ],
+            cwd=rpm.source_path,
+        )
+        logger.info(
+            "Done creating tarball source. Uploading to distgit lookaside cache..."
+        )
+        if not self._dry_run:
+            await exectools.cmd_assert_async(
+                ["rhpkg", "new-sources", tarball_name], cwd=dg.dg_path, retries=3
+            )
+        else:
+            async with aiofiles.open(dg.dg_path / "sources", "w") as f:
+                f.write("SHA512 ({}) = {}\n".format(tarball_name, "0" * 128))
+            logger.warning("DRY RUN - Would have uploaded %s", tarball_name)
+
+        # copy Source1, Source2,... and Patch0, Patch1,...
+        logger.info("Determining additional sources and patches...")
+        out, _ = await exectools.cmd_assert_async(
+            ["spectool", "--", dg_specfile_path], cwd=dg.dg_path
+        )
+        for line in out.splitlines():
+            line_split = line.split(": ")
+            if len(line_split) < 2 or line_split[0] == "Source0":
+                continue
+            filename = line_split[1].strip()
+            src = Path(rpm.source_path, filename)
+            # For security, ensure the source file referenced by the specfile is contained in both source and distgit directories.
+            if not is_in_directory(src, rpm.source_path):
+                raise ValueError(
+                    "STOP! Source file {} referenced in Specfile {} lives outside of the source directory {}".format(
+                        filename, dg_specfile_path, rpm.source_path
+                    )
+                )
+            dest = dg.dg_path / filename
+            if not is_in_directory(dest, dg.dg_path):
+                raise ValueError(
+                    "STOP! Source file {} referenced in Specfile {} would be copied to a directory outside of distgit directory {}".format(
+                        filename, dg_specfile_path, dg.dg_path
+                    )
+                )
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            logging.debug("Copying %s", filename)
+
+            shutil.copy(src, dest, follow_symlinks=False)
+
+        # run modifications
+        if rpm.config.content.source.modifications is not Missing:
+            logging.info("Running custom modifications...")
+            await exectools.to_thread(
+                rpm._run_modifications, dg_specfile_path, dg.dg_path
+            )
+
+        # commit changes
+        logging.info("Committing distgit changes...")
+        await aiofiles.os.remove(tarball_path)
+        commit_hash = await exectools.to_thread(dg.commit,
+                                                f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}]."
+                                                )
+
+        # push
+        if not self._dry_run:
+            await dg.push_async()
+        else:
+            logger.warning("Would have pushed %s", dg.name)
+        return commit_hash
+
+    async def build(self, rpm: RPMMetadata, retries: int = 3):
+        """ Builds rpm with the latest distgit commit
+        :param rpm: Metadata of the RPM
+        :param retries: The number of times to retry
+        """
+        logger = rpm.logger
+        dg = rpm.distgit_repo()
+
+        if len(rpm.targets) > 1:  # for a multi target build, we need to ensure all buildroots have valid versions of golang compilers
+            logger.info("Checking whether this is a golang package...")
+            if await self._golang_required(dg.dg_path / Path(rpm.specfile).name):
+                # assert buildroots contain the correct versions of golang
+                logger.info(
+                    "This is a golang package. Checking whether buildroots contain consistent versions of golang compilers..."
+                )
+                await exectools.to_thread(rpm.assert_golang_versions)
+
+        # Submit build tasks
+        message = "Unknown error"
+        for attempt in range(retries):
+            # errors, task_ids, task_urls = await self._create_build_tasks(dg)
+            task_ids = []
+            task_urls = []
+            logger.info("Creating Brew tasks...")
+            for task_id, task_url in await asyncio.gather(
+                *[self._build_target_async(rpm, target) for target in rpm.targets]
+            ):
+                task_ids.append(task_id)
+                task_urls.append(task_url)
+
+            # Wait for all tasks to complete
+            logger.info("Waiting for all tasks to complete")
+            errors = await self._watch_tasks_async(task_ids, logger)
+
+            # Gather brew-logs
+            logger.info("Gathering brew-logs")
+            for target, task_id in zip(rpm.targets, task_ids):
+                logs_dir = (
+                    Path(self._runtime.brew_logs_dir) / rpm.name / f"{target}-{task_id}"
+                )
+                cmd = ["brew", "download-logs", "--recurse", "-d", logs_dir, task_id]
+                if not self._dry_run:
+                    logs_rc, _, logs_err = await exectools.cmd_gather_async(cmd)
+                    if logs_rc != exectools.SUCCESS:
+                        logger.warning(
+                            "Error downloading build logs from brew for task %s: %s"
+                            % (task_id, logs_err)
+                        )
+                else:
+                    logger.warning("DRY RUN - Would have downloaded Brew logs with %s", cmd)
+            failed_tasks = {task_id for task_id, error in errors.items() if error is not None}
+            if not failed_tasks:
+                logger.info("Successfully built rpm: %s", rpm.rpm_name)
+                rpm.build_status = True
+                break
+            # An error occurred. We don't have a viable build.
+            message = ", ".join(
+                f"Task {task_id} failed: {errors[task_id]}"
+                for task_id in failed_tasks
+            )
+            logger.warning(
+                "Error building rpm %s [attempt #%s] in Brew: %s",
+                rpm.qualified_name,
+                attempt + 1,
+                message,
+            )
+            if attempt < retries - 1:
+                # Brew does not handle an immediate retry correctly, wait before trying another build
+                await asyncio.sleep(5 * 60)
+        if not rpm.build_status:
+            raise exectools.RetryException(
+                f"Giving up after {retries} failed attempt(s): {message}",
+                (task_ids, task_urls),
+            )
+        return task_ids, task_urls
+
+    async def _golang_required(self, specfile: PathLike):
+        """Returns True if this RPM requires a golang compiler"""
+        out, _ = await exectools.cmd_assert_async(
+            ["rpmspec", "-q", "--buildrequires", "--", specfile]
+        )
+        return any(dep.strip().startswith("golang") for dep in out.splitlines())
+
+    @staticmethod
+    async def _populate_specfile_async(
+        rpm: RPMMetadata, source_filename: str
+    ) -> List[str]:
+        """Populates spec file
+        :param source_filename: Path to the template spec file
+        """
+        if not rpm.source_path:
+            raise ValueError("Source is not cloned.")
+        maintainer = await exectools.to_thread(rpm.get_maintainer_info)
+        maintainer_string = ""
+        if maintainer:
+            flattened_info = ", ".join(f"{k}: {v}" for (k, v) in maintainer.items())
+            # The space before the [Maintainer] information is actual rpm spec formatting
+            # clue to preserve the line instead of assuming it is part of a paragraph.
+            maintainer_string = f"[Maintainer] {flattened_info}"
+
+        # otherwise, make changes similar to tito tagging
+        rpm_spec_tags = {
+            "Name:": "Name:           {}\n".format(rpm.config.name),
+            "Version:": "Version:        {}\n".format(rpm.version),
+            "Release:": "Release:        {}%{{?dist}}\n".format(rpm.release),
+            "Source0:": f"Source0:        {source_filename}\n",
+        }
+
+        # rpm.version example: 3.9.0
+        # Extract the major, minor, patch
+        major, minor, patch = rpm.version.split(".")
+        full = "v{}".format(rpm.version)
+
+        # If this is a pre-release RPM, the include the release field in
+        # the full version.
+        # pre-release full version: v3.9.0-0.20.1
+        # release full version: v3.9.0
+        if rpm.release.startswith("0."):
+            full += "-{}".format(rpm.release)
+
+        commit_sha = rpm.pre_init_sha
+
+        # Update with NVR, env vars, and descriptions
+        described = False
+        async with aiofiles.open(rpm.specfile, "r") as sf:
+            lines = await sf.readlines()
+        for i in range(len(lines)):
+            line = lines[i].strip().lower()
+            # If an RPM has sub packages, there can be multiple %description directives
+            if line.startswith("%description"):
+                lines[i] = f"{lines[i].strip()}\n{maintainer_string}\n"
+                described = True
+            elif line.startswith("%global os_git_vars "):
+                lines[
+                    i
+                ] = f"%global os_git_vars OS_GIT_VERSION={major}.{minor}.{patch}-{rpm.release}-{commit_sha[0:7]} OS_GIT_MAJOR={major} OS_GIT_MINOR={minor} OS_GIT_PATCH={patch} OS_GIT_COMMIT={commit_sha} OS_GIT_TREE_STATE=clean"
+                for k, v in rpm.extra_os_git_vars.items():
+                    lines[i] += f" {k}={v}"
+                lines[i] += "\n"
+            elif line.startswith("%global commit"):
+                lines[i] = re.sub(
+                    r"commit\s+\w+", "commit {}".format(commit_sha), lines[i]
+                )
+            elif line.startswith("%setup"):
+                lines[i] = f"%setup -q -n {rpm.config.name}-{rpm.version}\n"
+            elif line.startswith("%autosetup"):
+                lines[i] = f"%autosetup -S git -n {rpm.config.name}-{rpm.version} -p1\n"
+
+            elif rpm_spec_tags:  # If there are keys left to replace
+                for k in list(rpm_spec_tags.keys()):
+                    v = rpm_spec_tags[k]
+                    # Note that tags are not case sensitive
+                    if lines[i].lower().startswith(k.lower()):
+                        lines[i] = v
+                        del rpm_spec_tags[k]
+                        break
+
+        # If there are still rpm tags to inject, do so
+        for v in rpm_spec_tags.values():
+            lines.insert(0, v)
+
+        # If we didn't find a description, create one
+        if not described:
+            lines.insert(0, f"%description\n{maintainer_string}\n")
+
+        return lines
+
+    async def _build_target_async(self, rpm: RPMMetadata, target: str):
+        """ Creates a Brew task to build the rpm against specific target
+        :param rpm: Metadata of the rpm
+        :param target: The target to build against
+        """
+        dg: RPMDistGitRepo = rpm.distgit_repo()
+        logger = rpm.logger
+        logger.info("Building %s against target %s", rpm.name, target)
+        cmd = ["rhpkg", "build", "--nowait", "--target", target]
+        if self._scratch:
+            cmd.append("--skip-tag")
+        if not self._dry_run:
+            out, _ = await exectools.cmd_assert_async(cmd, cwd=dg.dg_path)
+        else:
+            logger.warning("DRY RUN - Would have created Brew task with %s", cmd)
+            out = "Created task: 0\nTask info: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=0\n"
+        # we should have a brew task we can monitor listed in the stdout.
+        out_lines = out.splitlines()
+        # Look for a line like: "Created task: 13949050" . Extract the identifier.
+        task_id = int(
+            next(
+                (line.split(":")[1]).strip()
+                for line in out_lines
+                if line.startswith("Created task:")
+            )
+        )
+        # Look for a line like: "Task info: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=13948942"
+        task_url = next(
+            (line.split(":", 1)[1]).strip()
+            for line in out_lines
+            if line.startswith("Task info:")
+        )
+        logger.info("Build running: %s - %s - %s", rpm.rpm_name, target, task_url)
+        return task_id, task_url
+
+    async def _watch_tasks_async(
+        self, task_ids: List[int], logger: logging.Logger
+    ) -> Dict[int, Optional[str]]:
+        """ Asynchronously watches Brew Tasks for completion
+        :param task_ids: List of Brew task IDs
+        :param logger: A logger for logging
+        :return: a dict of task ID and error message mappings
+        """
+        if self._dry_run:
+            return {task_id: None for task_id in task_ids}
+        brew_session = self._runtime.build_retrying_koji_client()
+        terminate_event = threading.Event()
+        try:
+            errors = await exectools.to_thread(
+                brew.watch_tasks, brew_session, logger.info, task_ids, terminate_event
+            )
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            terminate_event.set()
+            raise
+        return errors

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1340,7 +1340,7 @@ class Runtime(object):
             while not ret.ready():
                 ret.wait(60)
         except KeyboardInterrupt:
-            self.logger.warn('SIGINT received, signaling threads to terminate...')
+            self.logger.warning('SIGINT received, signaling threads to terminate...')
             terminate_event.set()
         pool.join()
         return ret

--- a/doozerlib/source_modifications.py
+++ b/doozerlib/source_modifications.py
@@ -164,7 +164,7 @@ class ReplaceModifier(object):
         LOGGER.debug(
             "Performed string replace '%s' -> '%s':\n%s\n" %
             (match, replacement, post))
-        context["content"] = post
+        context["result"] = post
 
 
 SourceModifierFactory.MODIFICATIONS["replace"] = ReplaceModifier
@@ -186,7 +186,8 @@ class CommandModifier(object):
         """
         context = kwargs["context"]
         set_env = context["set_env"]
-        with Dir(context['distgit_path']):
+        ceiling_dir = kwargs["ceiling_dir"]
+        with Dir(ceiling_dir):
             cmd_assert(self.command, set_env=set_env)
 
 

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, unicode_literals
+from pathlib import Path
 import click
 import copy
 import os
@@ -194,15 +195,16 @@ def is_commit_in_public_upstream(revision: str, public_upstream_branch: str, sou
     raise IOError(f"Couldn't determine if the commit {revision} is in the public upstream source repo. `git merge-base` exited with {rc}, stdout={out}, stderr={err}")
 
 
-def is_in_directory(path, directory):
+def is_in_directory(path: os.PathLike, directory: os.PathLike):
     """check whether a path is in another directory
-
-    FIXME: Use os.path.commonpath when migrated to Python 3
     """
-    path = os.path.realpath(path)
-    directory = os.path.realpath(directory)
-    relative = os.path.relpath(os.path.dirname(path), directory)
-    return relative != os.pardir and not relative.startswith(os.pardir + os.sep)
+    a = Path(path).parent.resolve()
+    b = Path(directory).resolve()
+    try:
+        a.relative_to(b)
+        return True
+    except ValueError:
+        return False
 
 
 def mkdirs(path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,10 @@ contextvars ; python_version<"3.7"
 dockerfile-parse >= 0.0.13
 future
 koji
-mock
 PyGitHub >= 1.46
 pyyaml >= 5.1
 requests
 requests_kerberos
-retry
 rpm-py-installer
 semver
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
+aiofiles
 bashlex
 click >= 6.7
+contextvars ; python_version<"3.7"
 dockerfile-parse >= 0.0.13
 future
 koji

--- a/tests/cli/test_rpms_build.py
+++ b/tests/cli/test_rpms_build.py
@@ -1,0 +1,124 @@
+import asyncio
+import logging
+from unittest import TestCase
+
+from mock import AsyncMock, MagicMock, Mock, patch
+
+from doozerlib import gitdata, rpmcfg
+from doozerlib.cli.rpms_build import _rpms_build
+from doozerlib.exectools import RetryException
+
+
+class TestRPMsBuildCli(TestCase):
+    @patch("doozerlib.cli.rpms_build.RPMBuilder")
+    def test_rpms_build_success(self, MockedRPMBuilder: Mock):
+        runtime = MagicMock(local=False)
+        runtime.assert_mutation_is_permitted = MagicMock()
+        version = "v1.2.3"
+        release = "202104070000.yuxzhu.test.p?"
+        embargoed = True
+        scratch = False
+        dry_run = False
+        rpms = []
+
+        data_obj = gitdata.DataObj("foo", "/path/to/ocp-build-data/rpms/foo.yml", {
+            "name": "foo",
+            "content": {
+                "source": {
+                    "git": {"url": "git@github.com:openshift-priv/foo.git", "branch": {"target": "release-4.8"}},
+                    "specfile": "foo.spec",
+                    "modifications": [
+                        {"action": "add", "command": ["my-command", "--my-arg"]}
+                    ],
+                }
+            },
+            "targets": ["rhaos-4.4-rhel-8-candidate", "rhaos-4.4-rhel-7-candidate"],
+        })
+        rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
+        rpm.logger = MagicMock(spec=logging.Logger)
+        rpms.append(rpm)
+
+        data_obj = gitdata.DataObj("bar", "/path/to/ocp-build-data/rpms/bar.yml", {
+            "name": "bar",
+            "content": {
+                "source": {
+                    "git": {"url": "git@github.com:openshift-priv/bar.git", "branch": {"target": "release-4.8"}},
+                    "specfile": "bar.spec",
+                }
+            },
+            "targets": ["rhaos-4.4-rhel-8-candidate"],
+        })
+        rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
+        rpm.logger = MagicMock(spec=logging.Logger)
+        rpms.append(rpm)
+
+        runtime.rpm_metas.return_value = rpms
+        builder = MockedRPMBuilder.return_value = AsyncMock()
+        builder.build.return_value = ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"])
+        records = []
+        runtime.add_record.side_effect = lambda action, **kwargs: records.append((action, kwargs))
+
+        result = asyncio.get_event_loop().run_until_complete(_rpms_build(runtime, version, release, embargoed, scratch, dry_run))
+
+        self.assertEqual(result, 0)
+        for rpm in rpms:
+            builder.rebase.assert_any_call(rpm, version.lstrip("v"), release)
+            builder.build.assert_any_call(rpm)
+        self.assertTrue(all(record["status"] == 0 for action, record in records))
+
+    @patch("doozerlib.cli.rpms_build.RPMBuilder")
+    def test_rpms_build_failure(self, MockedRPMBuilder: Mock):
+        runtime = MagicMock(local=False)
+        runtime.assert_mutation_is_permitted = MagicMock()
+        version = "v1.2.3"
+        release = "202104070000.yuxzhu.test.p?"
+        embargoed = True
+        scratch = False
+        dry_run = False
+        rpms = []
+
+        data_obj = gitdata.DataObj("foo", "/path/to/ocp-build-data/rpms/foo.yml", {
+            "name": "foo",
+            "content": {
+                "source": {
+                    "git": {"url": "git@github.com:openshift-priv/foo.git", "branch": {"target": "release-4.8"}},
+                    "specfile": "foo.spec",
+                    "modifications": [
+                        {"action": "add", "command": ["my-command", "--my-arg"]}
+                    ],
+                }
+            },
+            "targets": ["rhaos-4.4-rhel-8-candidate", "rhaos-4.4-rhel-7-candidate"],
+        })
+        rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
+        rpm.logger = MagicMock(spec=logging.Logger)
+        rpms.append(rpm)
+
+        data_obj = gitdata.DataObj("bar", "/path/to/ocp-build-data/rpms/bar.yml", {
+            "name": "bar",
+            "content": {
+                "source": {
+                    "git": {"url": "git@github.com:openshift-priv/bar.git", "branch": {"target": "release-4.8"}},
+                    "specfile": "bar.spec",
+                }
+            },
+            "targets": ["rhaos-4.4-rhel-8-candidate"],
+        })
+        rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
+        rpm.logger = MagicMock(spec=logging.Logger)
+        rpms.append(rpm)
+
+        runtime.rpm_metas.return_value = rpms
+        builder = MockedRPMBuilder.return_value = AsyncMock()
+        builder.side_effect = RetryException("Retry error", ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"]))
+
+        records = []
+        runtime.add_record.side_effect = lambda action, **kwargs: records.append((action, kwargs))
+
+        result = asyncio.get_event_loop().run_until_complete(_rpms_build(runtime, version, release, embargoed, scratch, dry_run))
+
+        self.assertEqual(result, 1)
+        for rpm in rpms:
+            builder.rebase.assert_any_call(rpm, version.lstrip("v"), release)
+            builder.build.assert_any_call(rpm)
+        self.assertTrue(all(record["status"] != 0 for action, record in records))

--- a/tests/cli/test_rpms_build.py
+++ b/tests/cli/test_rpms_build.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from mock import AsyncMock, MagicMock, Mock, patch
 
 from doozerlib import gitdata, rpmcfg
-from doozerlib.cli.rpms_build import _rpms_build
+from doozerlib.cli.rpms_build import _rpms_rebase_and_build
 from doozerlib.exectools import RetryException
 
 
@@ -35,6 +35,7 @@ class TestRPMsBuildCli(TestCase):
             "targets": ["rhaos-4.4-rhel-8-candidate", "rhaos-4.4-rhel-7-candidate"],
         })
         rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
+        rpm.distgit_repo = MagicMock(branch="rhaos-4.4-rhel-8")
         rpm.logger = MagicMock(spec=logging.Logger)
         rpms.append(rpm)
 
@@ -49,22 +50,17 @@ class TestRPMsBuildCli(TestCase):
             "targets": ["rhaos-4.4-rhel-8-candidate"],
         })
         rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
+        rpm.distgit_repo = MagicMock(branch="rhaos-4.4-rhel-8")
         rpm.logger = MagicMock(spec=logging.Logger)
         rpms.append(rpm)
 
         runtime.rpm_metas.return_value = rpms
         builder = MockedRPMBuilder.return_value = AsyncMock()
         builder.build.return_value = ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"])
-        records = []
-        runtime.add_record.side_effect = lambda action, **kwargs: records.append((action, kwargs))
 
-        result = asyncio.get_event_loop().run_until_complete(_rpms_build(runtime, version, release, embargoed, scratch, dry_run))
+        result = asyncio.get_event_loop().run_until_complete(_rpms_rebase_and_build(runtime, version, release, embargoed, scratch, dry_run))
 
         self.assertEqual(result, 0)
-        for rpm in rpms:
-            builder.rebase.assert_any_call(rpm, version.lstrip("v"), release)
-            builder.build.assert_any_call(rpm)
-        self.assertTrue(all(record["status"] == 0 for action, record in records))
 
     @patch("doozerlib.cli.rpms_build.RPMBuilder")
     def test_rpms_build_failure(self, MockedRPMBuilder: Mock):
@@ -92,6 +88,7 @@ class TestRPMsBuildCli(TestCase):
         })
         rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
         rpm.logger = MagicMock(spec=logging.Logger)
+        rpm.distgit_repo = MagicMock(branch="rhaos-4.4-rhel-8")
         rpms.append(rpm)
 
         data_obj = gitdata.DataObj("bar", "/path/to/ocp-build-data/rpms/bar.yml", {
@@ -106,19 +103,13 @@ class TestRPMsBuildCli(TestCase):
         })
         rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
         rpm.logger = MagicMock(spec=logging.Logger)
+        rpm.distgit_repo = MagicMock(branch="rhaos-4.4-rhel-8")
         rpms.append(rpm)
 
         runtime.rpm_metas.return_value = rpms
         builder = MockedRPMBuilder.return_value = AsyncMock()
         builder.side_effect = RetryException("Retry error", ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"]))
 
-        records = []
-        runtime.add_record.side_effect = lambda action, **kwargs: records.append((action, kwargs))
-
-        result = asyncio.get_event_loop().run_until_complete(_rpms_build(runtime, version, release, embargoed, scratch, dry_run))
+        result = asyncio.get_event_loop().run_until_complete(_rpms_rebase_and_build(runtime, version, release, embargoed, scratch, dry_run))
 
         self.assertEqual(result, 1)
-        for rpm in rpms:
-            builder.rebase.assert_any_call(rpm, version.lstrip("v"), release)
-            builder.build.assert_any_call(rpm)
-        self.assertTrue(all(record["status"] != 0 for action, record in records))

--- a/tests/test_distgit/test_generic_distgit.py
+++ b/tests/test_distgit/test_generic_distgit.py
@@ -382,12 +382,13 @@ class TestGenericDistGit(TestDistgit):
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             logger=flexmock(info=lambda _: None),
                             name="_irrelevant_")
+        (flexmock(distgit.DistGitRepo).should_receive("_get_diff").once().and_raise(ChildProcessError, "Command returned non-zero exit status: Failed fetching distgit diff"))
         repo = distgit.DistGitRepo(metadata, autoclone=False)
 
         try:
             repo.commit("commit msg", log_diff=True)
             self.fail()
-        except IOError as e:
+        except ChildProcessError as e:
             expected_msg = ("Command returned non-zero exit status: "
                             "Failed fetching distgit diff")
             self.assertEqual(expected_msg, str(e))
@@ -412,6 +413,8 @@ class TestGenericDistGit(TestDistgit):
             .with_args("my-distgit-key", "stdout")
             .once()
             .and_return(None))
+
+        (flexmock(distgit.DistGitRepo).should_receive("_get_diff").once().and_return("stdout"))
 
         distgit.DistGitRepo(metadata, autoclone=False).commit("commit msg", log_diff=True)
 

--- a/tests/test_distgit/test_rpm_distgit.py
+++ b/tests/test_distgit/test_rpm_distgit.py
@@ -29,12 +29,6 @@ class TestRPMDistGit(TestDistgit):
             actual = str(e)
             self.assertEqual(expected, actual)
 
-    def test_pkg_find_in_spec(self):
-        """ Test RPMDistGitRepo._find_in_spec """
-        self.assertEqual("", self.rpm_dg._find_in_spec("spec", "(?mx) nothing", "thing"))
-        self.assertIn("No thing found", self.stream.getvalue())
-        self.assertEqual("SOMEthing", self.rpm_dg._find_in_spec("no\nSOMEthing", "(?imx) ^ (something)", "thing"))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_distgit/test_rpm_distgit.py
+++ b/tests/test_distgit/test_rpm_distgit.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
-import unittest
 
-import flexmock
+import asyncio
+import unittest
+from pathlib import Path
+
+from mock import Mock, patch
 
 from doozerlib import distgit, model
 
@@ -14,20 +17,19 @@ class TestRPMDistGit(TestDistgit):
         self.rpm_dg = distgit.RPMDistGitRepo(self.md, autoclone=False)
         self.rpm_dg.runtime.group_config = model.Model()
 
-    def test_init_with_missing_source_specfile(self):
-        metadata = flexmock(config=flexmock(content=flexmock(source=distgit.Missing),
-                                            distgit=flexmock(branch="_irrelevant_")),
-                            runtime=flexmock(branch="_irrelevant_"),
-                            name="_irrelevant_",
-                            logger="_irrelevant_")
-
-        try:
-            distgit.RPMDistGitRepo(metadata, autoclone=False)
-            self.fail("Should have raised a ValueError")
-        except ValueError as e:
-            expected = "Must specify spec file name for RPMs."
-            actual = str(e)
-            self.assertEqual(expected, actual)
+    @patch("aiofiles.open")
+    @patch("doozerlib.distgit.exectools.cmd_assert_async", return_value=("foo-1.2.3-1", ""))
+    @patch("glob.glob", return_value=["/path/to/distgit/foo.spec"])
+    def test_resolve_specfile_async(self, mocked_glob: Mock, mocked_cmd_assert_async: Mock, mocked_open: Mock):
+        self.rpm_dg.distgit_dir = "/path/to/distgit"
+        mocked_file = mocked_open.return_value.__aenter__.return_value
+        mocked_file.__aiter__.return_value = iter(["hello", "%global commit abcdef012345", "world!"])
+        actual = asyncio.get_event_loop().run_until_complete(self.rpm_dg.resolve_specfile_async())
+        expected = (Path("/path/to/distgit/foo.spec"), ["foo", "1.2.3", "1"], "abcdef012345")
+        self.assertEqual(actual, expected)
+        mocked_open.assert_called_once_with(Path("/path/to/distgit/foo.spec"), "r")
+        mocked_glob.assert_called_once_with(self.rpm_dg.distgit_dir + "/*.spec")
+        mocked_cmd_assert_async.assert_called_once_with(["rpmspec", "-q", "--qf", "%{name}-%{version}-%{release}", "--srpm", "--undefine", "dist", "--", Path("/path/to/distgit/foo.spec")], strip=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -1,0 +1,256 @@
+import asyncio
+import logging
+import unittest
+from pathlib import Path
+
+import mock
+
+from doozerlib import distgit, gitdata, rpmcfg
+from doozerlib.exectools import RetryException
+from doozerlib.rpm_builder import RPMBuilder
+
+
+class TestRPMBuilder(unittest.TestCase):
+
+    def setUp(self) -> None:
+        pass
+
+    def _make_runtime(self):
+        runtime = mock.MagicMock()
+        runtime.group_config.public_upstreams = [{"private": "https://github.com/openshift-priv", "puiblic": "https://github.com/openshift"}]
+        runtime.brew_logs_dir = "/path/to/brew-logs"
+        return runtime
+
+    def _make_rpm_meta(self, runtime, source_sha, distgit_sha):
+        data_obj = gitdata.DataObj("foo", "/path/to/ocp-build-data/rpms/foo.yml", {
+            "name": "foo",
+            "content": {
+                "source": {
+                    "git": {"url": "git@github.com:openshift-priv/foo.git", "branch": {"target": "release-4.8"}},
+                    "specfile": "foo.spec",
+                    "modifications": [
+                        {"action": "add", "command": ["my-command", "--my-arg"]}
+                    ],
+                }
+            },
+            "targets": ["rhaos-4.4-rhel-8-candidate", "rhaos-4.4-rhel-7-candidate"],
+        })
+
+        rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
+        rpm.clone_source = mock.MagicMock(return_value=source_sha)
+        rpm.logger = mock.MagicMock(spec=logging.Logger)
+        rpm.private_fix = False
+        rpm.pre_init_sha = source_sha
+        rpm.source_path = "/path/to/sources/foo"
+        rpm.specfile = rpm.source_path + "/foo.spec"
+        dg = distgit.RPMDistGitRepo(rpm, autoclone=False)
+        dg.distgit_dir = "/path/to/distgits/rpms/foo"
+        dg.dg_path = Path(dg.distgit_dir)
+        dg.commit = mock.MagicMock(return_value=distgit_sha)
+        dg.push_async = mock.AsyncMock()
+        rpm.distgit_repo = mock.MagicMock(return_value=dg)
+        rpm._run_modifications = mock.MagicMock()
+        return rpm
+
+    @mock.patch("doozerlib.rpm_builder.Path.mkdir")
+    @mock.patch("shutil.copy")
+    @mock.patch("aiofiles.os.remove")
+    @mock.patch("aiofiles.open")
+    @mock.patch("doozerlib.rpm_builder.exectools.cmd_assert_async")
+    def test_rebase(self, mocked_cmd_assert_async: mock.Mock, mocked_open: mock.Mock, mocked_os_remove: mock.Mock,
+                    mocked_copy: mock.Mock, mocked_mkdir: mock.Mock):
+        source_sha = "3f17b42b8aa7d294c0d2b6f946af5fe488f3a722"
+        distgit_sha = "4cd7f576ad005aadd3c25ea56c7986bc6a7e7340"
+        runtime = self._make_runtime()
+        rpm = self._make_rpm_meta(runtime, source_sha, distgit_sha)
+        dg = rpm.distgit_repo()
+        mocked_cmd_assert_async.side_effect = \
+            lambda cmd, **kwargs: {"spectool": ("Source0: 1.tar.gz\nSource1: a.diff\nPatch0: b/c.diff\n", "")} \
+            .get(cmd[0], ("fake_stdout", "fake_stderr"))
+
+        builder = RPMBuilder(runtime, scratch=False, dry_run=False)
+        builder._populate_specfile_async = mock.AsyncMock(return_value=["fake spec content"])
+
+        actual = asyncio.get_event_loop().run_until_complete(builder.rebase(rpm, "1.2.3", "202104070000.test.p?"))
+
+        self.assertEqual(actual, distgit_sha)
+        self.assertEqual(rpm.release, "202104070000.test.p0.git." + source_sha[:7])
+        mocked_open.assert_called_once_with(dg.dg_path / "foo.spec", "w")
+        mocked_open.return_value.__aenter__.return_value.writelines.assert_called_once_with(["fake spec content"])
+        mocked_cmd_assert_async.assert_any_call(["tar", "-czf", dg.dg_path / f"{rpm.config.name}-{rpm.version}-{rpm.release}.tar.gz", "--exclude=.git", fr"--transform=s,^\./,{rpm.config.name}-{rpm.version}/,", "."], cwd=rpm.source_path)
+        mocked_cmd_assert_async.assert_any_call(["rhpkg", "new-sources", f"{rpm.config.name}-{rpm.version}-{rpm.release}.tar.gz"], cwd=dg.dg_path, retries=3)
+        mocked_cmd_assert_async.assert_called_with(["spectool", "--", dg.dg_path / "foo.spec"], cwd=dg.dg_path)
+        mocked_copy.assert_any_call(Path(rpm.source_path) / "a.diff", dg.dg_path / "a.diff", follow_symlinks=False)
+        mocked_copy.assert_any_call(Path(rpm.source_path) / "b/c.diff", dg.dg_path / "b/c.diff", follow_symlinks=False)
+        rpm._run_modifications.assert_called_once_with(dg.dg_path / "foo.spec", dg.dg_path)
+        dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].")
+        dg.push_async.assert_called_once()
+
+    @mock.patch("doozerlib.rpm_builder.exectools.cmd_gather_async")
+    def test_build_success(self, mocked_cmd_gather_async: mock.Mock):
+        source_sha = "3f17b42b8aa7d294c0d2b6f946af5fe488f3a722"
+        distgit_sha = "4cd7f576ad005aadd3c25ea56c7986bc6a7e7340"
+        runtime = self._make_runtime()
+        rpm = self._make_rpm_meta(runtime, source_sha, distgit_sha)
+        rpm.assert_golang_versions = mock.MagicMock()
+        dg = rpm.distgit_repo()
+        builder = RPMBuilder(runtime, scratch=False, dry_run=False)
+        builder._golang_required = mock.AsyncMock(return_value=True)
+        builder._build_target_async = mock.AsyncMock(side_effect=lambda _, target: {
+            "rhaos-4.4-rhel-8-candidate": (10001, "https://brewweb.example.com/brew/taskinfo?taskID=10001"),
+            "rhaos-4.4-rhel-7-candidate": (10002, "https://brewweb.example.com/brew/taskinfo?taskID=10002"),
+        }[target])
+        builder._watch_tasks_async = mock.AsyncMock(side_effect=lambda task_ids, _: {
+            task_id: None for task_id in task_ids})
+        mocked_cmd_gather_async.return_value = (0, "some stdout", "some stderr")
+
+        actual = asyncio.get_event_loop().run_until_complete(builder.build(rpm, retries=3))
+        expected = ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"])
+        self.assertEqual(actual, expected)
+        self.assertTrue(rpm.build_status)
+        builder._golang_required.assert_called_once_with(dg.dg_path / Path(rpm.specfile).name)
+        rpm.assert_golang_versions.assert_called_once()
+        builder._build_target_async.assert_any_call(rpm, "rhaos-4.4-rhel-8-candidate")
+        builder._build_target_async.assert_any_call(rpm, "rhaos-4.4-rhel-7-candidate")
+        builder._watch_tasks_async.assert_called_once_with([10001, 10002], mock.ANY)
+        mocked_cmd_gather_async.assert_any_call(["brew", "download-logs", "--recurse", "-d", mock.ANY, 10001])
+        mocked_cmd_gather_async.assert_any_call(["brew", "download-logs", "--recurse", "-d", mock.ANY, 10002])
+
+    @mock.patch("asyncio.sleep")
+    @mock.patch("doozerlib.rpm_builder.exectools.cmd_gather_async")
+    def test_build_failure(self, mocked_cmd_gather_async: mock.Mock, mocked_sleep: mock.Mock):
+        source_sha = "3f17b42b8aa7d294c0d2b6f946af5fe488f3a722"
+        distgit_sha = "4cd7f576ad005aadd3c25ea56c7986bc6a7e7340"
+        runtime = self._make_runtime()
+        rpm = self._make_rpm_meta(runtime, source_sha, distgit_sha)
+        rpm.assert_golang_versions = mock.MagicMock()
+        dg = rpm.distgit_repo()
+        builder = RPMBuilder(runtime, scratch=False, dry_run=False)
+        builder._golang_required = mock.AsyncMock(return_value=True)
+        builder._build_target_async = mock.AsyncMock(side_effect=lambda _, target: {
+            "rhaos-4.4-rhel-8-candidate": (10001, "https://brewweb.example.com/brew/taskinfo?taskID=10001"),
+            "rhaos-4.4-rhel-7-candidate": (10002, "https://brewweb.example.com/brew/taskinfo?taskID=10002"),
+        }[target])
+        builder._watch_tasks_async = mock.AsyncMock(side_effect=lambda task_ids, _: {
+            task_id: "Some error" for task_id in task_ids})
+        mocked_cmd_gather_async.return_value = (0, "some stdout", "some stderr")
+
+        with self.assertRaises(RetryException) as cm:
+            asyncio.get_event_loop().run_until_complete(builder.build(rpm, retries=3))
+
+        expected = ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"])
+        self.assertEqual(cm.exception.args[1], expected)
+        self.assertIn("Giving up after 3 failed attempt(s):", cm.exception.args[0])
+        self.assertFalse(rpm.build_status)
+        builder._golang_required.assert_called_once_with(dg.dg_path / Path(rpm.specfile).name)
+        rpm.assert_golang_versions.assert_called_once()
+        builder._build_target_async.assert_any_call(rpm, "rhaos-4.4-rhel-8-candidate")
+        builder._build_target_async.assert_any_call(rpm, "rhaos-4.4-rhel-7-candidate")
+        builder._watch_tasks_async.assert_any_call([10001, 10002], mock.ANY)
+        mocked_cmd_gather_async.assert_any_call(["brew", "download-logs", "--recurse", "-d", mock.ANY, 10001])
+        mocked_cmd_gather_async.assert_any_call(["brew", "download-logs", "--recurse", "-d", mock.ANY, 10002])
+        mocked_sleep.assert_called()
+
+    @mock.patch("doozerlib.rpm_builder.exectools.cmd_assert_async")
+    def test_golang_required(self, mocked_cmd_assert_async: mock.Mock):
+        mocked_cmd_assert_async.return_value = ("""
+git
+python3-devel
+        """, "")
+        builder = RPMBuilder(mock.Mock(), scratch=False, dry_run=False)
+        actual = asyncio.get_event_loop().run_until_complete(builder._golang_required("./foo.spec"))
+        self.assertFalse(actual)
+
+        mocked_cmd_assert_async.return_value = ("""
+git
+python3-devel
+golang-1.2.3
+systemd-units
+        """, "")
+        builder = RPMBuilder(mock.Mock(), scratch=False, dry_run=False)
+        actual = asyncio.get_event_loop().run_until_complete(builder._golang_required("./foo.spec"))
+        self.assertTrue(actual)
+
+    @mock.patch("aiofiles.open")
+    def test_populate_specfile_async(self, mocked_open: mock.Mock):
+        source_sha = "3f17b42b8aa7d294c0d2b6f946af5fe488f3a722"
+        distgit_sha = "4cd7f576ad005aadd3c25ea56c7986bc6a7e7340"
+        runtime = self._make_runtime()
+        rpm = self._make_rpm_meta(runtime, source_sha, distgit_sha)
+        version = "1.2.3"
+        release = "202104070000.yuxzhu_test.p0"
+        rpm.set_nvr(version, release)
+        maintainer_info = {
+            "product": "My Product",
+            "component": "My Component",
+            "subcomponent": "My Subcomponent",
+        }
+        rpm.get_maintainer_info = mock.MagicMock(return_value=maintainer_info)
+        mocked_file = mocked_open.return_value.__aenter__.return_value
+        mocked_file.readlines.return_value = """
+%global os_git_vars OS_GIT_VERSION='' OS_GIT_COMMIT='' OS_GIT_MAJOR='' OS_GIT_MINOR='' OS_GIT_TREE_STATE=''
+%global commit 0000000
+Name:           foo
+Version:        %{version}
+Release:        %{release}%{dist}
+Summary:        FOO binaries
+License:        ASL 2.0
+
+Source0:        https://example.com/foo/archive/%{commit}/%{name}-%{version}.tar.gz
+%description
+Some description
+
+%prep
+%setup -q
+#...
+%autosetup -S git
+        """.splitlines()
+
+        specfile_content = asyncio.get_event_loop().run_until_complete(RPMBuilder._populate_specfile_async(rpm, "foo-1.2.3.tar.gz"))
+
+        self.assertIn("Version:        1.2.3\n", specfile_content)
+        self.assertIn("Release:        202104070000.yuxzhu_test.p0%{?dist}\n", specfile_content)
+        self.assertIn("Source0:        foo-1.2.3.tar.gz\n", specfile_content)
+        self.assertIn("%description\n[Maintainer] product: My Product, component: My Component, subcomponent: My Subcomponent\n", specfile_content)
+        self.assertIn("%setup -q -n foo-1.2.3\n", specfile_content)
+        self.assertIn("%autosetup -S git -n foo-1.2.3 -p1\n", specfile_content)
+        self.assertIn("Version:        1.2.3\n", specfile_content)
+
+    @mock.patch("doozerlib.rpm_builder.exectools.cmd_assert_async")
+    def test_build_target_async(self, mocked_cmd_assert_async: mock.Mock):
+        source_sha = "3f17b42b8aa7d294c0d2b6f946af5fe488f3a722"
+        distgit_sha = "4cd7f576ad005aadd3c25ea56c7986bc6a7e7340"
+        runtime = self._make_runtime()
+        rpm = self._make_rpm_meta(runtime, source_sha, distgit_sha)
+        dg = rpm.distgit_repo()
+        mocked_cmd_assert_async.return_value = ("""
+Created task: 123456
+Task info: https://brewweb.example.com/brew/taskinfo?taskID=123456
+        """, "")
+
+        # call with scratch=False
+        builder = RPMBuilder(mock.Mock(), scratch=False, dry_run=False)
+        expected = (123456, "https://brewweb.example.com/brew/taskinfo?taskID=123456")
+        actual = asyncio.get_event_loop().run_until_complete(builder._build_target_async(rpm, "my-target"))
+
+        self.assertEqual(actual, expected)
+        mocked_cmd_assert_async.assert_called_once_with(["rhpkg", "build", "--nowait", "--target", "my-target"], cwd=dg.dg_path)
+
+        # call with scratch=True
+        builder = RPMBuilder(mock.Mock(), scratch=True, dry_run=False)
+        mocked_cmd_assert_async.reset_mock()
+        actual = asyncio.get_event_loop().run_until_complete(builder._build_target_async(rpm, "my-target2"))
+
+        self.assertEqual(actual, expected)
+        mocked_cmd_assert_async.assert_called_once_with(["rhpkg", "build", "--nowait", "--target", "my-target2", "--skip-tag"], cwd=dg.dg_path)
+
+    @mock.patch("doozerlib.rpm_builder.brew.watch_tasks")
+    def test_watch_tasks_async(self, mocked_watch_tasks: mock.Mock):
+        task_ids = [10001, 10002]
+        mocked_watch_tasks.return_value = {task: None for task in task_ids}
+
+        builder = RPMBuilder(mock.Mock(), scratch=True, dry_run=False)
+        actual = asyncio.get_event_loop().run_until_complete(builder._watch_tasks_async(task_ids, mock.Mock()))
+
+        self.assertEqual(actual, {task: None for task in task_ids})
+        mocked_watch_tasks.assert_called_once_with(mock.ANY, mock.ANY, task_ids, mock.ANY)


### PR DESCRIPTION
... and Including upstream git commit hash in RPM NVR.

Introduces a new implementation for building rpms.

Per https://issues.redhat.com/browse/ART-2690, we want to get rid of
`tito` in Doozer rpm build to gain more control over the build process.

This PR:

- provides a new command `beta:rpms:build` for building rpms without
  tito, which can eventually replace `rpms:build` once tested;
- includes upstream git commit hash in RPM NVR. e.g. `openshift-4.8.0-202011111040.p0.git.abcdef1.el8`;
- uses asyncio as much as possible to run parallel tasks;
- refactors some code to reuse some existing logic;
- adds more unit tests.

This PR makes a few changes to the existing code, but it shouldn't break
the existing implementation.

## Test builds:
https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=36010125