### PR TITLE
[ART-2925] Pin brew repo-urls to distgit commit

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -306,6 +306,7 @@ def images_update_dockerfile(runtime, version, release, repo_type, message, push
                 (meta, success) = dgr.push()
                 if success is not True:
                     state.record_image_fail(lstate, meta, success)
+                dgr.wait_on_cgit_file()
         except Exception as ex:
             msg = str(ex)
             state.record_image_fail(lstate, image_meta, msg, runtime.logger)
@@ -567,6 +568,7 @@ def images_rebase(runtime, version, release, embargoed, repo_type, message, push
                 (meta, success) = dgr.push()
                 if success is not True:
                     state.record_image_fail(lstate, meta, success)
+                dgr.wait_on_cgit_file()
 
         except Exception as ex:
             # Only the message will recorded in the state. Make sure we print out a stacktrace in the logs.

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1111,7 +1111,7 @@ class ImageDistGitRepo(DistGitRepo):
                 repo_file = f".oit/{repo_type}.repo"
                 existence, repo_url = self.cgit_file_available(repo_file)
                 if not existence:
-                    raise FileNotFoundError(f"Repo file {repo_file} is not available on cgit")
+                    raise FileNotFoundError(f"Repo file {repo_file} is not available on cgit; cgit cache may not be reflecting distgit in a timely manner.")
                 repo_list = list(repo_list)  # In case we get a tuple
                 repo_list.append(repo_url)
 

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -141,11 +141,26 @@ class Metadata(object):
         else:
             return list(self.runtime.get_global_arches())
 
-    def cgit_url(self, filename):
-        rev = self.branch()
-        ret = "/".join((self.runtime.group_config.urls.cgit, self.qualified_name, "plain", filename))
-        if rev is not None:
-            ret = "{}?h={}".format(ret, rev)
+    def cgit_url(self, filename: str, commit_hash: Optional[str] = None, branch: Optional[str] = None) -> str:
+        """ Construct a cgit URL to a given file associated with the commit hash pushed to distgit
+        :param filename: a relative path
+        :param commit_hash: commit hash; None implies the current HEAD
+        :param branch: branch name; None implies the branch specified in ocp-build-data
+        :return: a cgit URL
+        """
+        cgit_url_base = self.runtime.group_config.urls.cgit
+        if not cgit_url_base:
+            raise ValueError("urls.cgit is not set in group config")
+        ret = f"{cgit_url_base}/{urllib.parse.quote(self.qualified_name)}/plain/{urllib.parse.quote(filename)}"
+        params = {}
+        if branch is None:
+            branch = self.branch()
+        if branch:
+            params["h"] = branch
+        if commit_hash:
+            params["id"] = commit_hash
+        if params:
+            ret += "?" + urllib.parse.urlencode(params)
         return ret
 
     def fetch_cgit_file(self, filename):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,84 +1,16 @@
-#!/usr/bin/env python
+from unittest import TestCase
 
-from __future__ import absolute_import, print_function, unicode_literals
-import unittest
-import mock
-import os
-import tempfile
-import logging
-import shutil
-from flexmock import flexmock
-from doozerlib import metadata
-try:
-    from importlib import reload
-except ImportError:
-    pass
+from mock import MagicMock
 
-TEST_YAML = """---
-name: 'test'
-distgit:
-  namespace: 'hello'"""
+from doozerlib.metadata import Metadata
 
 
-class TestMetadataClass(unittest.TestCase):
-    pass
+class TestMetadata(TestCase):
 
-
-class MockRuntime(object):
-
-    def __init__(self, logger):
-        self.logger = logger
-
-
-class TestMetadata(unittest.TestCase):
-
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp(prefix="ocp-cd-test-logs")
-
-        self.test_file = os.path.join(self.test_dir, "test_file")
-        logging.basicConfig(filename=self.test_file, level=logging.DEBUG)
-        self.logger = logging.getLogger()
-
-        self.cwd = os.getcwd()
-        os.chdir(self.test_dir)
-
-        test_yml = open('test.yml', 'w')
-        test_yml.write(TEST_YAML)
-        test_yml.close()
-
-    def tearDown(self):
-        os.chdir(self.cwd)
-
-        logging.shutdown()
-        reload(logging)
-        shutil.rmtree(self.test_dir)
-
-    @unittest.skip("assertion failing, check if desired behavior changed")
-    def test_init(self):
-        """
-        The metadata object appears to need to be created while CWD is
-        in the root of a git repo containing a file called '<name>.yml'
-        This file must contain a structure:
-           {'distgit': {'namespace': '<value>'}}
-
-        The metadata object requires:
-          a type string <image|rpm>
-          a Runtime object placeholder
-
-        """
-
-        #
-        # Check the logs
-        #
-        logs = [log.rstrip() for log in open(self.test_file).readlines()]
-
-        expected = 6
-        actual = len(logs)
-        self.assertEqual(
-            expected, actual,
-            "logging lines - expected: {}, actual: {}".
-            format(expected, actual))
-
-
-if __name__ == "__main__":
-    unittest.main()
+    def test_cgit_url(self):
+        data_obj = MagicMock(key="foo", filename="foo.yml", data={"name": "foo"})
+        runtime = MagicMock()
+        runtime.group_config.urls.cgit = "http://distgit.example.com/cgit"
+        meta = Metadata("image", runtime, data_obj)
+        url = meta.cgit_url("some_path/some_file.txt", "abcdefg", "some-branch")
+        self.assertEqual(url, "http://distgit.example.com/cgit/containers/foo/plain/some_path/some_file.txt?h=some-branch&id=abcdefg")


### PR DESCRIPTION
- When rebasing distgit, waits for cgit cache to include the distgit
  commit. Raises an error if the cache does not update after 10 minutes.
- Before building an image, queries cgit for the existence of the .oit repo file for the commit. Raise an error if it doesn't exist.
- When building an image, supplies an .oit repo repo-url to brew that is
  pinned to the distgit commit that brew task is building.