### PR TITLE
Check for sources file before cloning

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -133,6 +133,10 @@ class DistGitRepo(object):
         Pull any distgit sources (use only after after clone)
         """
         with Dir(self.distgit_dir):
+            sources_file: pathlib.Path = self.dg_path.joinpath('sources')
+            if not sources_file.exists():
+                self.logger.debug('No sources file exists; skipping rhpkg sources')
+                return
             exectools.cmd_assert('rhpkg sources')
 
     def clone(self, distgits_root_dir, distgit_branch):


### PR DESCRIPTION
Not sure why, but rhpkg sometimes errors out instead of
just returning without doing anything.