### PR TITLE
Fix failing to rebase repos containing git submodules

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -60,7 +60,7 @@ def recursive_overwrite(src, dest, ignore=set()):
     """
     Use rsync to copy one file tree to a new location
     """
-    exclude = ' --exclude .git/ '
+    exclude = ' --exclude .git '
     for i in ignore:
         exclude += ' --exclude="{}" '.format(i)
     cmd = 'rsync -av {} {}/ {}/'.format(exclude, src, dest)


### PR DESCRIPTION
https://github.com/openshift/doozer/pull/364 instroduced a feature to
rebase sources with git submodules. However, the cloned submodule dirs
cloud contain a `.git` file (instead of a .git directory) referencing
the root git repo which is not contained by the `path` directory defined in the
image meta. This results in a rebase error like
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcustom/1913/console.

Simply ignoring `.git` file or directory in all subdirectories should
be able to fix this issue.