### PR TITLE
Do not assume list order in queryHistory

### DIFF
--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -312,7 +312,8 @@ def has_tag_changed_since_build(runtime, koji_client, build, tag, inherit=True) 
             # Example result of full queryHistory: https://gist.github.com/jupierce/943b845c07defe784522fd9fd76f4ab0
             tag_listing = koji_client.queryHistory(table='tag_listing',
                                                    tag=found_in_tag_name, build=last_tagged_build['build_id'])['tag_listing']
-            latest_tag_change_event = tag_listing[0]  # Order is by increasing age, so 0 is the most recent time this build was tagged
+            tag_listing.sort(key=lambda event: event['create_event'])
+            latest_tag_change_event = tag_listing[-1]
 
         with cache_lock:
             latest_tag_change_events[tag] = latest_tag_change_event

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1201,6 +1201,8 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
     {bz_product} - The BZ product, if known
     {bz_component} - The BZ component, if known
     {bz_subcomponent} - The BZ subcomponent, if known
+    {upstream} - The upstream repository for the image
+    {upstream_public} - The public upstream repository (if different) for the image
     {lf} - Line feed
 
     If pattern contains no braces, it will be wrapped with them automatically. For example:
@@ -1267,6 +1269,14 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
         s = s.replace("{image_name}", image.image_name)
         s = s.replace("{image_name_short}", image.image_name_short)
         s = s.replace("{component}", image.get_component_name())
+
+        source_url = image.config.content.source.git.url
+        s = s.replace("{upstream}", source_url or 'None')
+        if source_url:
+            public_url = runtime.get_public_upstream(source_url)[0]
+        else:
+            public_url = None
+        s = s.replace("{upstream_public}", public_url or 'None')
 
         if '{bz_' in s:
             mi = image.get_maintainer_info()

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -281,10 +281,11 @@ class ImageMetadata(Metadata):
                     extra_latest_tagging_infos = koji_api.queryHistory(table='tag_listing', tag=extra_package_brew_tag, package=extra_package_name, active=True)['tag_listing']
 
                     if extra_latest_tagging_infos:
+                        extra_latest_tagging_infos.sort(key=lambda event: event['create_event'])
                         # We have information about the most recent time this package was tagged into the
                         # relevant tag. Why the tagging event and not the build time? Well, the build could have been
                         # made long ago, but only tagged into the relevant tag recently.
-                        extra_latest_tagging_event = extra_latest_tagging_infos[0]['create_event']
+                        extra_latest_tagging_event = extra_latest_tagging_infos[-1]['create_event']
                         self.logger.debug(f'Checking image creation time against extra_packages {extra_package_name} in tag {extra_package_brew_tag} @ tagging event {extra_latest_tagging_event}')
                         if extra_latest_tagging_event > image_build_event_id:
                             return self, True, f'Image {dgk} is sensitive to extra_packages {extra_package_name} which changed at event {extra_latest_tagging_event}'


### PR DESCRIPTION
I've seen queryHistory return records in different orders depending on the parameter types supplied in the invocation. Eliminate assumptions about order by sorting.
To be clear, I do not believe this is affecting us - it is just insurance in case the API sort order changes in the future.