### PR TITLE
expand arch translation to include aarch64<->arm64

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -22,7 +22,8 @@ from doozerlib import coverity
 
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib import exectools
-from doozerlib.util import green_prefix, red_prefix, green_print, red_print, yellow_print, yellow_prefix, color_print, dict_get, analyze_debug_timing, get_cincinnati_channels, extract_version_fields, get_docker_config_json
+from doozerlib.util import green_prefix, red_prefix, green_print, red_print, yellow_print, yellow_prefix, color_print, dict_get
+from doozerlib.util import analyze_debug_timing, get_cincinnati_channels, extract_version_fields, get_docker_config_json, go_arch_for_brew_arch
 from doozerlib import operator_metadata
 from doozerlib import brew
 import click
@@ -869,7 +870,7 @@ def print_build_metrics(runtime):
 @click.option("--threads", default=1, metavar="NUM_THREADS",
               help="Number of concurrent builds to execute. Only valid for --local builds.")
 @click.option("--filter-by-os", default=None, metavar="ARCH",
-              help="Specify an exact arch to push (e.g. 'amd64').")
+              help="Specify an exact arch to push (golang name e.g. 'amd64').")
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @pass_runtime
 def images_build_image(runtime, repo_type, repo, push_to_defaults, push_to, scratch, threads, filter_by_os, dry_run):
@@ -1001,7 +1002,7 @@ def images_build_image(runtime, repo_type, repo, push_to_defaults, push_to, scra
 @click.option("--to", default=[], metavar="REGISTRY", multiple=True,
               help="Registry to push to when image build completes.  [multiple]")
 @click.option("--filter-by-os", default=None, metavar="ARCH",
-              help="Specify an exact arch to push (e.g. 'amd64').")
+              help="Specify an exact arch to push (golang name e.g. 'amd64').")
 @click.option('--dry-run', default=False, is_flag=True, help='Only print tag/push operations which would have occurred.')
 @pass_runtime
 def images_push(runtime, tag, version_release, to_defaults, late_only, to, filter_by_os, dry_run):
@@ -1719,8 +1720,7 @@ def config_gencsv(runtime, keys, as_type, output):
               help="Suggestions URL, load from {major}-{minor}-{arch}.yaml")
 def release_calc_previous(version, arch, graph_url, graph_content_stable, graph_content_candidate, suggestions_url):
     major, minor = extract_version_fields(version, at_least=2)[:2]
-    if arch == 'x86_64':
-        arch = 'amd64'  # Cincinnati is go code, and uses a different arch name than brew
+    arch = go_arch_for_brew_arch(arch)  # Cincinnati is go code, and uses a different arch name than brew
 
     # Refer to https://docs.google.com/document/d/16eGVikCYARd6nUUtAIHFRKXa7R_rU5Exc9jUPcQoG8A/edit
     # for information on channels & edges

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -7,7 +7,7 @@ import yaml
 from doozerlib import brew, build_status_detector, exectools, rhcos, state
 from doozerlib.cli import cli, pass_runtime
 from doozerlib.exceptions import DoozerFatalError
-from doozerlib.util import red_print, yellow_print
+from doozerlib.util import red_print, yellow_print, go_suffix_for_arch
 
 
 @cli.command("release:gen-payload", short_help="Generate input files for release mirroring")
@@ -581,7 +581,7 @@ def default_is_base_namespace():
 
 
 def is_name_and_space(base_name, base_namespace, arch, private):
-    arch_suffix = "" if arch == 'x86_64' else f"-{arch}"
+    arch_suffix = go_suffix_for_arch(arch)
     priv_suffix = "-priv" if private else ""
     name = f"{base_name}{arch_suffix}{priv_suffix}"
     namespace = f"{base_namespace}{arch_suffix}{priv_suffix}"

--- a/doozerlib/operator_metadata.py
+++ b/doozerlib/operator_metadata.py
@@ -12,6 +12,7 @@ import io
 from functools import wraps
 from dockerfile_parse import DockerfileParser
 from doozerlib import brew, exectools, logutil, pushd, util
+from doozerlib.util import go_arch_for_brew_arch
 
 logger = logutil.getLogger(__name__)
 
@@ -510,7 +511,7 @@ class OperatorMetadataBuilder(object):
         cmd = 'skopeo inspect --raw docker://{}/{}'.format(registry, image)
         out, err = exectools.cmd_assert(cmd, retries=3)
 
-        arch = 'amd64' if arch == 'x86_64' else arch  # x86_64 is called amd64 in skopeo
+        arch = go_arch_for_brew_arch(arch)  # skopeo uses go arch names
 
         def select_arch(manifests):
             return manifests['platform']['architecture'] == arch

--- a/doozerlib/rhcos.py
+++ b/doozerlib/rhcos.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import json
 from tenacity import retry, stop_after_attempt, wait_fixed
 from urllib import request
+from doozerlib.util import brew_suffix_for_arch
 
 RHCOS_BASE_URL = "https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases"
 
@@ -15,9 +16,8 @@ def rhcos_release_url(version, arch="x86_64", private=False):
     @param private  boolean, true for private stream, false for public (currently, no effect)
     @return e.g. "https://releases-rhcos-art...com/storage/releases/rhcos-4.6-s390x"
     """
-    arch_suffix = "" if arch in ["x86_64", "amd64"] else f"-{arch}"
     # TODO: create private rhcos builds and do something with "private" here
-    return f"{RHCOS_BASE_URL}/rhcos-{version}{arch_suffix}"
+    return f"{RHCOS_BASE_URL}/rhcos-{version}{brew_suffix_for_arch(arch)}"
 
 
 # this is hard to test with retries, so wrap testable method

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -414,3 +414,38 @@ def total_size(o, handlers={}, verbose=False):
         return s
 
     return sizeof(o)
+
+
+# some of our systems refer to golang's architecture nomenclature; translate between that and brew arches
+brew_arches = ["x86_64", "s390x", "ppc64le", "aarch64"]
+brew_arch_suffixes = ["", "-s390x", "-ppc64le", "-aarch64"]
+go_arches = ["amd64", "s390x", "ppc64le", "arm64"]
+go_arch_suffixes = ["", "-s390x", "-ppc64le", "-arm64"]
+
+
+def go_arch_for_brew_arch(brew_arch: str) -> str:
+    if brew_arch in go_arches:
+        return brew_arch   # allow to already be a go arch, just keep same
+    if brew_arch in brew_arches:
+        return go_arches[brew_arches.index(brew_arch)]
+    raise Exception(f"no such brew arch '{brew_arch}' - cannot translate to golang arch")
+
+
+def brew_arch_for_go_arch(go_arch: str) -> str:
+    if go_arch in brew_arches:
+        return go_arch  # allow to already be a brew arch, just keep same
+    if go_arch in go_arches:
+        return brew_arches[go_arches.index(go_arch)]
+    raise Exception(f"no such golang arch '{go_arch}' - cannot translate to brew arch")
+
+
+# imagestreams and such often began without consideration for multi-arch and then
+# added a suffix everywhere to accommodate arches (but kept the legacy location for x86).
+def go_suffix_for_arch(arch: str) -> str:
+    arch = go_arch_for_brew_arch(arch)  # translate either incoming arch style
+    return go_arch_suffixes[go_arches.index(arch)]
+
+
+def brew_suffix_for_arch(arch: str) -> str:
+    arch = brew_arch_for_go_arch(arch)  # translate either incoming arch style
+    return brew_arch_suffixes[brew_arches.index(arch)]

--- a/tests/test_rhcos.py
+++ b/tests/test_rhcos.py
@@ -29,6 +29,7 @@ class TestRhcos(unittest.TestCase):
     def test_release_url(self):
         self.assertIn("4.6-s390x", rhcos.rhcos_release_url("4.6", "s390x"))
         self.assertNotIn("x86_64", rhcos.rhcos_release_url("4.6", "x86_64"))
+        self.assertIn("4.9-aarch64", rhcos.rhcos_release_url("4.9", "aarch64"))
 
     @patch('urllib.request.urlopen')
     def test_build_id(self, mock_urlopen):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -56,6 +56,32 @@ class TestUtil(unittest.TestCase):
         self.assertRaises(IOError, util.extract_version_fields, 'v1.2', 3)
         self.assertRaises(IOError, util.extract_version_fields, '1.2', 3)
 
+    def test_go_arch_suffixes(self):
+        expectations = {
+            "x86_64": "",
+            "amd64": "",
+            "aarch64": "-arm64",
+            "arm64": "-arm64"
+        }
+        for arch, suffix in expectations.items():
+            self.assertEqual(util.go_suffix_for_arch(arch), suffix)
+
+    def test_brew_arch_suffixes(self):
+        expectations = {
+            "x86_64": "",
+            "amd64": "",
+            "aarch64": "-aarch64",
+            "arm64": "-aarch64"
+        }
+        for arch, suffix in expectations.items():
+            self.assertEqual(util.brew_suffix_for_arch(arch), suffix)
+
+    def test_bogus_arch_xlate(self):
+        with self.assertRaises(Exception):
+            util.go_arch_for_brew_arch("bogus")
+        with self.assertRaises(Exception):
+            util.brew_arch_for_go_arch("bogus")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
now that ARM is imminent we need doozer to understand its arch names. turns out it's just as special as x86_64/amd64 that way. this puts a central translation framework in place.