### PR TITLE
[ART-2974] Prevent unnecessary clone to determine RPM package name

### DIFF
--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -90,6 +90,10 @@ class RPMBuilder:
         dg_specfile_path = dg.dg_path / Path(rpm.specfile).name
         async with aiofiles.open(dg_specfile_path, "w") as f:
             await f.writelines(specfile)
+
+        if rpm.get_package_name_from_spec() != rpm.get_package_name():
+            raise IOError(f'RPM package name in .spec file ({rpm.get_package_name_from_spec()}) does not match doozer metadata name {rpm.get_package_name()}')
+
         rpm.specfile = str(dg_specfile_path)
 
         # create tarball source as Source0

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -207,10 +207,11 @@ class RPMMetadata(Metadata):
                 if (check_mode == "exact" and nevr[2] != first_nevr[2]) or (check_mode == "x.y" and nevr[2].split(".")[:2] != first_nevr[2].split(".")[:2]):
                     raise DoozerFatalError(f"Buildroot for target {target} has inconsistent golang compiler version {nevr[2]} while target {first_target} has {first_nevr[2]}.")
 
-    def get_package_name(self, default=-1):
+    def get_package_name_from_spec(self, default=-1):
         """
         Returns the brew package name for the distgit repository. Method requires
-        a local clone.
+        a local clone. This differs from get_package_name because it will actually
+        parse the .spec file in the distgit clone vs trusting the ocp-build-data.
         :param default: If specified, this value will be returned if package name could not be found. If
                         not specified, an exception will be raised instead.
         :return: The package name if detected in the distgit spec file. Otherwise, the specified default.
@@ -232,6 +233,25 @@ class RPMMetadata(Metadata):
             return default
 
         raise IOError(f'Unable to find Name: field in rpm spec: {spec_path}')
+
+    def get_package_name(self, default=-1):
+        """
+        Returns the brew package name for the distgit repository. Package names for RPMs
+        do not necessarily match the distgit component name. The package name is controlled
+        by the RPM's spec file. The 'name' field in the doozer metadata should match what is
+        in the RPM's spec file.
+        :param default: If specified, this value will be returned if package name could not be found.
+        :return: The package name - Otherwise, the specified default.
+                If default is not passed in, an exception will be raised if the package name can't be found.
+        """
+        package_name = self.config.name  # This should be the package name for the RPM
+        if package_name:
+            return package_name
+
+        if default != -1:
+            return default
+
+        raise IOError(f'Missing package name in RPM doozer metadata: {self.distgit_key}')
 
     def get_component_name(self, default=-1):
         return self.get_package_name(default=default)

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -39,6 +39,7 @@ class TestRPMBuilder(unittest.TestCase):
 
         rpm = rpmcfg.RPMMetadata(runtime, data_obj, clone_source=False)
         rpm.clone_source = mock.MagicMock(return_value=source_sha)
+        rpm.get_package_name_from_spec = mock.Mock(return_value='foo')
         rpm.logger = mock.MagicMock(spec=logging.Logger)
         rpm.private_fix = False
         rpm.pre_init_sha = source_sha


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-2974