### PR TITLE
[ART-2089] mark image contents private by tag

### DIFF
--- a/doozerlib/build_status_detector.py
+++ b/doozerlib/build_status_detector.py
@@ -1,6 +1,6 @@
 from logging import Logger
 from multiprocessing import Lock
-from typing import Dict, List, Optional, Union, Set
+from typing import Dict, List, Optional, Set
 
 from koji import ClientSession
 
@@ -20,9 +20,10 @@ class BuildStatusDetector:
         self.shipping_statuses: Dict[int, bool] = {}  # a dict for caching build shipping statues. key is build id, value is True if shipped.
         self.archive_lists: Dict[int, List[Dict]] = {}  # a dict for caching archive lists. key is build id, value is a list of archives associated with that build.
 
-    def find_embargoed_builds(self, builds: List[Dict]) -> Set[int]:
+    def find_embargoed_builds(self, builds: List[Dict], candidate_tags: List[str]) -> Set[int]:
         """ find embargoed builds in given list of koji builds
         :param builds: a list of koji build dicts returned by the koji api
+        :param candidate_tags: a list of candidate tags for the images being examined
         :return: a set of build IDs that have embargoed fixes
         """
         # first, exclude all shipped builds from suspicion of embargo - by definition no longer secret
@@ -35,41 +36,11 @@ class BuildStatusDetector:
 
         # finally, look at the remaining images in case they include embargoed rpms
         remaining_ids = {b["id"] for b in suspects if b["id"] not in embargoed_ids}
-        embargoed_ids.update(self.find_with_embargoed_rpms(remaining_ids))
+        embargoed_ids.update(self.find_with_embargoed_rpms(remaining_ids, candidate_tags))
 
         return embargoed_ids
 
-    def populate_archive_lists(self, suspect_build_ids: Set[Union[int, str]]):
-        """ populate self.archive_lists with any build IDs not already cached
-        :param suspect_build_ids: a list of koji build ids
-        """
-        build_ids = list(suspect_build_ids - self.archive_lists.keys())
-        if build_ids:
-            self.logger and self.logger.info(f"Fetching image archives for {len(build_ids)} builds...")
-            archive_lists = brew.list_archives_by_builds(build_ids, "image", self.koji_session)  # if a build is not an image (e.g. rpm), Brew will return an empty archive list for that build
-            for build_id, archive_list in zip(build_ids, archive_lists):
-                self.archive_lists[build_id] = archive_list  # save to cache
-
-    def find_with_embargoed_rpms(self, suspect_build_ids: Set[Union[int, str]]) -> Set[Union[int, str]]:
-        """ look for embargoed RPMs in the image archives (one per arch for every image)
-        :param suspect_build_ids: a list of koji build ids
-        """
-        self.populate_archive_lists(suspect_build_ids)
-
-        embargoed_ids = set()
-        for suspect in suspect_build_ids:
-            for archive in self.archive_lists[suspect]:
-                rpms = archive["rpms"]
-                suspected_rpms = [rpm for rpm in rpms if ".p1" in rpm["release"]]  # there should be a better way to check the release field...
-                shipped = self.find_shipped_builds([rpm["build_id"] for rpm in suspected_rpms])
-                embargoed_rpms = [rpm for rpm in suspected_rpms if rpm["build_id"] not in shipped]
-                if embargoed_rpms:
-                    image_build_id = archive["build_id"]
-                    embargoed_ids.add(image_build_id)
-
-        return embargoed_ids
-
-    def find_shipped_builds(self, build_ids: Set[Union[int, str]]) -> Set[Union[int, str]]:
+    def find_shipped_builds(self, build_ids: Set[int]) -> Set[int]:
         """ find shipped builds in the given builds
         :param build_ids: a list of build IDs
         :return: a set of shipped build IDs
@@ -87,8 +58,67 @@ class BuildStatusDetector:
         result = set(filter(lambda build_id: self.shipping_statuses[build_id], build_ids))
         return result
 
-    unshipped_candidate_rpms_cache = {}
+    def find_with_embargoed_rpms(self, suspect_build_ids: Set[int], candidate_tags: List[str]) -> Set[int]:
+        """ look for embargoed RPMs in the image archives (one per arch for every image)
+        :param suspect_build_ids: a list of koji build ids
+        :param candidate_tags: a list of candidate tags for the images being examined
+        :return: a set of build IDs that contain embargoed RPM contents
+        """
+        self.populate_archive_lists(suspect_build_ids)
+
+        embargoed_rpm_ids = set()
+        for tag in candidate_tags:
+            embargoed_rpm_ids.update(self.rpms_in_embargoed_tag(tag))
+
+        embargoed_image_ids = set()
+        for suspect in suspect_build_ids:
+            for archive in self.archive_lists[suspect]:
+                rpms = archive["rpms"]
+                suspected_rpms = [
+                    rpm for rpm in rpms
+                    if ".p1" in rpm["release"]  # there should be a better way to check the release field...
+                    or rpm["build_id"] in embargoed_rpm_ids
+                ]
+                shipped = self.find_shipped_builds([rpm["build_id"] for rpm in suspected_rpms])
+                embargoed_rpms = [rpm for rpm in suspected_rpms if rpm["build_id"] not in shipped]
+                if embargoed_rpms:
+                    image_build_id = archive["build_id"]
+                    embargoed_image_ids.add(image_build_id)
+                    break  # once marked embargoed, no point in checking other arches
+
+        return embargoed_image_ids
+
+    def populate_archive_lists(self, suspect_build_ids: Set[int]):
+        """ populate self.archive_lists with any build IDs not already cached
+        :param suspect_build_ids: a list of koji build ids
+        """
+        build_ids = list(suspect_build_ids - self.archive_lists.keys())
+        if build_ids:
+            self.logger and self.logger.info(f"Fetching image archives for {len(build_ids)} builds...")
+            archive_lists = brew.list_archives_by_builds(build_ids, "image", self.koji_session)  # if a build is not an image (e.g. rpm), Brew will return an empty archive list for that build
+            for build_id, archive_list in zip(build_ids, archive_lists):
+                self.archive_lists[build_id] = archive_list  # save to cache
+
+    embargoed_rpms_cache = {}  # define cache field to be used in method
+
+    def rpms_in_embargoed_tag(self, candidate_tag: List[str]) -> Set[int]:
+        """ find a list of RPMs in an -embargoed tag.
+        these are builds tagged in from an external source, e.g. kernel.
+        :param candidate_tag: string tag name that contains candidate builds
+        :return: a list of brew RPMs from builds in the corresponding embargoed tag
+        """
+        embargoed_tag = candidate_tag.replace('-candidate', '-embargoed')
+        key = embargoed_tag
+        with self.cache_lock:
+            if key not in self.embargoed_rpms_cache:
+                # note that we want all builds in the tag, not just the latest
+                embargoed_rpms = self.koji_session.listTagged(embargoed_tag, event=None, type="rpm")
+                self.embargoed_rpms_cache[key] = {r["id"] for r in embargoed_rpms}
+
+        return self.embargoed_rpms_cache[key]
+
     cache_lock = Lock()
+    unshipped_candidate_rpms_cache = {}
 
     def find_unshipped_candidate_rpms(self, candidate_tag, event=None):
         """ find latest RPMs in the candidate tag that have not been shipped yet.
@@ -99,7 +129,7 @@ class BuildStatusDetector:
         just if it's not using what we're trying to ship new.
 
         :param candidate_tag: string tag name to search for candidate builds
-        :return: a list of brew RPMs from those builds (not the builds themselves)
+        :return: a list of brew RPMs (the contents of the builds) from unshipped latest builds
         """
         key = (candidate_tag, event)
         with self.cache_lock:

--- a/doozerlib/build_status_detector.py
+++ b/doozerlib/build_status_detector.py
@@ -1,6 +1,6 @@
 from logging import Logger
 from multiprocessing import Lock
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Iterable
 
 from koji import ClientSession
 
@@ -20,7 +20,7 @@ class BuildStatusDetector:
         self.shipping_statuses: Dict[int, bool] = {}  # a dict for caching build shipping statues. key is build id, value is True if shipped.
         self.archive_lists: Dict[int, List[Dict]] = {}  # a dict for caching archive lists. key is build id, value is a list of archives associated with that build.
 
-    def find_embargoed_builds(self, builds: List[Dict], candidate_tags: List[str]) -> Set[int]:
+    def find_embargoed_builds(self, builds: List[Dict], candidate_tags: Iterable[str]) -> Set[int]:
         """ find embargoed builds in given list of koji builds
         :param builds: a list of koji build dicts returned by the koji api
         :param candidate_tags: a list of candidate tags for the images being examined
@@ -58,7 +58,7 @@ class BuildStatusDetector:
         result = set(filter(lambda build_id: self.shipping_statuses[build_id], build_ids))
         return result
 
-    def find_with_embargoed_rpms(self, suspect_build_ids: Set[int], candidate_tags: List[str]) -> Set[int]:
+    def find_with_embargoed_rpms(self, suspect_build_ids: Set[int], candidate_tags: Iterable[str]) -> Set[int]:
         """ look for embargoed RPMs in the image archives (one per arch for every image)
         :param suspect_build_ids: a list of koji build ids
         :param candidate_tags: a list of candidate tags for the images being examined

--- a/doozerlib/cli/detect_embargo.py
+++ b/doozerlib/cli/detect_embargo.py
@@ -137,7 +137,7 @@ def detect_embargoes_in_nvrs(runtime: Runtime, nvrs: List[str]):
             raise DoozerFatalError(f"Unable to get {nvrs[i]} from Brew.")
     runtime.logger.info(f"Detecting embargoes for {len(nvrs)} builds...")
     detector = bs_detector.BuildStatusDetector(brew_session, runtime.logger)
-    embargoed_build_ids = detector.find_embargoed_builds(builds)
+    embargoed_build_ids = detector.find_embargoed_builds(builds, runtime.get_candidate_brew_tags())
     embargoed_builds = [b for b in builds if b["id"] in embargoed_build_ids]
     return embargoed_builds
 
@@ -166,7 +166,7 @@ def detect_embargoes_in_tags(runtime: Runtime, kind: str, included_tags: List[st
     # Builds may have duplicate entries if we query from multiple tags. Don't worry, BuildStatusDetector is smart.
     runtime.logger.info(f"Detecting embargoes for {len(included_builds)} builds...")
     detector = bs_detector.BuildStatusDetector(brew_session, runtime.logger)
-    embargoed_build_ids = detector.find_embargoed_builds(included_builds)
+    embargoed_build_ids = detector.find_embargoed_builds(included_builds, runtime.get_candidate_brew_tags())
     embargoed_builds = [b for b in included_builds if b["id"] in embargoed_build_ids]
     return embargoed_builds
 

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -136,8 +136,10 @@ class PayloadGenerator:
         payload_images, invalid_name_items = self._get_payload_images(images)
         release_payload_images, non_release_items = self._get_payload_and_non_release_images(payload_images)
         self.state['payload_images'] = len(release_payload_images)
+
         latest_builds, images_missing_builds = self._get_latest_builds(release_payload_images)
-        self._designate_privacy(latest_builds)
+        self._designate_privacy(latest_builds, images)
+
         mismatched_siblings = self._find_mismatched_siblings(latest_builds)
 
         return latest_builds, invalid_name_items, images_missing_builds, mismatched_siblings, non_release_items
@@ -202,7 +204,7 @@ class PayloadGenerator:
         self.state["builds_found"] = len(latest_builds)
         return latest_builds, missing_images
 
-    def _designate_privacy(self, latest_builds):
+    def _designate_privacy(self, latest_builds, images):
         """
         For a list of build records, determine if they have private contents. If
         so, then set "private" to True for that build record. This is done for a
@@ -218,7 +220,10 @@ class PayloadGenerator:
             self.bs_detector.archive_lists[r.build["id"]] = r.archives
 
         # determine if each image build is embargoed (or otherwise "private")
-        embargoed_build_ids = self.bs_detector.find_embargoed_builds([r.build for r in latest_builds])
+        embargoed_build_ids = self.bs_detector.find_embargoed_builds(
+            [r.build for r in latest_builds],
+            {image.candidate_brew_tag() for image in images}
+        )
         for r in latest_builds:
             if r.build["id"] in embargoed_build_ids:
                 r.private = True

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1351,6 +1351,15 @@ class Runtime(object):
     def get_default_candidate_brew_tag(self):
         return self.branch + '-candidate' if self.branch else None
 
+    def get_candidate_brew_tags(self):
+        """Return a set of known candidate tags relevant to this group"""
+        tag = self.get_default_candidate_brew_tag()
+        # assumptions here:
+        # releases with default rhel-7 tag also have rhel 8.
+        # releases with default rhel-8 tag do not also care about rhel-7.
+        # adjust as needed (and just imagine rhel 9)!
+        return {tag, tag.replace('-rhel-7', '-rhel-8')} if tag else set()
+
     def get_minor_version(self):
         # only applicable if appropriate vars are defined in group config
         return '.'.join(str(self.group_config.vars[v]) for v in ('MAJOR', 'MINOR'))

--- a/tests/cli/test_detect_embargo.py
+++ b/tests/cli/test_detect_embargo.py
@@ -23,6 +23,9 @@ class TestDetectEmbargoCli(TestCase):
 
     def test_detect_embargoes_in_tags(self):
         included_tags = ["a-candidate", "b-candidate"]
+        candidate_tags = set(included_tags)
+        runtime = MagicMock()
+        runtime.get_candidate_brew_tags.return_value = candidate_tags
         included_builds = [
             [{"id": 11, "nvr": "foo11-1.2.3-1.p0"}, {"id": 12, "nvr": "foo12-1.2.3-1.p1"}, {"id": 13, "nvr": "foo13-1.2.3-1.p1"}],
             [{"id": 21, "nvr": "foo21-1.2.3-1.p0"}, {"id": 22, "nvr": "foo22-1.2.3-1.p1"}, {"id": 23, "nvr": "foo23-1.2.3-1.p1"}],
@@ -38,8 +41,8 @@ class TestDetectEmbargoCli(TestCase):
         with patch("doozerlib.brew.get_latest_builds", return_value=included_builds), \
              patch("doozerlib.brew.get_tagged_builds", return_value=excluded_builds), \
              patch("doozerlib.build_status_detector.BuildStatusDetector.find_embargoed_builds", return_value=[13, 23]) as find_embargoed_builds:
-            actual = detect_embargo.detect_embargoes_in_tags(MagicMock(), "all", included_tags, excluded_tags, event_id)
-            find_embargoed_builds.assert_called_once_with(builds_to_detect)
+            actual = detect_embargo.detect_embargoes_in_tags(runtime, "all", included_tags, excluded_tags, event_id)
+            find_embargoed_builds.assert_called_once_with(builds_to_detect, candidate_tags)
         self.assertEqual(actual, expected)
 
     def test_detect_embargoes_in_pullspecs(self):


### PR DESCRIPTION
arbitrary rpm builds may be marked as private by tagging with the
parallel `-embargoed` brew tag. images that contain RPMs from these builds
are now also considered private.

much of the changes here are simply moving things around and updating test cases, but there are a few that matter.