### PR TITLE
ART-2943: Tag all non-stream builds with the hotfix tag

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -830,6 +830,10 @@ class ImageDistGitRepo(DistGitRepo):
                 if 'member' in builder:
                     self._set_wait_for(builder['member'], terminate_event)
 
+            if self.runtime.assembly and not release.endswith(f".assembly.{self.runtime.assembly}"):
+                # Assemblies should follow its naming convention
+                raise ValueError(f"Image {self.name} is not rebased with assembly '{self.runtime.assembly}'.")
+
             # Allow an image to wait on an arbitrary image in the group. This is presently
             # just a workaround for: https://projects.engineering.redhat.com/browse/OSBS-5592
             if self.config.wait_for is not Missing:
@@ -859,12 +863,13 @@ class ImageDistGitRepo(DistGitRepo):
                     if terminate_event.wait(timeout=5 * 60):
                         raise KeyboardInterrupt()
 
-                if len(profile["targets"]) > 1:
+                if len(self.metadata.targets) > 1:
                     # FIXME: Currently we don't really support building images against multiple targets,
                     # or we would overwrite the image tag when pushing to the registry.
                     # `targets` is defined as an array just because we want to keep consistency with RPM build.
                     raise DoozerFatalError("Building images against multiple targets is not currently supported.")
-                target = '' if not profile["targets"] else profile["targets"][0]
+                target = self.metadata.targets[0]
+
                 exectools.retry(
                     retries=retries, wait_f=wait,
                     task_f=lambda: self._build_container(

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -428,6 +428,13 @@ class ImageMetadata(Metadata):
         digest = hashlib.sha256(json.dumps(message, sort_keys=True, default=default).encode("utf-8")).hexdigest()
         return "sha256:" + digest
 
+    def default_brew_target(self):
+        if self.runtime.hotfix:
+            target = f"{self.branch()}-containers-hotfix"
+        else:
+            target = f"{self.branch()}-containers-candidate"
+        return target
+
 
 def is_image_older_than_package_build_tagging(image_meta, image_build_event_id, package_build, newest_image_event_ts, oldest_image_event_ts):
     """

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import threading
 import traceback
-from typing import Optional
+from typing import List, Optional
 
 import rpm
 
@@ -58,19 +58,6 @@ class RPMMetadata(Metadata):
 
         # If populated, extra variables that will added as os_git_vars
         self.extra_os_git_vars = {}
-
-        # List of Brew targets.
-        # The first target is the primary target, against which tito will direct build.
-        # Others are secondary targets. We will use Brew API to build against secondary targets with the same distgit commit as the primary target.
-        self.targets = self.config.get('targets', [])
-        if not self.targets:
-            # If not specified, load from group config
-            profile_name = runtime.profile or runtime.group_config.default_rpm_build_profile
-            if profile_name:
-                self.targets = runtime.group_config.build_profiles.rpm[profile_name].targets.primitive()
-        if not self.targets:
-            # If group config doesn't define the targets either, the target name will be derived from the distgit branch name
-            self.targets = [self.branch() + "-candidate"]
 
         self.source_path = None
         self.source_head = None
@@ -254,3 +241,10 @@ class RPMMetadata(Metadata):
 
     def candidate_brew_tags(self):
         return self.targets.copy()
+
+    def default_brew_target(self):
+        if self.runtime.hotfix:
+            target = f"{self.branch()}-hotfix"
+        else:
+            target = f"{self.branch()}-candidate"
+        return target

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -400,9 +400,13 @@ class Runtime(object):
         self.group_dir = self.gitdata.data_dir
         self.group_config = self.get_group_config()
 
+        self.hotfix = False  # True indicates builds should be tagged with associated hotfix tag for the artifacts branch
+
         if self.group_config.assemblies.enabled or self.enable_assemblies:
             if re.fullmatch(r'[\w.]+', self.assembly) is None or self.assembly[0] == '.' or self.assembly[-1] == '.':
                 raise ValueError('Assembly names may only consist of alphanumerics, ., and _, but not start or end with a dot (.).')
+            # FIXME: Hardcoding !=stream in code until we come up with a way to construct meaningful metadata for this convention in group.yml or releases.yml.
+            self.hotfix = self.assembly != "stream"
         else:
             # If assemblies are not enabled for the group,
             # ignore this argument throughout doozer.

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -159,7 +159,7 @@ class TestImageMetadata(unittest.TestCase):
             'data': image_model,
             'filename': 'my-distgit.yaml',
         })
-        rt = MockRuntime(self.logger)
+        rt = mock.MagicMock()
         imeta = image.ImageMetadata(rt, data_obj)
         self.assertEqual(imeta.get_brew_image_name_short(), 'openshift-test')
 

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -44,6 +44,7 @@ class TestRPMBuilder(unittest.TestCase):
         rpm.pre_init_sha = source_sha
         rpm.source_path = "/path/to/sources/foo"
         rpm.specfile = rpm.source_path + "/foo.spec"
+        rpm.targets = ["rhaos-4.4-rhel-8-candidate", "rhaos-4.4-rhel-7-candidate"]
         dg = distgit.RPMDistGitRepo(rpm, autoclone=False)
         dg.distgit_dir = "/path/to/distgits/rpms/foo"
         dg.dg_path = Path(dg.distgit_dir)

--- a/tests/test_rpmcfg.py
+++ b/tests/test_rpmcfg.py
@@ -38,6 +38,7 @@ targets:
         )
         koji_session.multicall.return_value.__enter__.return_value.getBuildTarget.side_effect = lambda target: MagicMock(result={"build_tag_name": target.replace("-candidate", "-build")})
         metadata = RPMMetadata(runtime, data_obj, clone_source=False)
+        metadata.targets = ["rhaos-4.7-rhel-7-candidate", "rhaos-4.7-rhel-8-candidate"]
 
         runtime.group_config.check_golang_versions = "exact"
         with mock.patch("doozerlib.rpmcfg.brew.get_latest_builds") as get_latest_builds:


### PR DESCRIPTION
If assemblies are enabled, images builds for non-stream assemblies should be tagged with the rhaos hotfix tags.

Also adds `--push/--no-push` flag to `rpms:rebase` verb for better testing.

Some rpms use non-default Brew targets. Needs to merge ocp-build-data PR https://github.com/openshift/ocp-build-data/pull/928 before this PR.