### PR TITLE
Initial implementation of --assembly

### DIFF
--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -50,6 +50,9 @@ def print_version(ctx, param, value):
               help="Username for rhpkg. Env var: DOOZER_USER")
 @click.option("-g", "--group", default=None, metavar='NAME[@commitish]',
               help="The group of images on which to operate. Env var: DOOZER_GROUP")
+@click.option("--assembly", metavar="ASSEMBLY_NAME", default='test',
+              help="The name of an assembly to rebase & build for. Assemblies must be enabled in group.yml or with --enable-assemblies.")
+@click.option('--enable-assemblies', default=False, is_flag=True, help='Enable assemblies even if not enabled in group.yml. Primarily for testing purposes.')
 @click.option("--branch", default=None, metavar='BRANCH',
               help="DistGit to override any default in group.yml.")
 @click.option('--stage', default=False, is_flag=True, help='Force checkout stage branch for sources in group.yml.')

--- a/doozerlib/cli/rpms_build.py
+++ b/doozerlib/cli/rpms_build.py
@@ -136,7 +136,7 @@ async def _rebase_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata, v
         "release": release,
         "message": "Unknown failure",
         "status": -1,
-        # Status defaults to failure until explicitly set by succcess. This handles raised exceptions.
+        # Status defaults to failure until explicitly set by success. This handles raised exceptions.
     }
     try:
         await builder.rebase(rpm, version, release)
@@ -206,7 +206,7 @@ async def _build_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata):
         "message": "Unknown failure",
         "targets": rpm.targets,
         "status": -1,
-        # Status defaults to failure until explicitly set by succcess. This handles raised exceptions.
+        # Status defaults to failure until explicitly set by success. This handles raised exceptions.
     }
     task_ids = []
     task_urls = []

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1472,6 +1472,9 @@ class ImageDistGitRepo(DistGitRepo):
 
             # If the release is specified as "+", this means the user wants to bump the release.
             if release == "+":
+                if self.runtime.assembly:
+                    raise ValueError('"+" is not supported for the release value when assemblies are enabled')
+
                 # increment the release that was in the Dockerfile
                 if prev_release:
                     self.logger.info("Bumping release field in Dockerfile")
@@ -1514,8 +1517,14 @@ class ImageDistGitRepo(DistGitRepo):
                     release = release[:-3]  # strip .p?
                     release += pval
 
+                if self.runtime.assembly:
+                    release += f'.assembly.{self.runtime.assembly}'
+
                 dfp.labels['release'] = release
             else:
+                if self.runtime.assembly:
+                    raise ValueError('Release value must be specified when assemblies are enabled')
+
                 if self.runtime.group_config.public_upstreams:
                     raise ValueError("We are not able to let OSBS choose a release value for an image with a public upstream.")
                 if "release" in dfp.labels:

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -277,7 +277,7 @@ class ImageMetadata(Metadata):
                 for package_details in self.config.scan_sources.extra_packages:
                     extra_package_name = package_details.name
                     extra_package_brew_tag = package_details.tag
-                    # Example output: https://gist.github.com/jupierce/3bbc8be7265348a8f549d401664c9972
+                    # Example of queryHistory: https://gist.github.com/jupierce/943b845c07defe784522fd9fd76f4ab0
                     extra_latest_tagging_infos = koji_api.queryHistory(table='tag_listing', tag=extra_package_brew_tag, package=extra_package_name, active=True)['tag_listing']
 
                     if extra_latest_tagging_infos:

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -75,6 +75,10 @@ class RPMBuilder:
 
         # include commit hash in release field
         release += ".git." + rpm.pre_init_sha[:7]
+
+        if self._runtime.assembly:
+            release += f'.assembly.{self._runtime.assembly}'
+
         rpm.set_nvr(version, release)
 
         # generate new specfile

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -147,6 +147,7 @@ class Runtime(object):
         self.session_pool = {}
         self.session_pool_available = {}
         self.brew_event = None
+        self.assembly = 'test'
 
         self.stream: List[str] = []  # Click option. A list of image stream overrides from the command line.
         self.stream_overrides: Dict[str, str] = {}  # Dict of stream name -> pullspec from command line.
@@ -398,6 +399,14 @@ class Runtime(object):
 
         self.group_dir = self.gitdata.data_dir
         self.group_config = self.get_group_config()
+
+        if self.group_config.assembles.enabled or self.enable_assemblies:
+            if re.match(r'^[a-zA-Z0-9._]+$', self.assembly) is None:
+                raise ValueError('Assembly names may only consistent of alphanumerics, ., and _. ')
+        else:
+            # If assemblies are not enabled for the group,
+            # ignore this argument throughout doozer.
+            self.assembly = None
 
         # register the sources
         # For each "--source alias path" on the command line, register its existence with

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -401,8 +401,8 @@ class Runtime(object):
         self.group_config = self.get_group_config()
 
         if self.group_config.assembles.enabled or self.enable_assemblies:
-            if re.match(r'^[a-zA-Z0-9._]+$', self.assembly) is None:
-                raise ValueError('Assembly names may only consistent of alphanumerics, ., and _. ')
+            if re.fullmatch(r'[\w.]+', self.assembly) is None or self.assembly[0] == '.' or self.assembly[-1] == '.':
+                raise ValueError('Assembly names may only consist of alphanumerics, ., and _, but not start or end with a dot (.).')
         else:
             # If assemblies are not enabled for the group,
             # ignore this argument throughout doozer.

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -354,6 +354,25 @@ def get_docker_config_json(config_dir):
         raise FileNotFoundError("Can not find the registry config file in {}".format(config_dir))
 
 
+def isolate_pflag_in_release(release: str):
+    """
+    Given a release field, determines whether is contains
+    .p0/.p1 information. If it does, it returns the value
+    'p0' or 'p1'. If it is not found, None is returned.
+    """
+    if release.endswith('.p1') or release.endswith('.p0'):
+        return release[-2:]
+
+    # p? is not always at the end of the release field if
+    # assemblies are being used.
+    for pflag in ['p0', 'p1']:
+        idx = release.find(f'.{pflag}.')
+        if idx > -1:
+            return pflag
+
+    return None
+
+
 # https://code.activestate.com/recipes/577504/
 def total_size(o, handlers={}, verbose=False):
     """ Returns the approximate memory footprint an object and all of its contents.

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -15,10 +15,11 @@ class TestRPMBuilder(unittest.TestCase):
     def setUp(self) -> None:
         pass
 
-    def _make_runtime(self):
+    def _make_runtime(self, assembly=None):
         runtime = mock.MagicMock()
         runtime.group_config.public_upstreams = [{"private": "https://github.com/openshift-priv", "puiblic": "https://github.com/openshift"}]
         runtime.brew_logs_dir = "/path/to/brew-logs"
+        runtime.assembly = assembly
         return runtime
 
     def _make_rpm_meta(self, runtime, source_sha, distgit_sha):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+
+from doozerlib import util
+
+
+class TestUtil(unittest.TestCase):
+
+    def test_isolate_pflag(self):
+        self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p1'), 'p1')
+        self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p0'), 'p0')
+        self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p2'), None)
+        self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p1.assembly.p'), 'p1')
+        self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p0.assembly.test'), 'p0')
+        self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p2.assembly.stream'), None)
+
+    def test_convert_remote_git_to_https(self):
+        # git@ to https
+        self.assertEqual(util.convert_remote_git_to_https('git@github.com:openshift/aos-cd-jobs.git'),
+                         'https://github.com/openshift/aos-cd-jobs')
+
+        # https to https (no-op)
+        self.assertEqual(util.convert_remote_git_to_https('https://github.com/openshift/aos-cd-jobs'),
+                         'https://github.com/openshift/aos-cd-jobs')
+
+        # https to https, remove suffix
+        self.assertEqual(util.convert_remote_git_to_https('https://github.com/openshift/aos-cd-jobs.git'),
+                         'https://github.com/openshift/aos-cd-jobs')
+
+        # ssh to https
+        self.assertEqual(util.convert_remote_git_to_https('ssh://ocp-build@github.com/openshift/aos-cd-jobs.git'),
+                         'https://github.com/openshift/aos-cd-jobs')
+
+    def test_convert_remote_git_to_ssh(self):
+        # git@ to https
+        self.assertEqual(util.convert_remote_git_to_ssh('https://github.com/openshift/aos-cd-jobs'),
+                         'git@github.com:openshift/aos-cd-jobs.git')
+
+        # https to https (no-op)
+        self.assertEqual(util.convert_remote_git_to_ssh('https://github.com/openshift/aos-cd-jobs'),
+                         'git@github.com:openshift/aos-cd-jobs.git')
+
+        # https to https, remove suffix
+        self.assertEqual(util.convert_remote_git_to_ssh('https://github.com/openshift/aos-cd-jobs'),
+                         'git@github.com:openshift/aos-cd-jobs.git')
+
+        # ssh to https
+        self.assertEqual(util.convert_remote_git_to_ssh('ssh://ocp-build@github.com/openshift/aos-cd-jobs.git'),
+                         'git@github.com:openshift/aos-cd-jobs.git')
+
+    def test_extract_version_fields(self):
+        self.assertEqual(util.extract_version_fields('1.2.3'), [1, 2, 3])
+        self.assertEqual(util.extract_version_fields('1.2'), [1, 2])
+        self.assertEqual(util.extract_version_fields('v1.2.3'), [1, 2, 3])
+        self.assertEqual(util.extract_version_fields('v1.2'), [1, 2])
+        self.assertRaises(IOError, util.extract_version_fields, 'v1.2', 3)
+        self.assertRaises(IOError, util.extract_version_fields, '1.2', 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_functional/README.MD
+++ b/tests_functional/README.MD
@@ -1,0 +1,33 @@
+# Runs a suite of functional tests with no side effects.
+
+## Setup
+It is suggested that you run these tests on buildvm. 
+
+### Ensure and ssh-agent with clone permissions is running
+```
+$ eval $(ssh-agent)
+$ ssh-add ...
+```
+
+### Set environment variables
+Set `DOOZER_WORKING_DIR` to a directory that does not exist. This will be used as the working directory
+for the tests. Ensure the mount on which it resides has sufficient space.
+```
+$ export DOOZER_WORKING_DIR=$PWD/test-wd
+``` 
+
+Set `DOOZER_CACHE_DIR` appropriately
+```
+# on buildvm
+$ export DOOZER_CACHE_DIR=/mnt/workspace/jenkins/doozer_cache
+```
+
+## Run all the tests
+```
+$ python3 -m unittest discover -s tests_functional
+```
+
+## Run a specific suite
+```
+$  python3 -m unittest tests_functional/test_basic_rebase.py
+```

--- a/tests_functional/test_basic_rebase.py
+++ b/tests_functional/test_basic_rebase.py
@@ -40,6 +40,7 @@ class TestBasicRebase(DoozerRunnerTestCase):
         upstream_commit_ced = '0f7594616f7ea72e28f065ef2c172fa3d852abcf'
         upstream_commit_ced_short = upstream_commit_ced[:7]
         doozer_args = [
+            '--assembly', 'tester',  # This should only have an effect if assemblies=True
             '--group', f'openshift-4.6@{target_ocp_build_data_commitish}',
             '-i', 'openshift-enterprise-base',
             '-i', 'cluster-etcd-operator',
@@ -53,9 +54,7 @@ class TestBasicRebase(DoozerRunnerTestCase):
         ]
 
         if assemblies:
-            assembly_args = ['--assembly', 'tester', '--enable-assemblies']
-            assembly_args.extend(doozer_args)
-            doozer_args = assembly_args
+            doozer_args.insert(0, '--enable-assemblies')
             target_release += '.assembly.tester'
 
         _, _ = self.run_doozer(*doozer_args)

--- a/tests_functional/test_golang_rebase.py
+++ b/tests_functional/test_golang_rebase.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
 import unittest
-from dockerfile_parse import DockerfileParser
-from . import DoozerRunnerTestCase
 
-from doozerlib import image, exectools, model
+from dockerfile_parse import DockerfileParser
+from tests_functional import DoozerRunnerTestCase
 
 
 class TestGoLangRebase(DoozerRunnerTestCase):

--- a/tests_functional/test_koji_wrapper.py
+++ b/tests_functional/test_koji_wrapper.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
 
 import unittest
-from . import DoozerRunnerTestCase
 
-import koji
-import logging
-
-from doozerlib import image, exectools, model
+from tests_functional import DoozerRunnerTestCase
 from doozerlib import brew
 
 

--- a/tests_functional/test_sanity.py
+++ b/tests_functional/test_sanity.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 
 import unittest
-from . import DoozerRunnerTestCase
 
-import koji
-import logging
-
+from tests_functional import DoozerRunnerTestCase
 from doozerlib import image, exectools, model
-from doozerlib import brew
 
 
 class TestSanity(DoozerRunnerTestCase):

--- a/tests_functional/test_scan_sources.py
+++ b/tests_functional/test_scan_sources.py
@@ -2,9 +2,8 @@
 
 import unittest
 import yaml
-from . import DoozerRunnerTestCase
 
-from doozerlib import image, exectools, model
+from tests_functional import DoozerRunnerTestCase
 
 
 class TestScanSources(DoozerRunnerTestCase):


### PR DESCRIPTION
First part of https://issues.redhat.com/browse/ART-2940 .
Basic implementation of doozer `--assembly` parameter. It does not impact builds until group.yml is updated with
```
assemblies:
  enabled: true
```