### PR TITLE
Unify the way of extracting assembly names from release fields

### DIFF
--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -475,13 +475,13 @@ def find_latest_build(builds: List[Dict], assembly: Optional[str]) -> Optional[D
         chosen_build = builds[0] if builds else None
     else:  # assembly is enabled
         # find the newest build containing ".assembly.<assembly-name>" in its RELEASE field
-        chosen_build = next((build for build in builds if f".assembly.{assembly}." in f'{build["release"]}.'), None)
+        chosen_build = next((build for build in builds if isolate_assembly_in_release(build["release"]) == assembly), None)
         if not chosen_build and assembly != "stream":
             # If no such build, fall back to the newest build containing ".assembly.stream"
-            chosen_build = next((build for build in builds if ".assembly.stream." in f'{build["release"]}.'), None)
+            chosen_build = next((build for build in builds if isolate_assembly_in_release(build["release"]) == "stream"), None)
         if not chosen_build:
             # If none of the builds have .assembly.stream in the RELEASE field, fall back to the latest build without .assembly in the RELEASE field
-            chosen_build = next((build for build in builds if ".assembly." not in f'{build["release"]}.'), None)
+            chosen_build = next((build for build in builds if isolate_assembly_in_release(build["release"]) is None), None)
     return chosen_build
 
 


### PR DESCRIPTION
Use `util.isolate_assembly_in_release` introduced by https://github.com/openshift/doozer/pull/426.