### PR TITLE
Find current metas by uuid tag instead of nvr

### DIFF
--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -767,7 +767,7 @@ class Runtime(object):
                     self.image_order.append(i)
 
     def image_distgit_by_name(self, name):
-        """Returns image meta but full name, short name, or distgit"""
+        """Returns image meta by full name, short name, or distgit"""
         return self.image_name_map.get(name, None)
 
     def rpm_metas(self):


### PR DESCRIPTION
The previous logic assumed that the other images used
the same version & release field as the operator
being built. However, releases now contain .git.<upstream hash>
in their release. Use the uuid tag placed in additional
tags, which should serve the same purposes but more reliably.