### PR TITLE
ART-3034: Implement doozer images:rebase --force-yum-updates

### DIFF
--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -195,6 +195,8 @@ def _get_upstreaming_entries(runtime, stream_names=None):
         if image_meta.config.content.source.ci_alignment.upstream_image is not Missing:
             upstream_entry = model.Model(dict_to_model=image_meta.config.content.source.ci_alignment.primitive())  # Make a copy
             upstream_entry['image'] = image_meta.pull_url()  # Make the image metadata entry match what would exist in streams.yml.
+            if upstream_entry.final_user is Missing:
+                upstream_entry.final_user = image_meta.config.final_stage_user
             upstreaming_entries[image_meta.distgit_key] = upstream_entry
 
     return upstreaming_entries

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1697,7 +1697,7 @@ class ImageDistGitRepo(DistGitRepo):
             else:
                 self.logger.warning("Will not inject `USER 0` before `yum update -y` for the final build stage because `final_stage_user` is missing (or 0) in image meta."
                                     " If this build fails with `yum update -y` permission denied error, please set correct `final_stage_user` and rebase again.")
-            output.write(f"# {yum_update_line_flag}\n{yum_update_line}\n")
+            output.write(f"# {yum_update_line_flag}\n{yum_update_line}  # set final_stage_user in ART metadata if this fails\n")
             if build_stage == build_stage_num and final_stage_user:
                 output.write(f"# {yum_update_line_flag}\nUSER {final_stage_user}\n")
         output.seek(0)

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1361,11 +1361,8 @@ class ImageDistGitRepo(DistGitRepo):
                 if changed:
                     dfp.add_lines_at(entry, "RUN " + new_value, replace=True)
 
-    def update_distgit_dir(self, version, release, prev_release=None):
+    def update_distgit_dir(self, version, release, prev_release=None, force_yum_updates=False):
         ignore_missing_base = self.runtime.ignore_missing_base
-        # A collection of comment lines that will be included in the generated Dockerfile. They
-        # will be prefix by the OIT_COMMENT_PREFIX and followed by newlines in the Dockerfile.
-        oit_comments = []
 
         dg_path = self.dg_path
         with Dir(self.distgit_dir):
@@ -1646,10 +1643,10 @@ class ImageDistGitRepo(DistGitRepo):
                 'BUILD_RELEASE': release if release else '',
             }
 
+            df_fileobj = self._update_yum_update_commands(force_yum_updates, io.StringIO(df_content))
             with dg_path.joinpath('Dockerfile').open('w', encoding="utf-8") as df:
-                for comment in oit_comments:
-                    df.write("%s %s\n" % (OIT_COMMENT_PREFIX, comment))
-                df.write(df_content)
+                shutil.copyfileobj(df_fileobj, df)
+                df_fileobj.close()
 
             self._update_environment_variables(env_vars)
 
@@ -1658,6 +1655,53 @@ class ImageDistGitRepo(DistGitRepo):
             self._update_csv(version, release)
 
             return version, release
+
+    def _update_yum_update_commands(self, force_yum_updates: bool, df_fileobj: io.TextIOBase) -> io.StringIO:
+        """ If force_yum_updates is True, inject "yum updates -y" in each stage; Otherwise, remove the lines we injected.
+        Returns an in-memory text stream for the new Dockerfile content
+        """
+        if force_yum_updates and not self.config.get('enabled_repos'):
+            # If no yum repos are disabled in image meta, "yum update -y" will fail with "Error: There are no enabled repositories in ...".
+            # Remove "yum update -y" lines intead.
+            self.logger.warning("Will not inject \"yum updates -y\" for this image because no yum repos are enabled.")
+            force_yum_updates = False
+        if force_yum_updates:
+            self.logger.info("Injecting \"yum updates -y\" in each stage...")
+
+        parser = DockerfileParser(fileobj=df_fileobj)
+
+        df_lines_iter = iter(parser.content.splitlines(False))
+        build_stage_num = len(parser.parent_images)
+        final_stage_user = self.metadata.config.final_stage_user or 0
+
+        yum_update_line_flag = "__doozer=yum-update"
+        yum_update_line = "RUN yum update -y && yum clean all"
+        output = io.StringIO()
+        build_stage = 0
+        for line in df_lines_iter:
+            if yum_update_line_flag in line:
+                # Remove the lines we have injected by skipping 2 lines
+                next(df_lines_iter)
+                continue
+            output.write(f'{line}\n')
+            if not force_yum_updates or not line.startswith('FROM '):
+                continue
+            build_stage += 1
+            # If the curent user inherited from the base image for this stage is not root, `yum update -y` will fail.
+            # We need to change the current user to root.
+            # For non-final stages, it should be safe to inject "USER 0" before `yum update -y`.
+            # However for the final stage, injecting "USER 0" without changing the user back may cause unexpected behavior.
+            # Per https://github.com/openshift/doozer/pull/428#issuecomment-861795424, introduce a new metadata `final_stage_user` for images so we can switch the user back later.
+            if build_stage < build_stage_num or final_stage_user:
+                output.write(f"# {yum_update_line_flag}\nUSER 0\n")
+            else:
+                self.logger.warning("Will not inject `USER 0` before `yum update -y` for the final build stage because `final_stage_user` is missing (or 0) in image meta."
+                                    " If this build fails with `yum update -y` permission denied error, please set correct `final_stage_user` and rebase again.")
+            output.write(f"# {yum_update_line_flag}\n{yum_update_line}\n")
+            if build_stage == build_stage_num and final_stage_user:
+                output.write(f"# {yum_update_line_flag}\nUSER {final_stage_user}\n")
+        output.seek(0)
+        return output
 
     def _generate_config_digest(self):
         # The config digest is used by scan-sources to detect config changes
@@ -2175,7 +2219,7 @@ class ImageDistGitRepo(DistGitRepo):
             return version, prev_release, private_fix
         return None, None, None
 
-    def rebase_dir(self, version, release, terminate_event):
+    def rebase_dir(self, version, release, terminate_event, force_yum_updates=False):
         try:
             # If this image is FROM another group member, we need to wait on that group member to determine if there are embargoes in that group member.
             image_from = Model(self.config.get('from', None))
@@ -2215,7 +2259,7 @@ class ImageDistGitRepo(DistGitRepo):
             if self.private_fix:
                 self.logger.warning("The source of this image contains embargoed fixes.")
 
-            real_version, real_release = self.update_distgit_dir(version, release, prev_release)
+            real_version, real_release = self.update_distgit_dir(version, release, prev_release, force_yum_updates)
             self.rebase_status = True
             return real_version, real_release
         except Exception:

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -335,12 +335,12 @@ FROM some-base-image:some-tag AS builder
 # __doozer=yum-update
 USER 0
 # __doozer=yum-update
-RUN yum update -y && yum clean all
+RUN yum update -y && yum clean all  # set final_stage_user in ART metadata if this fails
 LABEL name=value
 RUN some-command
 FROM another-base-image:some-tag
 # __doozer=yum-update
-RUN yum update -y && yum clean all
+RUN yum update -y && yum clean all  # set final_stage_user in ART metadata if this fails
 COPY --from=builder /some/path/a /some/path/b
         """.strip().splitlines()
         self.assertListEqual(actual, expected)
@@ -372,14 +372,14 @@ FROM some-base-image:some-tag AS builder
 # __doozer=yum-update
 USER 0
 # __doozer=yum-update
-RUN yum update -y && yum clean all
+RUN yum update -y && yum clean all  # set final_stage_user in ART metadata if this fails
 LABEL name=value
 RUN some-command
 FROM another-base-image:some-tag
 # __doozer=yum-update
 USER 0
 # __doozer=yum-update
-RUN yum update -y && yum clean all
+RUN yum update -y && yum clean all  # set final_stage_user in ART metadata if this fails
 # __doozer=yum-update
 USER 1002
 COPY --from=builder /some/path/a /some/path/b
@@ -404,14 +404,14 @@ FROM some-base-image:some-tag AS builder
 # __doozer=yum-update
 USER 0
 # __doozer=yum-update
-RUN yum update -y && yum clean all
+RUN yum update -y && yum clean all  # set final_stage_user in ART metadata if this fails
 LABEL name=value
 RUN some-command
 FROM another-base-image:some-tag
 # __doozer=yum-update
 USER 0
 # __doozer=yum-update
-RUN yum update -y && yum clean all
+RUN yum update -y && yum clean all  # set final_stage_user in ART metadata if this fails
 # __doozer=yum-update
 USER 1001
 COPY --from=builder /some/path/a /some/path/b
@@ -444,14 +444,14 @@ FROM some-base-image:some-tag AS builder
 # __doozer=yum-update
 USER 0
 # __doozer=yum-update
-RUN yum update -y && yum clean all
+RUN yum update -y && yum clean all  # set final_stage_user in ART metadata if this fails
 LABEL name=value
 RUN some-command
 FROM another-base-image:some-tag
 # __doozer=yum-update
 USER 0
 # __doozer=yum-update
-RUN yum update -y && yum clean all
+RUN yum update -y && yum clean all  # set final_stage_user in ART metadata if this fails
 # __doozer=yum-update
 USER 1001
 COPY --from=builder /some/path/a /some/path/b

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -1,11 +1,19 @@
 from __future__ import absolute_import, print_function, unicode_literals
+import io
+import logging
+import pathlib
+
 import re
 import tempfile
 import unittest
 from threading import Lock
+
 import flexmock
+from mock import MagicMock, Mock
+from mock.mock import patch
 
 from doozerlib import distgit, model
+from doozerlib.image import ImageMetadata
 
 from ..support import MockScanner, TestDistgit
 
@@ -300,6 +308,163 @@ class TestImageDistGit(TestDistgit):
         # source specified and doesn't match Dockerfile in dist-git
         flexmock(self.img_dg.runtime).should_receive("detect_remote_source_branch").and_return(("branch", "eggs"))
         self.assertFalse(self.img_dg.matches_source_commit({}))
+
+    def test_inject_yum_update_commands_without_final_stage_user(self):
+        runtime = MagicMock()
+        meta = ImageMetadata(runtime, model.Model({
+            "key": "foo",
+            'data': {
+                'name': 'openshift/foo',
+                'distgit': {'branch': 'fake-branch-rhel-8'},
+                "enabled_repos": ["repo-a", "repo-b"]
+            },
+        }))
+        dg = distgit.ImageDistGitRepo(meta, autoclone=False)
+        dockerfile = """
+FROM some-base-image:some-tag AS builder
+LABEL name=value
+RUN some-command
+FROM another-base-image:some-tag
+COPY --from=builder /some/path/a /some/path/b
+        """.strip()
+        dg.logger = logging.getLogger()
+        dg.dg_path = MagicMock()
+        actual = dg._update_yum_update_commands(True, io.StringIO(dockerfile)).getvalue().strip().splitlines()
+        expected = """
+FROM some-base-image:some-tag AS builder
+# __doozer=yum-update
+USER 0
+# __doozer=yum-update
+RUN yum update -y && yum clean all
+LABEL name=value
+RUN some-command
+FROM another-base-image:some-tag
+# __doozer=yum-update
+RUN yum update -y && yum clean all
+COPY --from=builder /some/path/a /some/path/b
+        """.strip().splitlines()
+        self.assertListEqual(actual, expected)
+
+    def test_inject_yum_update_commands_with_final_stage_user(self):
+        runtime = MagicMock()
+        meta = ImageMetadata(runtime, model.Model({
+            "key": "foo",
+            'data': {
+                'name': 'openshift/foo',
+                'distgit': {'branch': 'fake-branch-rhel-8'},
+                "enabled_repos": ["repo-a", "repo-b"],
+                "final_stage_user": 1002,
+            },
+        }))
+        dg = distgit.ImageDistGitRepo(meta, autoclone=False)
+        dockerfile = """
+FROM some-base-image:some-tag AS builder
+LABEL name=value
+RUN some-command
+FROM another-base-image:some-tag
+COPY --from=builder /some/path/a /some/path/b
+        """.strip()
+        dg.logger = logging.getLogger()
+        dg.dg_path = MagicMock()
+        actual = dg._update_yum_update_commands(True, io.StringIO(dockerfile)).getvalue().strip().splitlines()
+        expected = """
+FROM some-base-image:some-tag AS builder
+# __doozer=yum-update
+USER 0
+# __doozer=yum-update
+RUN yum update -y && yum clean all
+LABEL name=value
+RUN some-command
+FROM another-base-image:some-tag
+# __doozer=yum-update
+USER 0
+# __doozer=yum-update
+RUN yum update -y && yum clean all
+# __doozer=yum-update
+USER 1002
+COPY --from=builder /some/path/a /some/path/b
+        """.strip().splitlines()
+        self.assertListEqual(actual, expected)
+
+    def test_remove_yum_update_commands(self):
+        runtime = MagicMock()
+        meta = ImageMetadata(runtime, model.Model({
+            "key": "foo",
+            'data': {
+                'name': 'openshift/foo',
+                'distgit': {'branch': 'fake-branch-rhel-8'},
+                "enabled_repos": ["repo-a", "repo-b"]
+            },
+        }))
+        dg = distgit.ImageDistGitRepo(meta, autoclone=False)
+        dg.logger = logging.getLogger()
+        dg.dg_path = MagicMock()
+        dockerfile = """
+FROM some-base-image:some-tag AS builder
+# __doozer=yum-update
+USER 0
+# __doozer=yum-update
+RUN yum update -y && yum clean all
+LABEL name=value
+RUN some-command
+FROM another-base-image:some-tag
+# __doozer=yum-update
+USER 0
+# __doozer=yum-update
+RUN yum update -y && yum clean all
+# __doozer=yum-update
+USER 1001
+COPY --from=builder /some/path/a /some/path/b
+        """.strip()
+        actual = dg._update_yum_update_commands(False, io.StringIO(dockerfile)).getvalue().strip().splitlines()
+        expected = """
+FROM some-base-image:some-tag AS builder
+LABEL name=value
+RUN some-command
+FROM another-base-image:some-tag
+COPY --from=builder /some/path/a /some/path/b
+        """.strip().splitlines()
+        self.assertListEqual(actual, expected)
+
+    def test_inject_yum_update_commands_without_repos(self):
+        runtime = MagicMock()
+        meta = ImageMetadata(runtime, model.Model({
+            "key": "foo",
+            'data': {
+                'name': 'openshift/foo',
+                'distgit': {'branch': 'fake-branch-rhel-8'},
+                "enabled_repos": []
+            },
+        }))
+        dg = distgit.ImageDistGitRepo(meta, autoclone=False)
+        dg.logger = logging.getLogger()
+        dg.dg_path = MagicMock()
+        dockerfile = """
+FROM some-base-image:some-tag AS builder
+# __doozer=yum-update
+USER 0
+# __doozer=yum-update
+RUN yum update -y && yum clean all
+LABEL name=value
+RUN some-command
+FROM another-base-image:some-tag
+# __doozer=yum-update
+USER 0
+# __doozer=yum-update
+RUN yum update -y && yum clean all
+# __doozer=yum-update
+USER 1001
+COPY --from=builder /some/path/a /some/path/b
+        """.strip()
+        actual = dg._update_yum_update_commands(True, io.StringIO(dockerfile)).getvalue().strip().splitlines()
+        expected = """
+FROM some-base-image:some-tag AS builder
+LABEL name=value
+RUN some-command
+FROM another-base-image:some-tag
+COPY --from=builder /some/path/a /some/path/b
+        """.strip().splitlines()
+        self.assertListEqual(actual, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`--force-yum-updates` will inject `yum update -y` in each stage. This ensures the component image will be able to override RPMs it is inheriting from its parent image using RPMs in the rebuild plashet.

If the option is not set, previously injected `yum update -y` commands
should be removed (in case we are injecting distgit-only repos).

Note if no repos are enabled for an image, we shouldn't inject `yum
update -y` otherwise the command will fail.