### PR TITLE
ART-2941: Basic interpretation of assembly in gen-payload

### DIFF
--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -187,7 +187,7 @@ def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], build_type: O
     return [task.result if task else None for task in tasks]
 
 
-def get_tagged_builds(tag_component_tuples: Iterable[Tuple[str, Optional[str]]], build_type: Optional[str], event: Optional[int], session: koji.ClientSession) -> List[Optional[List[Dict]]]:
+def get_tagged_builds(tag_component_tuples: Iterable[Tuple[str, Optional[str]]], build_type: Optional[str], event: Optional[int], session: koji.ClientSession, inherit: bool = False) -> List[Optional[List[Dict]]]:
     """ Get tagged builds as of the given event
 
     In each list for a component, builds are ordered from newest tagged to oldest tagged:
@@ -197,6 +197,7 @@ def get_tagged_builds(tag_component_tuples: Iterable[Tuple[str, Optional[str]]],
     :param build_type: if given, only retrieve specified build type (rpm, image)
     :param event: Brew event ID, or None for now.
     :param session: instance of Brew session
+    :param inherit: True to include builds inherited from parent tags
     :return: a list of lists of Koji/Brew build dicts
     """
     tasks = []
@@ -205,7 +206,7 @@ def get_tagged_builds(tag_component_tuples: Iterable[Tuple[str, Optional[str]]],
             if not tag:
                 tasks.append(None)
                 continue
-            tasks.append(m.listTagged(tag, event=event, package=component_name, type=build_type))
+            tasks.append(m.listTagged(tag, event=event, package=component_name, type=build_type, inherit=inherit))
     return [task.result if task else None for task in tasks]
 
 

--- a/doozerlib/cli/detect_embargo.py
+++ b/doozerlib/cli/detect_embargo.py
@@ -157,7 +157,7 @@ def detect_embargoes_in_tags(runtime: Runtime, kind: str, included_tags: List[st
     runtime.logger.info(f"Found {len(included_builds)} builds from Brew tags {included_tags}.")
     if included_builds and excluded_tags:  # if we have tags to exclude, get all builds with excluded_tags then exclude them
         runtime.logger.info(f"Fetching builds from Brew tags {excluded_tags}...")
-        excluded_build_lists = brew.get_tagged_builds(excluded_tags, build_type, event_id, brew_session)
+        excluded_build_lists = brew.get_tagged_builds([(tag, None) for tag in excluded_tags], build_type, event_id, brew_session)
         excluded_build_ids = {b["id"] for builds in excluded_build_lists if builds for b in builds}
         builds = [b for b in included_builds if b["id"] not in excluded_build_ids]
         runtime.logger.info(f"Excluded {len(included_builds) - len(builds)} builds that are also tagged into {excluded_tags}.")

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -214,6 +214,9 @@ class PayloadGenerator:
                 if not chosen_build and self.runtime.assembly != "stream":
                     # If no such build, fall back to the newest build containing ".assembly.stream"
                     chosen_build = next((build for build in builds if build["release"].endswith(".assembly.stream")), None)
+                if not chosen_build:
+                    # If none of the builds have .assembly.stream in the RELEASE field, fall back to the latest build without .assembly in the RELEASE field
+                    chosen_build = next((build for build in builds if ".assembly." not in build["release"]), None)
             brew_latest_builds.append(chosen_build)
 
         # look up the archives for each image (to get the RPMs that went into them)

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -200,7 +200,7 @@ class PayloadGenerator:
         :return: list of build records, list of images missing builds
         """
         tag_component_tuples = [(image.candidate_brew_tag(), image.get_component_name()) for image in payload_images]
-        lists_of_brew_builds = brew.get_tagged_builds(tag_component_tuples, "image", self.brew_event, self.brew_session)
+        lists_of_brew_builds = brew.get_tagged_builds(tag_component_tuples, "image", event=self.brew_event, session=self.brew_session, inherit=True)
         brew_latest_builds = []
         for builds in lists_of_brew_builds:  # builds are ordered from newest tagged to oldest tagged
             chosen_build = None

--- a/tests/cli/test_release_gen_payload.py
+++ b/tests/cli/test_release_gen_payload.py
@@ -133,7 +133,7 @@ class TestPayloadGenerator(TestCase):
 
         # assembly == "hotfix_a"
         runtime.assembly = "hotfix_a"
-        expected = [12, 21]
+        expected = [12, 21, 33]
         latest, _ = generator._get_latest_builds(image_metas)
         actual = [record.build["id"] for record in latest]
         self.assertEqual(actual, expected)
@@ -147,7 +147,7 @@ class TestPayloadGenerator(TestCase):
 
         # assembly == "hotfix_c"
         runtime.assembly = "hotfix_c"
-        expected = [13, 21]
+        expected = [13, 21, 33]
         latest, _ = generator._get_latest_builds(image_metas)
         actual = [record.build["id"] for record in latest]
         self.assertEqual(actual, expected)

--- a/tests/cli/test_release_gen_payload.py
+++ b/tests/cli/test_release_gen_payload.py
@@ -1,3 +1,6 @@
+import mock
+from doozerlib.model import Model
+from doozerlib.image import ImageMetadata
 import json
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
@@ -79,4 +82,79 @@ class TestReleaseGenPayloadCli(TestCase):
         entries = []
         expected = {}
         actual = _fake_generator()._inconsistency_annotation(entries)
+        self.assertEqual(actual, expected)
+
+
+class TestPayloadGenerator(TestCase):
+    @mock.patch("doozerlib.cli.release_gen_payload.brew.get_tagged_builds")
+    def test_get_latest_builds(self, get_tagged_builds: mock.Mock):
+        runtime = MagicMock()
+        image_metas = [
+            ImageMetadata(runtime, Model({
+                "key": "a",
+                'data': {
+                    'name': 'openshift/a',
+                    'distgit': {'branch': 'fake-branch-rhel-8'},
+                },
+            })),
+            ImageMetadata(runtime, Model({
+                "key": "b",
+                'data': {
+                    'name': 'openshift/b',
+                    'distgit': {'branch': 'fake-branch-rhel-7'},
+                },
+            })),
+            ImageMetadata(runtime, Model({
+                "key": "c",
+                'data': {
+                    'name': 'openshift/c',
+                    'distgit': {'branch': 'fake-branch-rhel-8'},
+                },
+            })),
+        ]
+        get_tagged_builds.return_value = [
+            [
+                {"id": 13, "name": "a-container", "version": "v1.2.3", "release": "3.assembly.stream"},
+                {"id": 12, "name": "a-container", "version": "v1.2.3", "release": "2.assembly.hotfix_a"},
+                {"id": 11, "name": "a-container", "version": "v1.2.3", "release": "1.assembly.hotfix_a"},
+            ],
+            [
+                {"id": 23, "name": "b-container", "version": "v1.2.3", "release": "3.assembly.test"},
+                {"id": 22, "name": "b-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b"},
+                {"id": 21, "name": "b-container", "version": "v1.2.3", "release": "1.assembly.stream"},
+            ],
+            [
+                {"id": 33, "name": "c-container", "version": "v1.2.3", "release": "3"},
+                {"id": 32, "name": "c-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b"},
+                {"id": 31, "name": "c-container", "version": "v1.2.3", "release": "1"},
+            ],
+        ]
+        generator = rgp.PayloadGenerator(runtime, MagicMock(), None, MagicMock())
+
+        # assembly == "hotfix_a"
+        runtime.assembly = "hotfix_a"
+        expected = [12, 21]
+        latest, _ = generator._get_latest_builds(image_metas)
+        actual = [record.build["id"] for record in latest]
+        self.assertEqual(actual, expected)
+
+        # assembly == "hotfix_b"
+        runtime.assembly = "hotfix_b"
+        expected = [13, 22, 32]
+        latest, _ = generator._get_latest_builds(image_metas)
+        actual = [record.build["id"] for record in latest]
+        self.assertEqual(actual, expected)
+
+        # assembly == "hotfix_c"
+        runtime.assembly = "hotfix_c"
+        expected = [13, 21]
+        latest, _ = generator._get_latest_builds(image_metas)
+        actual = [record.build["id"] for record in latest]
+        self.assertEqual(actual, expected)
+
+        # assembly == None
+        runtime.assembly = None
+        expected = [13, 23, 33]
+        latest, _ = generator._get_latest_builds(image_metas)
+        actual = [record.build["id"] for record in latest]
         self.assertEqual(actual, expected)


### PR DESCRIPTION
- If assemblies are disabled, everything in `-candidate` tags will be
introduced into nightlies (existing behavior).

- If assemblies are enabled, only images containing `.assembly.<assembly-name>` in its `RELEASE` field will be
introduced into nightlies. If no build for an image is found, the newest
build containing `.assembly.stream` will substitute.