### PR TITLE
Fix some rpm spec variables are not injected

### DIFF
--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -302,14 +302,14 @@ class RPMBuilder:
             if line.startswith("%description"):
                 lines[i] = f"{lines[i].strip()}\n{maintainer_string}\n"
                 described = True
-            elif line.startswith("%global os_git_vars "):
+            elif "%global os_git_vars " in line:
                 lines[
                     i
                 ] = f"%global os_git_vars OS_GIT_VERSION={major}.{minor}.{patch}-{rpm.release}-{commit_sha[0:7]} OS_GIT_MAJOR={major} OS_GIT_MINOR={minor} OS_GIT_PATCH={patch} OS_GIT_COMMIT={commit_sha} OS_GIT_TREE_STATE=clean"
                 for k, v in rpm.extra_os_git_vars.items():
                     lines[i] += f" {k}={v}"
                 lines[i] += "\n"
-            elif line.startswith("%global commit"):
+            elif "%global commit" in line:
                 lines[i] = re.sub(
                     r"commit\s+\w+", "commit {}".format(commit_sha), lines[i]
                 )


### PR DESCRIPTION
`%global commit` and `%global os_git_vars` could appear anywhere in a
line.
https://github.com/openshift/service-idler/blob/330c6efbea04112460270bc0b913393865f672b3/service-idler.spec#L14