### PR TITLE
Scan sources assembly

### DIFF
--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -8,6 +8,7 @@ import json
 import threading
 import time
 import traceback
+from enum import Enum
 from multiprocessing import Lock
 from typing import Dict, Iterable, List, Optional, Tuple
 
@@ -31,6 +32,23 @@ logger = logutil.getLogger(__name__)
 watch_task_info = {}
 # Protects threaded access to watch_task_info
 watch_task_lock = Lock()
+
+
+class TaskStates(Enum):
+    FREE = 0
+    OPEN = 1
+    CLOSED = 2
+    CANCELED = 3
+    ASSIGNED = 4
+    FAILED = 5
+
+
+class BuildStates(Enum):
+    BUILDING = 0
+    COMPLETE = 1
+    DELETED = 2
+    FAILED = 3
+    CANCELED = 4
 
 
 def get_watch_task_info_copy():

--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -419,6 +419,7 @@ class KojiWrapper(koji.ClientSession):
         'getBuild',
         'listArchives',
         'listRPMs',
+        'getPackage',
     ])
 
     def __init__(self, koji_session_args, brew_event=None):

--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -429,7 +429,7 @@ class KojiWrapper(koji.ClientSession):
         'newRepo',
     ])
 
-    # Methods which cannot be constrained, but are considered safe to allow even wthen brew-event is set.
+    # Methods which cannot be constrained, but are considered safe to allow even when brew-event is set.
     # Why? If you know the parameters, those parameters should have already been constrained by another
     # koji API call.
     safe_methods = set([
@@ -438,6 +438,7 @@ class KojiWrapper(koji.ClientSession):
         'listArchives',
         'listRPMs',
         'getPackage',
+        'listTags',
     ])
 
     def __init__(self, koji_session_args, brew_event=None):

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -11,11 +11,7 @@ from doozerlib.cli import cli, pass_runtime
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
 from doozerlib.runtime import Runtime
-<<<<<<< HEAD
 from doozerlib.util import find_latest_build, go_suffix_for_arch, red_print, yellow_print
-=======
-from doozerlib.util import go_suffix_for_arch, red_print, yellow_print, isolate_assembly_in_release
->>>>>>> e7135b6 (Do not assume release endswith .assembly.<name>)
 
 
 @cli.command("release:gen-payload", short_help="Generate input files for release mirroring")

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -11,7 +11,11 @@ from doozerlib.cli import cli, pass_runtime
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
 from doozerlib.runtime import Runtime
+<<<<<<< HEAD
 from doozerlib.util import find_latest_build, go_suffix_for_arch, red_print, yellow_print
+=======
+from doozerlib.util import go_suffix_for_arch, red_print, yellow_print, isolate_assembly_in_release
+>>>>>>> e7135b6 (Do not assume release endswith .assembly.<name>)
 
 
 @cli.command("release:gen-payload", short_help="Generate input files for release mirroring")

--- a/doozerlib/cli/scan_sources.py
+++ b/doozerlib/cli/scan_sources.py
@@ -68,7 +68,7 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
         runtime.logger.info(f'scan-sources coordinate: emulated_brew_event: {runtime.brew_event}')
 
         # First, scan for any upstream source code changes. If found, these are guaranteed rebuilds.
-        for meta, change_info in runtime.scan_distgit_sources():
+        for meta, change_info in runtime.scan_for_upstream_changes():
             needs_rebuild, reason = change_info
             dgk = meta.distgit_key
             if not (meta.enabled or meta.mode == "disabled" and runtime.load_disabled):

--- a/doozerlib/cli/scan_sources.py
+++ b/doozerlib/cli/scan_sources.py
@@ -6,7 +6,8 @@ import yaml
 from doozerlib import brew, exectools, rhcos
 from doozerlib.cli import cli, pass_runtime
 from doozerlib.cli import release_gen_payload as rgp
-from doozerlib.metadata import RebuildHint
+from doozerlib.metadata import RebuildHint, RebuildHintCode
+
 
 @cli.command("config:scan-sources", short_help="Determine if any rpms / images need to be rebuilt.")
 @click.option("--ci-kubeconfig", metavar='KC_PATH', required=False,
@@ -36,7 +37,7 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
     \b
     It will report machine-os-content updates available per imagestream.
     """
-    runtime.initialize(mode='both', clone_distgits=True)
+    runtime.initialize(mode='both', clone_distgits=False, clone_source=False, prevent_cloning=True)
 
     all_rpm_metas = set(runtime.rpm_metas())
     all_image_metas = set(runtime.image_metas())
@@ -54,13 +55,13 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
         if key not in assessment_reason:
             assessment_reason[key] = rebuild_hint.reason
 
-    def add_image_meta_change(meta, msg):
+    def add_image_meta_change(meta, rebuild_hint: RebuildHint):
         nonlocal changing_image_metas
         changing_image_metas.add(meta)
-        add_assessment_reason(meta, RebuildHint(True, msg))
+        add_assessment_reason(meta, rebuild_hint)
         for descendant_meta in meta.get_descendants():
             changing_image_metas.add(descendant_meta)
-            add_assessment_reason(descendant_meta, RebuildHint(True, f'Ancestor {meta.distgit_key} is changing'))
+            add_assessment_reason(descendant_meta, RebuildHint(RebuildHintCode.ANCESTOR_CHANGING, f'Ancestor {meta.distgit_key} is changing'))
 
     with runtime.shared_koji_client_session() as koji_api:
         runtime.logger.info(f'scan-sources coordinate: brew_event: {koji_api.getLastEvent(brew.KojiWrapperOpts(brew_event_aware=True))}')
@@ -68,16 +69,15 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
 
         # First, scan for any upstream source code changes. If found, these are guaranteed rebuilds.
         for meta, rebuild_hint in runtime.scan_for_upstream_changes():
-            needs_rebuild = rebuild_hint.rebuild
-            reason = rebuild_hint.reason
+
             dgk = meta.distgit_key
             if not (meta.enabled or meta.mode == "disabled" and runtime.load_disabled):
                 # An enabled image's dependents are always loaded. Ignore disabled configs unless explicitly indicated
                 continue
 
             if meta.meta_type == 'rpm':
-                package_name = meta.get_package_name(default=None)
-                if needs_rebuild is False and package_name:  # If no change has been detected, check buildroots to see if it has changed
+                package_name = meta.get_package_name()
+                if not rebuild_hint.rebuild:  # If no change has been detected, check buildroots to see if it has changed
 
                     # A package may contain multiple RPMs; find the oldest one in the latest package build.
                     eldest_rpm_build = None
@@ -89,39 +89,29 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
                     build_root_change = brew.has_tag_changed_since_build(runtime, koji_api, eldest_rpm_build, meta.build_root_tag(), inherit=True)
 
                     if build_root_change:
-                        reason = 'Oldest package rpm build was before buildroot change'
+                        rebuild_hint = RebuildHint(RebuildHintCode.BUILD_ROOT_CHANGING, 'Oldest package rpm build was before buildroot change')
                         runtime.logger.info(f'{dgk} ({eldest_rpm_build}) in {package_name} is older than more recent buildroot change: {build_root_change}')
-                        needs_rebuild = True
 
-                if reason:
-                    add_assessment_reason(meta, RebuildHint(needs_rebuild, reason=reason))
-
-                if needs_rebuild:
+                if rebuild_hint.rebuild:
+                    add_assessment_reason(meta, rebuild_hint)
                     changing_rpm_metas.add(meta)
-                    if package_name:
-                        changing_rpm_packages.add(package_name)
-                    else:
-                        runtime.logger.warning(f"Appears that {dgk} has never been built before; can't determine package name")
+                    changing_rpm_packages.add(package_name)
+
             elif meta.meta_type == 'image':
-                if not needs_rebuild:  # If no change has been detected, check configurations like image meta, repos, and streams to see if they have changed
+                if not rebuild_hint.rebuild:
+                    # If no upstream change has been detected, check configurations
+                    # like image meta, repos, and streams to see if they have changed
                     # We detect config changes by comparing their digest changes.
                     # The config digest of the previous build is stored at .oit/config_digest on distgit repo.
-                    dgr = meta.distgit_repo()
-                    path = Path(dgr.distgit_dir).joinpath(".oit", "config_digest")
-                    if not path.exists():  # alway request a buiild if config_digest hasn't been stored
-                        runtime.logger.info('%s config_digest does not exist; request a build', dgk)
-                        needs_rebuild = True
-                        reason = '.oit/config_digest does not exist'
-                    else:
-                        with path.open('r') as f:
-                            prev_digest = f.read()
+                    try:
+                        prev_digest = meta.fetch_cgit_file('.oit/config_digest').decode('utf-8')
                         current_digest = meta.calculate_config_digest(runtime.group_config, runtime.streams)
                         if current_digest.strip() != prev_digest.strip():
                             runtime.logger.info('%s config_digest %s is differing from %s', dgk, prev_digest, current_digest)
-                            needs_rebuild = True
-                            reason = 'Config changed'
-                if needs_rebuild:
-                    add_image_meta_change(meta, reason)
+                            add_image_meta_change(meta, RebuildHint(RebuildHintCode.CONFIG_CHANGE, 'Config changed'))
+                    except exectools.RetryException:
+                        runtime.logger.info('%s config_digest cannot be retrieved; request a build', dgk)
+                        add_image_meta_change(meta, RebuildHint(RebuildHintCode.CONFIG_CHANGE, 'Unable to retrieve config_digest'))
             else:
                 raise IOError(f'Unsupported meta type: {meta.meta_type}')
 
@@ -145,9 +135,9 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
     )
 
     for change_result in change_results.get():
-        meta, changing, msg = change_result
-        if changing:
-            add_image_meta_change(meta, msg)
+        meta, rebuild_hint = change_result
+        if rebuild_hint.rebuild:
+            add_image_meta_change(meta, rebuild_hint)
 
     # does_image_need_change() checks whether its non-member builder images have changed
     # but cannot determine whether member builder images have changed until anticipated
@@ -166,7 +156,7 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
             for builder in image_meta.config['from'].builder:
                 if builder.member and builder.member in changing_image_dgks:
                     runtime.logger.info(f'{dgk} will be rebuilt due to change in builder member ')
-                    add_image_meta_change(image_meta, f'Builder group member has changed: {builder.member}')
+                    add_image_meta_change(image_meta, RebuildHint(RebuildHintCode.BUILDER_CHANGING, f'Builder group member has changed: {builder.member}'))
 
         if len(changing_image_metas) == len(changing_image_dgks):
             # The for loop didn't find anything new, we can break

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -858,7 +858,7 @@ class ImageDistGitRepo(DistGitRepo):
                 if 'member' in builder:
                     self._set_wait_for(builder['member'], terminate_event)
 
-            if self.runtime.assembly and not release.endswith(f".assembly.{self.runtime.assembly}"):
+            if self.runtime.assembly and util.isolate_assembly_in_release(release) != self.runtime.assembly:
                 # Assemblies should follow its naming convention
                 raise ValueError(f"Image {self.name} is not rebased with assembly '{self.runtime.assembly}'.")
 

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1405,7 +1405,10 @@ class ImageDistGitRepo(DistGitRepo):
 
             if not self.runtime.local:
                 with dg_path.joinpath('additional-tags').open('w', encoding="utf-8") as at:
-                    at.write("%s\n" % uuid_tag)  # The uuid which we ensure we get the right
+                    # Include the UUID in the tags. This will allow other images being rebased
+                    # to have a known tag to refer to this image if they depend on it - even
+                    # before it is built.
+                    at.write("%s\n" % uuid_tag)
                     if len(vsplit) > 1:
                         at.write("%s.%s\n" % (vsplit[0], vsplit[1]))  # e.g. "v3.7.0" -> "v3.7"
                     if self.metadata.config.additional_tags is not Missing:

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -310,7 +310,7 @@ class DistGitRepo(object):
         """
         assert self.sha is not None
         self.logger.debug("Checking if distgit commit %s is available on cgit...", self.sha)
-        url = self.metadata.cgit_url(filename, commit_hash=self.sha, branch=self.branch)
+        url = self.metadata.cgit_file_url(filename, commit_hash=self.sha, branch=self.branch)
         response = requests.head(url)
         if response.status_code == 404:
             self.logger.debug("Distgit commit %s is not available on cgit", self.sha)

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -144,6 +144,9 @@ class DistGitRepo(object):
             exectools.cmd_assert('rhpkg sources')
 
     def clone(self, distgits_root_dir, distgit_branch):
+        if self.metadata.prevent_cloning:
+            raise IOError(f'Attempt to clone downstream {self.metadata.distgit_key} after cloning disabled; a regression has been introduced.')
+
         with Dir(distgits_root_dir):
 
             namespace_dir = os.path.join(distgits_root_dir, self.metadata.namespace)

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1409,6 +1409,8 @@ class ImageDistGitRepo(DistGitRepo):
                     # to have a known tag to refer to this image if they depend on it - even
                     # before it is built.
                     at.write("%s\n" % uuid_tag)
+                    if self.runtime.assembly:
+                        at.write("assembly.%s\n" % self.runtime.assembly)
                     if len(vsplit) > 1:
                         at.write("%s.%s\n" % (vsplit[0], vsplit[1]))  # e.g. "v3.7.0" -> "v3.7"
                     if self.metadata.config.additional_tags is not Missing:

--- a/doozerlib/exectools.py
+++ b/doozerlib/exectools.py
@@ -76,7 +76,7 @@ def urlopen_assert(url_or_req, httpcode=200, retries=3):
 
 
 def cmd_assert(cmd, realtime=False, retries=1, pollrate=60, on_retry=None,
-               set_env=None, strip=False, log_stdout: bool = False, log_stderr: bool = True):
+               set_env=None, strip=False, log_stdout: bool = False, log_stderr: bool = True) -> Tuple[str, str]:
     """
     Run a command, logging (using exec_cmd) and raise an exception if the
     return code of the command indicates failure.
@@ -123,7 +123,7 @@ cmd_counter_lock = threading.Lock()
 cmd_counter = 0  # Increments atomically to help search logs for command start/stop
 
 
-def cmd_gather(cmd, set_env=None, realtime=False, strip=False, log_stdout=False, log_stderr=True):
+def cmd_gather(cmd, set_env=None, realtime=False, strip=False, log_stdout=False, log_stderr=True) -> Tuple[int, str, str]:
     """
     Runs a command and returns rc,stdout,stderr as a tuple.
 

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -99,7 +99,7 @@ class ImageMetadata(Metadata):
         """
         :param default: Not used. Here to stay consistent with similar rpmcfg.get_component_name
         :return: Returns the component name of the image. This is the name in the nvr
-        that brew assigns to this image's build.
+        that brew assigns to this image's build. Component name is synonymous with package name.
         """
         # By default, the bugzilla component is the name of the distgit,
         # but this can be overridden in the config yaml.

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 import hashlib
 import json
 import random
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from doozerlib import brew, exectools, util
 from doozerlib.distgit import pull_image
-from doozerlib.metadata import Metadata
+from doozerlib.metadata import Metadata, RebuildHint, RebuildHintCode
 from doozerlib.model import Missing, Model
 from doozerlib.pushd import Dir
 from doozerlib import coverity
@@ -15,8 +15,8 @@ from doozerlib import coverity
 
 class ImageMetadata(Metadata):
 
-    def __init__(self, runtime, data_obj: Dict, commitish: Optional[str] = None, clone_source: Optional[bool] = False):
-        super(ImageMetadata, self).__init__('image', runtime, data_obj, commitish)
+    def __init__(self, runtime, data_obj: Dict, commitish: Optional[str] = None, clone_source: Optional[bool] = False, prevent_cloning: Optional[bool] = False):
+        super(ImageMetadata, self).__init__('image', runtime, data_obj, commitish, prevent_cloning=prevent_cloning)
         self.image_name = self.config.name
         self.required = self.config.get('required', False)
         self.image_name_short = self.image_name.split('/')[-1]
@@ -236,7 +236,7 @@ class ImageMetadata(Metadata):
     # Mapping of brew pullspec => most recent brew build dict.
     builder_image_builds = dict()
 
-    def does_image_need_change(self, changing_rpm_packages=[], buildroot_tag=None, newest_image_event_ts=None, oldest_image_event_ts=None):
+    def does_image_need_change(self, changing_rpm_packages=[], buildroot_tag=None, newest_image_event_ts=None, oldest_image_event_ts=None) -> Tuple[Metadata, RebuildHint]:
         """
         Answers the question of whether the latest built image needs to be rebuilt based on
         the packages (and therefore RPMs) it is dependent on might have changed in tags
@@ -246,8 +246,7 @@ class ImageMetadata(Metadata):
         :param buildroot_tag: The build root for this image
         :param newest_image_event_ts: The build timestamp of the most recently built image in this group.
         :param oldest_image_event_ts: The build timestamp of the oldest build in this group from getLatestBuild of each component.
-        :return: (meta, <bool>, messsage). If True, the image might need to be rebuilt -- the message will say
-                why. If False, message will be None.
+        :return: (meta, RebuildHint).
         """
 
         dgk = self.distgit_key
@@ -259,7 +258,7 @@ class ImageMetadata(Metadata):
             image_build = self.get_latest_build(default='')
             if not image_build:
                 # Seems this have never been built. Mark it as needing change.
-                return self, True, 'Image has never been built before'
+                return self, RebuildHint(RebuildHintCode.NO_LATEST_BUILD, 'Image has never been built before')
 
             self.logger.debug(f'Image {dgk} latest is {image_build}')
 
@@ -288,7 +287,7 @@ class ImageMetadata(Metadata):
                         extra_latest_tagging_event = extra_latest_tagging_infos[-1]['create_event']
                         self.logger.debug(f'Checking image creation time against extra_packages {extra_package_name} in tag {extra_package_brew_tag} @ tagging event {extra_latest_tagging_event}')
                         if extra_latest_tagging_event > image_build_event_id:
-                            return self, True, f'Image {dgk} is sensitive to extra_packages {extra_package_name} which changed at event {extra_latest_tagging_event}'
+                            return self, RebuildHint(RebuildHintCode.PACKAGE_CHANGE, f'Image {dgk} is sensitive to extra_packages {extra_package_name} which changed at event {extra_latest_tagging_event}')
                     else:
                         self.logger.warning(f'{dgk} unable to find tagging event for for extra_packages {extra_package_name} in tag {extra_package_brew_tag} ; Possible metadata error.')
 
@@ -332,14 +331,14 @@ class ImageMetadata(Metadata):
 
                 if image_build_event_id < builder_brew_build['creation_event_id']:
                     self.logger.info(f'will be rebuilt because a builder or parent image changed: {builder_image_name}')
-                    return self, True, f'A builder or parent image {builder_image_name} has changed since {image_nvr} was built'
+                    return self, RebuildHint(RebuildHintCode.BUILDER_CHANGING, f'A builder or parent image {builder_image_name} has changed since {image_nvr} was built')
 
             build_root_change = brew.has_tag_changed_since_build(runtime, koji_api, image_build, buildroot_tag, inherit=True)
             if build_root_change:
                 self.logger.info(f'Image will be rebuilt due to buildroot change since {image_nvr} (last build event={image_build_event_id}). Build root change: [{build_root_change}]')
-                return self, True, f'Buildroot tag changes since {image_nvr} was built'
+                return self, RebuildHint(RebuildHintCode.BUILD_ROOT_CHANGING, f'Buildroot tag changes since {image_nvr} was built')
 
-            archives = koji_api.listArchives(image_build['id'])
+            archives = koji_api.listArchives(image_build['build_id'])
 
             # Compare to the arches in runtime
             build_arches = set()
@@ -351,7 +350,7 @@ class ImageMetadata(Metadata):
             target_arches = set(self.get_arches())
             if target_arches != build_arches:
                 # The latest brew build does not exactly match the required arches as specified in group.yml
-                return self, True, f'Arches of {image_nvr}: ({build_arches}) does not match target arches {target_arches}'
+                return self, RebuildHint(RebuildHintCode.ARCHES_CHANGE, f'Arches of {image_nvr}: ({build_arches}) does not match target arches {target_arches}')
 
             for archive in archives:
                 # Example results of listing RPMs in an given imageID:
@@ -363,7 +362,7 @@ class ImageMetadata(Metadata):
                     build = koji_api.getBuild(build_id, brew.KojiWrapperOpts(caching=True))
                     package_name = build['package_name']
                     if package_name in changing_rpm_packages:
-                        return self, True, f'Image includes {package_name} which is also about to change'
+                        return self, RebuildHint(RebuildHintCode.PACKAGE_CHANGE, f'Image includes {package_name} which is also about to change')
                     # Several RPMs may belong to the same package, and each archive must use the same
                     # build of a package, so all we need to collect is the set of build_ids for the packages
                     # across all of the archives.
@@ -384,11 +383,11 @@ class ImageMetadata(Metadata):
             n_threads=10
         )
 
-        for changed, msg in changes_res.get():
-            if changed:
-                return self, True, msg
+        for rebuild_hint in changes_res.get():
+            if rebuild_hint.rebuild:
+                return self, rebuild_hint
 
-        return self, False, None
+        return self, RebuildHint(RebuildHintCode.BUILD_IS_UP_TO_DATE, 'No change detected')
 
     def covscan(self, cc: coverity.CoverityContext) -> bool:
         self.logger.info('Setting up for coverity scan')
@@ -437,7 +436,7 @@ class ImageMetadata(Metadata):
         return target
 
 
-def is_image_older_than_package_build_tagging(image_meta, image_build_event_id, package_build, newest_image_event_ts, oldest_image_event_ts):
+def is_image_older_than_package_build_tagging(image_meta, image_build_event_id, package_build, newest_image_event_ts, oldest_image_event_ts) -> RebuildHint:
     """
     Determines if a given rpm is part of a package that has been tagged in a relevant tag AFTER image_build_event_id
     :param image_meta: The image meta object for the image.
@@ -445,8 +444,7 @@ def is_image_older_than_package_build_tagging(image_meta, image_build_event_id, 
     :param package_build: The package build to assess.
     :param newest_image_event_ts: The build timestamp of the most recently built image in this group.
     :param oldest_image_event_ts: The build timestamp of the oldest build in this group from getLatestBuild of each component.
-    :return: (<bool>, message) . If True, the message will describe the change reason. If False, message will
-            will be None.
+    :return: A rebuild hint with information on whether a rebuild should be performed and why
     """
 
     # If you are considering changing this code, you are going to have to contend with
@@ -529,6 +527,6 @@ def is_image_older_than_package_build_tagging(image_meta, image_build_event_id, 
         intersection_set = subsequent_active_tag_names.intersection(contemporary_active_tag_names)
 
         if intersection_set:
-            return True, f'Package {package_name} has been retagged by potentially relevant tags since image build: {intersection_set}'
+            return RebuildHint(RebuildHintCode.PACKAGE_CHANGE, f'Package {package_name} has been retagged by potentially relevant tags since image build: {intersection_set}')
 
-    return False, None
+    return RebuildHint(RebuildHintCode.BUILD_IS_UP_TO_DATE, 'No package change detected')

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -319,13 +319,13 @@ class Metadata(object):
         :return: Returns the most recent build object from koji for this package & assembly.
                  Example https://gist.github.com/jupierce/57e99b80572336e8652df3c6be7bf664
         """
-        package_name = self.get_component_name()
+        component_name = self.get_component_name()
         builds = []
 
         with self.runtime.pooled_koji_client_session() as koji_api:
-            package_info = koji_api.getPackage(package_name)  # e.g. {'id': 66873, 'name': 'atomic-openshift-descheduler-container'}
+            package_info = koji_api.getPackage(component_name)  # e.g. {'id': 66873, 'name': 'atomic-openshift-descheduler-container'}
             if not package_info:
-                raise IOError(f'No brew package is defined for {package_name}')
+                raise IOError(f'No brew package is defined for {component_name}')
             package_id = package_info['id']  # we could just constrain package name using pattern glob, but providing package ID # should be a much more efficient DB query.
             # listBuilds returns all builds for the package; We need to limit the query to the builds
             # relevant for our major/minor.
@@ -345,7 +345,7 @@ class Metadata(object):
                     else:
                         raise IOError(f'Unable to determine rhel version from specified el_target: {el_target}')
 
-            pattern_prefix = f'{package_name}-{ver_prefix}{self.branch_major_minor()}.'
+            pattern_prefix = f'{component_name}-{ver_prefix}{self.branch_major_minor()}.'
 
             if assembly is None:
                 assembly = self.runtime.assembly
@@ -425,7 +425,7 @@ class Metadata(object):
         :param default: If the component name cannot be determined,
         :return: Returns the component name of the image. This is the name in the nvr
         that brew assigns to component build. Component name is synonymous with package name.
-        For RPMs, spec files declare the package name. For images, it is always based on
+        For RPMs, spec files declare the package name. For images, it is usually based on
         the distgit repo name + '-container'.
         """
         raise IOError('Subclass must implement')

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -218,7 +218,6 @@ class Metadata(object):
             if not package_info:
                 raise IOError(f'No brew package is defined for {package_name}')
             package_id = package_info['id']  # we could just contrain package name using pattern glob, but providing package ID # should be a much more efficient DB query.
-            self.candidate_brew_tags()
             # listBuilds returns all builds for the package; We need to limit the query to the builds
             # relevant for our major/minor.
             pattern_prefix = f'{package_name}-v{self.branch_major_minor()}.'
@@ -239,7 +238,7 @@ class Metadata(object):
                 builds = latestBuildList(f'*.assembly.{assembly}')
                 if not builds:
                     if assembly != 'stream':
-                        builds = latestBuildList(f'*.assembly.stream')
+                        builds = latestBuildList('*.assembly.stream')
                     if not builds:
                         # Fall back to true latest
                         builds = latestBuildList('*')

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -15,7 +15,7 @@ from doozerlib.distgit import RPMDistGitRepo
 from doozerlib.model import Missing
 from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.runtime import Runtime
-from doozerlib.util import is_in_directory
+from doozerlib.util import is_in_directory, isolate_assembly_in_release
 
 
 class RPMBuilder:
@@ -187,7 +187,7 @@ class RPMBuilder:
         if rpm.specfile is None:
             rpm.specfile, nvr, rpm.pre_init_sha = await dg.resolve_specfile_async()
             rpm.set_nvr(nvr[1], nvr[2])
-        if self._runtime.assembly and not rpm.release.endswith(f".assembly.{self._runtime.assembly}"):
+        if self._runtime.assembly and isolate_assembly_in_release(rpm.release) != self._runtime.assembly:
             # Assemblies should follow its naming convention
             raise ValueError(f"RPM {rpm.name} is not rebased with assembly '{self._runtime.assembly}'.")
         if rpm.private_fix is None:

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -40,8 +40,8 @@ remote_git_name = {name}
 class RPMMetadata(Metadata):
 
     def __init__(self, runtime, data_obj, commitish: Optional[str] = None, clone_source=True,
-                 source_modifier_factory=SourceModifierFactory()):
-        super(RPMMetadata, self).__init__('rpm', runtime, data_obj, commitish)
+                 source_modifier_factory=SourceModifierFactory(), prevent_cloning: Optional[bool] = False):
+        super(RPMMetadata, self).__init__('rpm', runtime, data_obj, commitish, prevent_cloning=prevent_cloning)
 
         self.source = self.config.content.source
         if self.source is Missing:

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -36,7 +36,7 @@ from .pushd import Dir
 
 from .image import ImageMetadata
 from .rpmcfg import RPMMetadata
-from .metadata import Metadata
+from .metadata import Metadata, RebuildHint
 from doozerlib import state
 from .model import Model, Missing
 from multiprocessing import Lock, RLock, Semaphore
@@ -1400,7 +1400,7 @@ class Runtime(object):
         ]
         return {n: (v, r) for n, v, r in builds}
 
-    def scan_for_upstream_changes(self) -> List[Tuple[Metadata, Tuple[bool, str]]]:
+    def scan_for_upstream_changes(self) -> List[Tuple[Metadata, RebuildHint]]:
         """
         Determines if the current upstream source commit hash has a downstream
         build associated with it.

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -24,7 +24,7 @@ import signal
 import io
 import pathlib
 import koji
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple
 import time
 
 from doozerlib import gitdata
@@ -36,6 +36,7 @@ from .pushd import Dir
 
 from .image import ImageMetadata
 from .rpmcfg import RPMMetadata
+from .metadata import Metadata
 from doozerlib import state
 from .model import Model, Missing
 from multiprocessing import Lock, RLock, Semaphore
@@ -1399,7 +1400,13 @@ class Runtime(object):
         ]
         return {n: (v, r) for n, v, r in builds}
 
-    def scan_distgit_sources(self):
+    def scan_for_upstream_changes(self) -> List[Tuple[Metadata, Tuple[bool, str]]]:
+        """
+        Determines if the current upstream source commit hash has a downstream
+        build associated with it.
+        :return: Returns a list of tuples. Each tuple contains an rpm or image metadata
+        and a change tuple (changed: bool, message: str).
+        """
         return self.parallel_exec(
             lambda meta, _: (meta, meta.needs_rebuild()),
             self.image_metas() + self.rpm_metas(),

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -357,21 +357,31 @@ def get_docker_config_json(config_dir):
         raise FileNotFoundError("Can not find the registry config file in {}".format(config_dir))
 
 
-def isolate_pflag_in_release(release: str):
+def isolate_pflag_in_release(release: str) -> str:
     """
     Given a release field, determines whether is contains
     .p0/.p1 information. If it does, it returns the value
     'p0' or 'p1'. If it is not found, None is returned.
     """
-    if release.endswith('.p1') or release.endswith('.p0'):
-        return release[-2:]
+    match = re.match(r'.*\.(p[?01])(?:\.+|$)', release)
 
-    # p? is not always at the end of the release field if
-    # assemblies are being used.
-    for pflag in ['p0', 'p1']:
-        idx = release.find(f'.{pflag}.')
-        if idx > -1:
-            return pflag
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def isolate_assembly_in_release(release: str) -> str:
+    """
+    Given a release field, determines whether is contains
+    an assembly name. If it does, it returns the assembly
+    name. If it is not found, None is returned.
+    """
+    # Because RPM releases will have .el? as their suffix, we cannot
+    # assume that endswith(.assembly.<name>).
+    match = re.match(r'.*\.assembly\.([^.]+)(?:\.+|$)', release)
+    if match:
+        return match.group(1)
 
     return None
 

--- a/tests/test_distgit/test_generic_distgit.py
+++ b/tests/test_distgit/test_generic_distgit.py
@@ -58,6 +58,7 @@ class TestGenericDistGit(TestDistgit):
                             runtime=flexmock(local=False, branch="_irrelevant_", upcycle=False),
                             config=MockConfig(),
                             logger=logger,
+                            prevent_cloning=False,
                             name="_irrelevant_")
 
         expected_cmd = ['git', '-C', 'my-root-dir/my-namespace/my-distgit-key', 'rev-parse', 'HEAD']
@@ -84,6 +85,7 @@ class TestGenericDistGit(TestDistgit):
                             name="_irrelevant_",
                             logger="_irrelevant_",
                             namespace="_irrelevant_",
+                            prevent_cloning=False,
                             distgit_key="_irrelevant_")
 
         repo = distgit.DistGitRepo(metadata, autoclone=False)
@@ -140,6 +142,7 @@ class TestGenericDistGit(TestDistgit):
                                              rhpkg_config_lst=[]),
                             namespace="my-namespace",
                             distgit_key="my-distgit-key",
+                            prevent_cloning=False,
                             logger=logger,
                             name="_irrelevant_")
 
@@ -196,6 +199,7 @@ class TestGenericDistGit(TestDistgit):
                             namespace="my-namespace",
                             distgit_key="my-distgit-key",
                             qualified_name="my-qualified-name",
+                            prevent_cloning=False,
                             logger=logger,
                             name="_irrelevant_")
 
@@ -241,6 +245,7 @@ class TestGenericDistGit(TestDistgit):
                             distgit_key="my-distgit-key",
                             qualified_name="my-qualified-name",
                             logger=flexmock(info=lambda _: None),
+                            prevent_cloning=False,
                             name="_irrelevant_",)
 
         distgit.DistGitRepo(metadata, autoclone=False).clone("my-root-dir", "my-branch")
@@ -644,7 +649,7 @@ class TestGenericDistGit(TestDistgit):
     def test_cgit_file_available(self, mocked_head):
         meta = MockMetadata(MockRuntime(self.logger))
         cgit_url = "http://distgit.example.com/cgit/containers/foo/plain/some_path/some_file.txt?h=some-branch&id=abcdefg"
-        meta.cgit_url = lambda *args, **kwargs: cgit_url
+        meta.cgit_file_url = lambda *args, **kwargs: cgit_url
         dg = distgit.ImageDistGitRepo(meta, autoclone=False)
         dg.sha = "abcdefg"
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -12,5 +12,5 @@ class TestMetadata(TestCase):
         runtime = MagicMock()
         runtime.group_config.urls.cgit = "http://distgit.example.com/cgit"
         meta = Metadata("image", runtime, data_obj)
-        url = meta.cgit_url("some_path/some_file.txt", "abcdefg", "some-branch")
+        url = meta.cgit_file_url("some_path/some_file.txt", "abcdefg", "some-branch")
         self.assertEqual(url, "http://distgit.example.com/cgit/containers/foo/plain/some_path/some_file.txt?h=some-branch&id=abcdefg")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -16,6 +16,7 @@ class TestMetadata(TestCase):
         data_obj = MagicMock(key="foo", filename="foo.yml", data={"name": "foo"})
         runtime = MagicMock()
         runtime.group_config.urls.cgit = "http://distgit.example.com/cgit"
+        runtime.group_config.scan_freshness.threshold_hours = 6
         runtime.logger = Mock()
 
         koji_mock = Mock()
@@ -35,6 +36,7 @@ class TestMetadata(TestCase):
         image_meta.logger = Mock()
         image_meta.get_component_name = Mock(return_value='foo-container')
         image_meta.branch_major_minor = Mock(return_value='4.7')
+        image_meta.branch = Mock(return_value='rhaos-4.7-rhel-8')
         image_meta.candidate_brew_tags = Mock(return_value=['rhaos-4.7-rhel-8-candidate', 'rhaos-4.7-rhel-7-candidate'])
 
         self.runtime = runtime

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,11 +1,43 @@
 from unittest import TestCase
 
-from mock import MagicMock
+import re
+import datetime
 
-from doozerlib.metadata import Metadata
+from mock import MagicMock, Mock
+
+from doozerlib.metadata import Metadata, CgitAtomFeedEntry, RebuildHintCode
+from doozerlib.brew import BuildStates
+from doozerlib.model import Model, Missing
+from doozerlib import exectools
 
 
 class TestMetadata(TestCase):
+
+    def setUp(self) -> None:
+        data_obj = MagicMock(key="foo", filename="foo.yml", data={"name": "foo"})
+        runtime = MagicMock()
+        runtime.group_config.urls.cgit = "http://distgit.example.com/cgit"
+
+        koji_mock = Mock()
+        koji_mock.__enter__ = Mock()
+        koji_mock.__enter__.return_value = koji_mock
+        koji_mock.__exit__ = Mock()
+
+        runtime.pooled_koji_client_session = Mock()
+        runtime.pooled_koji_client_session.return_value = koji_mock
+
+        self.package_id = 5
+        koji_mock.getPackage = Mock(return_value={'name': 'foo-container', 'id': self.package_id})
+
+        runtime.assembly = 'hotfix_a'
+        meta = Metadata("image", runtime, data_obj)
+
+        meta.get_component_name = Mock(return_value='foo-container')
+        meta.branch_major_minor = Mock(return_value='4.7')
+
+        self.runtime = runtime
+        self.meta = meta
+        self.koji_mock = koji_mock
 
     def test_cgit_url(self):
         data_obj = MagicMock(key="foo", filename="foo.yml", data={"name": "foo"})
@@ -14,3 +46,344 @@ class TestMetadata(TestCase):
         meta = Metadata("image", runtime, data_obj)
         url = meta.cgit_file_url("some_path/some_file.txt", "abcdefg", "some-branch")
         self.assertEqual(url, "http://distgit.example.com/cgit/containers/foo/plain/some_path/some_file.txt?h=some-branch&id=abcdefg")
+
+    def build_record(self, creation_dt: datetime.datetime, assembly, name='foo-container',
+                     version='4.7.0', p='p0', epoch=None, git_commit='4c0ed6d',
+                     release_prefix=None, release_suffix='',
+                     build_state: BuildStates = BuildStates.COMPLETE):
+        """
+        :return: Returns an artificial brew build record.
+        """
+        if not release_prefix:
+            release_prefix = creation_dt.strftime('%Y%m%d%H%M%S')
+
+        release = release_prefix
+
+        if p:
+            release += f'.{p}'
+
+        if git_commit:
+            release += f'.git.{git_commit[:7]}'
+
+        if assembly is not None:
+            release += f'.assembly.{assembly}{release_suffix}'
+
+        return {
+            'name': name,
+            'package_name': name,
+            'version': version,
+            'release': release,
+            'epoch': epoch,
+            'nvr': f'{name}-v{version}-{release}',
+            'build_id': creation_dt.timestamp(),
+            'creation_event_id': creation_dt.timestamp(),
+            'creation_ts': creation_dt.timestamp(),
+            'creation_time': creation_dt.isoformat(),
+            'state': build_state.value,
+            'package_id': self.package_id,
+        }
+
+    def _list_builds(self, builds, packageID=None, state=None, pattern=None, queryOpts=None):
+        """
+        A simple replacement of koji's listBuilds API. The vital input to this
+        the `builds` variable. It will be filtered based on
+        some of the parameters passed to this method.
+        """
+        pattern_regex = re.compile(r'.*')
+        if pattern:
+            regex = pattern.replace('.', "\\.")
+            regex = regex.replace('*', '.*')
+            pattern_regex = re.compile(regex)
+
+        refined = list(builds)
+        refined = [build for build in refined if pattern_regex.match(build['nvr'])]
+
+        if packageID is not None:
+            refined = [build for build in refined if build['package_id'] == packageID]
+
+        if state is not None:
+            refined = [build for build in refined if build['state'] == state]
+
+        refined.sort(key=lambda e: e['creation_ts'], reverse=True)
+        return refined
+
+    def test_get_latest_build(self):
+        runtime = self.runtime
+        meta = self.meta
+        koji_mock = self.koji_mock
+        now = datetime.datetime.utcnow()
+
+        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
+            return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
+
+        koji_mock.listBuilds.side_effect = list_builds
+
+        # If listBuilds returns nothing, no build should be returned
+        builds = []
+        self.assertIsNone(meta.get_latest_build(default=None))
+
+        # If listBuilds returns a build from an assembly that is not ours
+        # get_latest_builds should not return it.
+        builds = [
+            self.build_record(now, assembly='not_ours')
+        ]
+        self.assertIsNone(meta.get_latest_build(default=None))
+
+        # If there is a build from the 'stream' assembly, it shold be
+        # returned.
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly='stream')
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[1])
+
+        # If there is a build for our assembly, it should be returned
+        builds = [
+            self.build_record(now, assembly=runtime.assembly)
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[0])
+
+        # If there is a build for our assembly and stream, our assembly
+        # should be preferred even if stream is more recent.
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly=runtime.assembly)
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[2])
+
+        # The most recent assembly build should be preferred.
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
+            self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly=runtime.assembly)
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[3])
+
+        # Make sure that just matching the prefix of an assembly is not sufficient.
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
+            self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly=f'{runtime.assembly}b')
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[1])
+
+        # But, a proper suffix like '.el8' should still match.
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
+            self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly=f'{runtime.assembly}', release_suffix='.el8')
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[3])
+
+        # By default, we should only be finding COMPLETE builds
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly='stream', build_state=BuildStates.COMPLETE),
+            self.build_record(now, assembly='stream', build_state=BuildStates.FAILED),
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[0])
+
+        # By default, we should only be finding COMPLETE builds
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly=None, build_state=BuildStates.COMPLETE),
+            self.build_record(now, assembly=None, build_state=BuildStates.FAILED),
+            self.build_record(now, assembly=None, build_state=BuildStates.COMPLETE),
+        ]
+        self.assertEqual(meta.get_latest_build(default=None, assembly=''), builds[2])
+
+        # Check whether extra pattern matching works
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
+            self.build_record(now - datetime.timedelta(hours=25), assembly='stream', release_prefix='99999.git.1234567', release_suffix='.el8'),
+            self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now - datetime.timedelta(hours=8), assembly=f'{runtime.assembly}')
+        ]
+        self.assertEqual(meta.get_latest_build(default=None, extra_pattern='*.git.1234567.*'), builds[1])
+
+    def test_needs_rebuild_disgit_only(self):
+        runtime = self.runtime
+        meta = self.meta
+        koji_mock = self.koji_mock
+        now = datetime.datetime.utcnow()
+        then = now - datetime.timedelta(hours=5)
+
+        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
+            return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
+
+        runtime.downstream_commitish_overrides = {}
+        koji_mock.listBuilds.side_effect = list_builds
+        meta.has_source = Mock(return_value=False)  # Emulate a distgit-only repo
+
+        # If listBuilds returns nothing, we want to trigger a rebuild
+        builds = []
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.NO_LATEST_BUILD)
+
+        meta.cgit_atom_feed = Mock()
+
+        # If we find that that the most recent distgit commit is newer than the build,
+        # we must rebuild.
+        meta.cgit_atom_feed.return_value = [
+            CgitAtomFeedEntry(title='', content='', updated=now, id='1234567')
+        ]
+        builds = [
+            self.build_record(then, assembly=runtime.assembly, git_commit=None)
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.DISTGIT_ONLY_COMMIT_NEWER)
+
+        # If we find that that the most recent distgit commit is newer than the build,
+        # we must rebuild. If there was a recent failed build, delay retrying to not
+        # constantly flood brew.
+        meta.cgit_atom_feed.return_value = [
+            CgitAtomFeedEntry(title='', content='', updated=now, id='1234567')
+        ]
+        builds = [
+            self.build_record(now - datetime.timedelta(minutes=5), assembly=runtime.assembly,
+                              git_commit=None, build_state=BuildStates.FAILED),
+            self.build_record(then, assembly=runtime.assembly,
+                              git_commit=None)
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.DELAYING_NEXT_ATTEMPT)
+
+        # If we find that that the most recent distgit commit is OLDER than the
+        # current build, no rebuild is necessary
+        meta.cgit_atom_feed.return_value = [
+            CgitAtomFeedEntry(title='', content='', updated=then, id='1234567')
+        ]
+        builds = [
+            self.build_record(now, assembly=runtime.assembly, git_commit=None)
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.DISTGIT_ONLY_COMMIT_OLDER)
+
+        # Sanity check that failed builds and unrelated assemblies do not affect our queries
+        meta.cgit_atom_feed.return_value = [
+            CgitAtomFeedEntry(title='', content='', updated=then, id='1234567')
+        ]
+        builds = [
+            self.build_record(now, assembly=runtime.assembly, git_commit=None, build_state=BuildStates.FAILED),
+            self.build_record(now, assembly='not_ours', git_commit=None)
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.NO_LATEST_BUILD)
+
+    def test_needs_rebuild_with_upstream(self):
+        runtime = self.runtime
+        meta = self.meta
+        koji_mock = self.koji_mock
+        now = datetime.datetime.utcnow()
+        then = now - datetime.timedelta(hours=5)
+
+        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
+            return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
+
+        runtime.downstream_commitish_overrides = {}
+        koji_mock.listBuilds.side_effect = list_builds
+        ls_remote_commit = '296ac244f3e7fd2d937316639892f90f158718b0'
+
+        meta.config.content = Model(dict_to_model={
+            'source': {
+                'git': {
+                    'url': 'git@github.com:openshift/release.git',
+                }
+            }
+        })
+        exectools.cmd_assert = Mock(return_value=(ls_remote_commit, ''))  # emulate response to ls-remote of openshift/release
+
+        # If listBuilds returns nothing, we want to trigger a rebuild
+        builds = []
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.NO_LATEST_BUILD)
+
+        # Make sure irrelevant builds are ignored
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly=runtime.assembly, build_state=BuildStates.FAILED),
+            self.build_record(now, assembly=runtime.assembly, git_commit=ls_remote_commit, build_state=BuildStates.FAILED),
+            self.build_record(now, assembly=f'{runtime.assembly}extra', git_commit=ls_remote_commit)  # Close but not quite our assembly
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.NO_LATEST_BUILD)
+
+        meta.cgit_atom_feed = Mock()
+        meta.cgit_atom_feed.return_value = [
+            CgitAtomFeedEntry(title='', content='', updated=then, id='1234567')
+        ]
+
+        # In this scenario, we have a build newer than distgit's commit, but it's git.<> release
+        # component does not match the current upstream ls-remote commit. This means there is
+        # a new build required.
+        builds = [
+            self.build_record(now, assembly=runtime.assembly, git_commit='abcdefg')
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.NEW_UPSTREAM_COMMIT)
+
+        # In this scenario, we have a build newer than distgit's commit. It's git.<> release
+        # component matches the ls-remote value. No new build required.
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly='not_ours', git_commit=ls_remote_commit),
+            self.build_record(now, assembly=runtime.assembly, build_state=BuildStates.FAILED),
+            self.build_record(now, assembly=runtime.assembly, git_commit=ls_remote_commit, build_state=BuildStates.FAILED),
+            self.build_record(now, assembly=runtime.assembly, git_commit=ls_remote_commit)  # This one should match perfectly
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.BUILD_IS_UP_TO_DATE)
+
+        # We should also accept the 'stream' assembly
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly=runtime.assembly, build_state=BuildStates.FAILED),
+            self.build_record(now, assembly=runtime.assembly, git_commit=ls_remote_commit, build_state=BuildStates.FAILED),
+            self.build_record(now, assembly='stream', git_commit=ls_remote_commit)  # This one should match perfectly
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.BUILD_IS_UP_TO_DATE)
+
+        # If we tried the upstream commit recently and failed, there should be a delay before the next attempt
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now - datetime.timedelta(days=5), git_commit='1234567', assembly=runtime.assembly, build_state=BuildStates.COMPLETE),
+            self.build_record(now, assembly=runtime.assembly, git_commit=ls_remote_commit, build_state=BuildStates.FAILED),
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.DELAYING_NEXT_ATTEMPT)
+
+        # If the failed build attempt is old, try again
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now - datetime.timedelta(days=5), git_commit='1234567', assembly=runtime.assembly, build_state=BuildStates.COMPLETE),
+            self.build_record(now - datetime.timedelta(days=5), assembly=runtime.assembly, git_commit=ls_remote_commit, build_state=BuildStates.FAILED),
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.LAST_BUILD_FAILED)
+
+        # Scenario where the latest build has a commit that does not agree with current upstream commit
+        # but there is an old build that does. Indicates some type of revert. Rebuild.
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, git_commit='1234567', assembly=runtime.assembly, build_state=BuildStates.COMPLETE),
+            self.build_record(now - datetime.timedelta(days=5), assembly=runtime.assembly, git_commit=ls_remote_commit),
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.UPSTREAM_COMMIT_MISMATCH)
+
+        # The preceding revert scenario only applies if the assemblies match
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, git_commit='1234567', assembly='stream', build_state=BuildStates.COMPLETE),
+            self.build_record(now - datetime.timedelta(days=5), assembly=runtime.assembly, git_commit=ls_remote_commit),
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.BUILD_IS_UP_TO_DATE)
+
+        # If both builds are 'stream' assembly, the upstream commit revert DOES affect our assembly
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, git_commit='1234567', assembly='stream', build_state=BuildStates.COMPLETE),
+            self.build_record(now - datetime.timedelta(days=5), assembly='stream', git_commit=ls_remote_commit),
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.UPSTREAM_COMMIT_MISMATCH)
+
+        # If there is any build of our assembly, it does not matter if there is one from stream; only use
+        # one specific to our assembly. In this case, our last assembly specific build does not have the
+        # right upstream commit.
+        builds = [
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now - datetime.timedelta(days=5), git_commit=ls_remote_commit, assembly='stream', build_state=BuildStates.COMPLETE),
+            self.build_record(now, assembly=runtime.assembly, git_commit='123457'),
+        ]
+        self.assertEqual(meta.needs_rebuild().code, RebuildHintCode.UPSTREAM_COMMIT_MISMATCH)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,13 +6,22 @@ from doozerlib import util
 
 class TestUtil(unittest.TestCase):
 
+    def test_isolate_assembly_in_release(self):
+        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1'), None)
+        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly'), None)
+        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.x'), 'x')
+        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.xyz'), 'xyz')
+        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.xyz.el7'), 'xyz')
+
     def test_isolate_pflag(self):
         self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p1'), 'p1')
+        self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p1.el7'), 'p1')
         self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p0'), 'p0')
         self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p2'), None)
         self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p1.assembly.p'), 'p1')
         self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p0.assembly.test'), 'p0')
         self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p2.assembly.stream'), None)
+        self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p0.assembly.test.el7'), 'p0')
 
     def test_convert_remote_git_to_https(self):
         # git@ to https

--- a/tests_functional/test_koji_wrapper.py
+++ b/tests_functional/test_koji_wrapper.py
@@ -72,8 +72,8 @@ class TestKojiWrapper(DoozerRunnerTestCase):
     def test_koji_wrapper_event_constraint(self):
         brew.KojiWrapper.clear_global_cache()
 
-        lock_on_event = 34966523
-        test_tag = 'rhaos-4.7-rhel-8-candidate'
+        lock_on_event = 37152928
+        test_tag = 'rhaos-4.5-rhel-8-candidate'
 
         # Get a non brew-event locked wrapper
         k = brew.KojiWrapper(['https://brewhub.engineering.redhat.com/brewhub'], brew_event=lock_on_event)
@@ -88,18 +88,18 @@ class TestKojiWrapper(DoozerRunnerTestCase):
         # However, if you tell the wrapper you are aware of the lock, you may perform the call
         k.getLastEvent(brew.KojiWrapperOpts(brew_event_aware=True))
 
-        results = k.listTagged(test_tag, brew.KojiWrapperOpts(caching=True), package='openshift')  # This should be transparently locked in brew time by the wrapper
-        self.assertEqual(results[0]['task_id'], 31840691)  # since we are locked in the time. this task_id is locked in time
+        results = k.listTagged(test_tag, brew.KojiWrapperOpts(caching=True, logger=self.logger), package='openshift')  # This should be transparently locked in brew time by the wrapper
+        self.assertEqual(results[0]['task_id'], 34774198)  # since we are locked in the time. this task_id is locked in time
         call_meta: brew.KojiWrapperMetaReturn = k.listTagged(test_tag, brew.KojiWrapperOpts(caching=True, return_metadata=True), package='openshift')  # Test to ensure caching is working with a brew event constraint.
         self.assertTrue(call_meta.cache_hit)
-        self.assertEqual(call_meta.result[0]['task_id'], 31840691)
+        self.assertEqual(call_meta.result[0]['task_id'], 34774198)
 
         # Now perform the same query, with caching on, without constraining the brew event.
         # The cache for constrained query vs an unconstrained query share different namespaces
         # and thus we expect a different result.
         unlocked_k = brew.KojiWrapper(['https://brewhub.engineering.redhat.com/brewhub'])
         unlocked_results = unlocked_k.listTagged(test_tag, brew.KojiWrapperOpts(caching=True), package='openshift')
-        self.assertNotEqual(unlocked_results[0]['task_id'], 31840691)  # This was an unlocked query and we know the latest task has moved on
+        self.assertNotEqual(unlocked_results[0]['task_id'], 34774198)  # This was an unlocked query and we know the latest task has moved on
 
 
 if __name__ == "__main__":

--- a/tests_functional/test_metadata.py
+++ b/tests_functional/test_metadata.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from mock import MagicMock
+
+from tests_functional import DoozerRunnerTestCase
+from doozerlib import metadata
+
+
+class TestMetadata(DoozerRunnerTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_cgit_atom(self):
+        data_obj = MagicMock(key="cluster-etcd-operator", filename="cluster-etcd-operator.yml", data={"name": "cluster-etcd-operator"})
+        runtime = MagicMock()
+        runtime.group_config.urls.cgit = "http://pkgs.devel.redhat.com/cgit"
+        meta = metadata.Metadata("image", runtime, data_obj)
+        entry_list = meta.cgit_atom_feed(commit_hash='35ecfa4436139442edc19585c1c81ebfaca18550')
+        entry = entry_list[0]
+        self.assertEqual(entry.updated, '2019-07-09T18:01:53+00:00')
+        self.assertEqual(entry.id, '81597b027a3cb2c38865273b13ab320b361feca6')
+
+        entry_list = meta.cgit_atom_feed(branch='rhaos-4.8-rhel-8')
+        self.assertTrue(len(entry_list) > 1)
+        self.assertIsNotNone(entry_list[0].id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Makes get_latest_build and scan-sources assembly aware. As a side benefit, it also completely eliminates the need to clone upstream & downstream git repos. scan-sources can run in just a couple of minutes!