### PR TITLE
[ART-2946] Make config:plashet assemblies aware

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -82,6 +82,33 @@ class TestUtil(unittest.TestCase):
         with self.assertRaises(Exception):
             util.brew_arch_for_go_arch("bogus")
 
+    def test_find_latest_builds(self):
+        builds = [
+            {"id": 13, "name": "a-container", "version": "v1.2.3", "release": "3.assembly.stream", "tag_name": "tag1"},
+            {"id": 12, "name": "a-container", "version": "v1.2.3", "release": "2.assembly.hotfix_a", "tag_name": "tag1"},
+            {"id": 11, "name": "a-container", "version": "v1.2.3", "release": "1.assembly.hotfix_a", "tag_name": "tag1"},
+            {"id": 23, "name": "b-container", "version": "v1.2.3", "release": "3.assembly.test", "tag_name": "tag1"},
+            {"id": 22, "name": "b-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b", "tag_name": "tag1"},
+            {"id": 21, "name": "b-container", "version": "v1.2.3", "release": "1.assembly.stream", "tag_name": "tag1"},
+            {"id": 33, "name": "c-container", "version": "v1.2.3", "release": "3", "tag_name": "tag1"},
+            {"id": 32, "name": "c-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b", "tag_name": "tag1"},
+            {"id": 31, "name": "c-container", "version": "v1.2.3", "release": "1", "tag_name": "tag1"},
+        ]
+        actual = util.find_latest_builds(builds, "stream")
+        self.assertEqual([13, 21, 33], [b["id"] for b in actual])
+
+        actual = util.find_latest_builds(builds, "hotfix_a")
+        self.assertEqual([12, 21, 33], [b["id"] for b in actual])
+
+        actual = util.find_latest_builds(builds, "hotfix_b")
+        self.assertEqual([13, 22, 32], [b["id"] for b in actual])
+
+        actual = util.find_latest_builds(builds, "test")
+        self.assertEqual([13, 23, 33], [b["id"] for b in actual])
+
+        actual = util.find_latest_builds(builds, None)
+        self.assertEqual([13, 23, 33], [b["id"] for b in actual])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
1. Uses the logic like https://issues.redhat.com/browse/ART-2941 to find the latest builds for the runtime assembly.
2. When creating plashets for `-hotfix` tags, also check the build is shipped or not.
3. Fixes some minor issues:
    - `nvre_obj` should be parsed after unembargoed build substitution.
    -  Unembargoed build substitution should conform to `--inherit` option.

Requires https://github.com/openshift/doozer/pull/424.

Can be tested with:

```sh
$ doozer --assembly=test --debug --group=openshift-4.5 config:plashet --base-dir=./plashets/el8 --name=4.9-embargoed --repo-subdir=os --arch x86_64 unsigned from-tags  --inherit --brew-tag rhaos-4.8-rhel-8-candidate OSE-4.8-RHEL-8 --embargoed-brew-tag=rhaos-4.8-rhel-8-embargoed --include-previous-for openshift-clients --embargoed-nvr openshift-clients-4.8.0-202106030157.p0.git.714295d.assembly.stream.el8
```