### PR TITLE
Assembly lense

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -1,0 +1,106 @@
+import copy
+
+from doozerlib.model import Model
+
+
+def merger(a, b):
+    """
+    Merges two, potentially deep, objects into a new one and returns the result.
+    Conceptually, 'a' is layered over 'b' and is dominant when
+    necessary. The output is 'c'.
+    1. if 'a' specifies a primitive value, regardless of depth, 'c' will contain that value.
+    2. if a key in 'a' specifies a list and 'b' has the same key/list, a's list will be appended to b's for c's list.
+       Duplicates entries will be removed and primitive (str, int, ..) lists will be returned in sorted order).
+    3. if a key ending with '!' in 'a' specifies a value, c's key-! will be to set that value exactly.
+    4. if a key ending with a '?' in 'a' specifies a value, c's key-? will be set to that value is 'c' does not contain the key.
+    """
+
+    if type(a) in [bool, int, float, str, bytes, type(None)]:
+        return a
+
+    c = copy.deepcopy(b)
+
+    if type(a) is list:
+        if type(c) is not list:
+            return a
+        for entry in a:
+            if entry not in c:  # do not include duplicates
+                c.append(entry)
+
+        if c and type(c[0]) in [str, int, float]:
+            return sorted(c)
+        return c
+
+    if type(a) is dict:
+        if type(c) is not dict:
+            return a
+        for k, v in a.items():
+            if k.endswith('!'):  # full dominant key
+                k = k[:-1]
+                c[k] = v
+            elif k.endswith('?'):  # default value key
+                k = k[:-1]
+                if k not in c:
+                    c[k] = v
+            else:
+                if k in c:
+                    c[k] = merger(a[k], c[k])
+                else:
+                    c[k] = a[k]
+        return c
+
+    raise IOError(f'Unexpected value type: {type(a)}: {a}')
+
+
+def group_for_assembly(releases_config: Model, assembly: str, group_config: Model):
+    """
+    Returns a group config based on the assembly information
+    and the input group config.
+    :param releases_config: A Model for releases.yaml.
+    :param assembly: The name of the assembly
+    :param group_config: The group config to merge into a new group config (original Model will not be altered)
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return group_config
+
+    target_assembly = releases_config.releases[assembly].assembly
+
+    if target_assembly.basis.assembly:  # Does this assembly inherit from another?
+        # Recursive apply ancestor assemblies
+        group_config = group_for_assembly(releases_config, target_assembly.basis.assembly, group_config)
+
+    target_assembly_group = target_assembly.group
+    if not target_assembly_group:
+        return group_config
+
+    return Model(dict_to_model=merger(target_assembly_group.primitive(), group_config.primitive()))
+
+
+def metadata_config_for_assembly(releases_config: Model, assembly: str, meta_type: str, distgit_key: str, meta_config: Model):
+    """
+    Returns a group config based on the assembly information
+    and the input group config.
+    :param releases_config: A Model for releases.yaml.
+    :param assembly: The name of the assembly
+    :param meta_type: 'rpm' or 'image'
+    :param distgit_key: The name of the underlying component
+    :param meta_config: The meta's config object
+    :return: Returns a computed config for the metadata (e.g. value for meta.config).
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return meta_config
+
+    target_assembly = releases_config.releases[assembly].assembly
+
+    if target_assembly.basis.assembly:  # Does this assembly inherit from another?
+        # Recursive apply ancestor assemblies
+        meta_config = metadata_config_for_assembly(releases_config, target_assembly.basis.assembly, meta_type, distgit_key, meta_config)
+
+    config_dict = meta_config.primitive()
+
+    component_list = target_assembly.members[f'{meta_type}s']
+    for component_entry in component_list:
+        if component_entry.distgit_key == '*' or component_entry.distgit_key == distgit_key:
+            config_dict = merger(component_entry.metadata.primitive(), config_dict)
+
+    return Model(dict_to_model=config_dict)

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1462,7 +1462,7 @@ class ImageDistGitRepo(DistGitRepo):
 
                 original_parents = dfp.parent_images
                 count = 0
-                for image in parent_images:
+                for i, image in enumerate(parent_images):
                     # Does this image inherit from an image defined in a different distgit?
                     if image.member is not Missing:
                         base = image.member
@@ -1497,9 +1497,56 @@ class ImageDistGitRepo(DistGitRepo):
                         mapped_images.append(image.image)
 
                     elif image.stream is not Missing:
-                        stream = self.runtime.resolve_stream(image.stream)
-                        # TODO: implement expiring images?
-                        mapped_images.append(stream.image)
+                        if self.runtime.assembly_basis_event:
+                            # When rebasing for an assembly build, we want to use the same parent image
+                            # as our corresponding basis image. To that end, we cannot rely on a stream.yml
+                            # entry -- which usually refers to a floating tag. Instead, we look up the latest
+                            # build of this image, relative to the assembly basis event, in brew. It will have
+                            # information on the exact parent images used at the time. We want to use that
+                            # specific sha.
+                            # If you are here trying to figure out how to change this behavior, you should
+                            # consider using 'from!:' in the assembly metadata for this component. This will
+                            # all you to fully pin the parent images (e.g. {'from!:' ['image': <pullspec>] })
+                            latest_build = self.metadata.get_latest_build(default=None)
+                            assembly_msg = f'{self.metadata.distgit_key} in assembly {self.runtime.assembly} with basis event {self.runtime.assembly_basis_event}'
+                            if not latest_build:
+                                raise IOError(f'Unable to find latest build for {assembly_msg}')
+                            build_model = Model(dict_to_model=latest_build)
+                            if build_model.extra.parent_images is Missing:
+                                raise IOError(f'Unable to find latest build parent images in {latest_build} for {assembly_msg}')
+                            elif len(build_model.extra.parent_images) != len(parent_images):
+                                raise IOError(f'Did not find the expected cardinality ({len(parent_images)} of parent images in {latest_build} for {assembly_msg}')
+
+                            # build_model.extra.parent_images is an array of tags (entries like openshift/golang-builder:rhel_8_golang_1.15).
+                            # We can't use floating tags for this, so we need to look up those tags in parent_image_builds,
+                            # which is also in the extras data.
+                            # example parent_image_builds: {'registry-proxy.engineering.redhat.com/rh-osbs/openshift-base-rhel8:v4.6.0.20210528.150530': {'id': 1616717,
+                            #       'nvr': 'openshift-base-rhel8-container-v4.6.0-202105281403.p0.git.f17f552'},
+                            #      'registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.15': {'id': 1542268,
+                            #       'nvr': 'openshift-golang-builder-container-v1.15.7-202103191923.el8'}}
+                            # Note this map actually gets us to an NVR.
+                            # Example latest_build return: https://gist.github.com/jupierce/57e99b80572336e8652df3c6be7bf664
+                            target_parent_name = build_model.extra.parent_images[i]  # Which parent are looking for? e.g. 'openshift/golang-builder:rhel_8_golang_1.15'
+                            tag_pullspec = self.runtime.resolve_brew_image_url(target_parent_name)  # e.g. registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.15
+                            parent_build_info = build_model.extra.parent_image_builds[tag_pullspec]
+                            if parent_build_info is Missing:
+                                raise IOError(f'Unable to resolve parent {target_parent_name} in {latest_build} for {assembly_msg}; tried {tag_pullspec}')
+                            parent_build_nvr = parent_build_info.nvr
+                            # Hang in there.. this is a long dance. Now that we know the NVR, we can constuct
+                            # a truly unique pullspec.
+                            if '@' in tag_pullspec:
+                                unique_pullspec = tag_pullspec.rsplit('@', 1)[0]  # remove the sha
+                            elif ':' in tag_pullspec:
+                                unique_pullspec = tag_pullspec.rsplit(':', 1)[0]  # remove the tag
+                            else:
+                                raise IOError(f'Unexpected pullspec format: {tag_pullspec}')
+                            unique_pullspec += f':{parent_build_nvr}'  # qualify with the pullspec using nvr as a tag; e.g. registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.15.7-202103191923.el8'
+                            mapped_images.append(unique_pullspec)
+
+                        else:
+                            # Othwerwise, do typical stream resolution.
+                            stream = self.runtime.resolve_stream(image.stream)
+                            mapped_images.append(stream.image)
 
                     else:
                         raise IOError("Image in 'from' for [%s] is missing its definition." % base)
@@ -2177,7 +2224,8 @@ class ImageDistGitRepo(DistGitRepo):
 
     def rebase_dir(self, version, release, terminate_event):
         try:
-            # If this image is FROM another group member, we need to wait on that group member to determine if there are embargoes in that group member.
+            # If this image is FROM another group member, we need to wait on that group
+            # member to determine if there are embargoes in that group member.
             image_from = Model(self.config.get('from', None))
             if image_from.member is not Missing:
                 self.wait_for_rebase(image_from.member, terminate_event)

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -95,29 +95,6 @@ class ImageMetadata(Metadata):
     def for_release(self):
         return self.config.get('for_release', True)
 
-    def get_component_name(self, default=-1):
-        """
-        :param default: Not used. Here to stay consistent with similar rpmcfg.get_component_name
-        :return: Returns the component name of the image. This is the name in the nvr
-        that brew assigns to this image's build. Component name is synonymous with package name.
-        """
-        # By default, the bugzilla component is the name of the distgit,
-        # but this can be overridden in the config yaml.
-        component_name = self.name
-
-        # For apbs, component name seems to have -apb appended.
-        # ex. http://dist-git.host.prod.eng.bos.redhat.com/cgit/apbs/openshift-enterprise-mediawiki/tree/Dockerfile?h=rhaos-3.7-rhel-7
-        if self.namespace == "apbs":
-            component_name = "%s-apb" % component_name
-
-        if self.namespace == "containers":
-            component_name = "%s-container" % component_name
-
-        if self.config.distgit.component is not Missing:
-            component_name = self.config.distgit.component
-
-        return component_name
-
     def get_brew_image_name_short(self):
         # Get image name in the Brew pullspec. e.g. openshift3/ose-ansible --> openshift3-ose-ansible
         return self.image_name.replace("/", "-")

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -6,6 +6,7 @@ import pathlib
 import json
 import traceback
 import datetime
+import time
 import re
 from enum import Enum
 
@@ -19,8 +20,8 @@ from . import exectools
 from . import logutil
 from .brew import BuildStates
 
-
 from .model import Model, Missing
+from doozerlib.assembly import metadata_config_for_assembly
 
 
 class CgitAtomFeedEntry(NamedTuple):
@@ -111,29 +112,17 @@ class Metadata(object):
 
         self.runtime.logger.debug("Loading metadata from {}".format(self.full_config_path))
 
-        self.config = Model(data_obj.data)
+        self.raw_config = Model(data_obj.data)  # Config straight from ocp-build-data
+        assert (self.raw_config.name is not Missing)
+
+        self.config = metadata_config_for_assembly(runtime.get_releases_config(), runtime.assembly, meta_type, self.distgit_key, self.raw_config)
+        self.namespace, self._component_name = Metadata.extract_component_info(meta_type, self.name, self.config)
 
         self.mode = self.config.get('mode', CONFIG_MODE_DEFAULT).lower()
         if self.mode not in CONFIG_MODES:
             raise ValueError('Invalid mode for {}'.format(self.config_filename))
 
         self.enabled = (self.mode == CONFIG_MODE_DEFAULT)
-
-        # Basic config validation. All images currently required to have a name in the metadata.
-        # This is required because from.member uses these data to populate FROM in images.
-        # It would be possible to query this data from the distgit Dockerflie label, but
-        # not implementing this until we actually need it.
-        assert (self.config.name is not Missing)
-
-        # Choose default namespace for config data
-        if meta_type == "image":
-            self.namespace = "containers"
-        else:
-            self.namespace = "rpms"
-
-        # Allow config data to override
-        if self.config.distgit.namespace is not Missing:
-            self.namespace = self.config.distgit.namespace
 
         self.qualified_name = "%s/%s" % (self.namespace, self.name)
         self.qualified_key = "%s/%s" % (self.namespace, self.distgit_key)
@@ -145,7 +134,8 @@ class Metadata(object):
 
         # List of Brew targets.
         # The first target is the primary target, against which tito will direct build.
-        # Others are secondary targets. We will use Brew API to build against secondary targets with the same distgit commit as the primary target.
+        # Others are secondary targets. We will use Brew API to build against secondary
+        # targets with the same distgit commit as the primary target.
         self.targets = self.determine_targets()
 
     def determine_targets(self) -> List[str]:
@@ -371,7 +361,14 @@ class Metadata(object):
                     # a rebuild). If we find the latest build is not tagged appropriately, blow up
                     # and let a human figure out what happened.
                     check_nvr = refined[0]['nvr']
-                    tags = {tag['name'] for tag in koji_api.listTags(build=check_nvr)}
+                    for i in range(2):
+                        tags = {tag['name'] for tag in koji_api.listTags(build=check_nvr)}
+                        if tags:
+                            break
+                        # Observed that a complete build needs some time before it gets tagged. Give it some
+                        # time if not immediately available.
+                        time.sleep(60)
+
                     # RPMS have multiple targets, so our self.branch() isn't perfect.
                     # We should permit rhel-8/rhel-7/etc.
                     tag_prefix = self.branch().rsplit('-', 1)[0] + '-'   # String off the rhel version.
@@ -420,15 +417,56 @@ class Metadata(object):
             return default
         return build['name'], build['version'], build['release']
 
-    def get_component_name(self, default=-1) -> str:
+    @classmethod
+    def extract_component_info(cls, meta_type: str, meta_name: str, config_model: Model) -> Tuple[str, str]:
         """
-        :param default: If the component name cannot be determined,
-        :return: Returns the component name of the image. This is the name in the nvr
+        Determine the component information for either RPM or Image metadata
+        configs.
+        :param meta_type: 'rpm' or 'image'
+        :param meta_name: The name of the component's distgit
+        :param config_model: The configuration for the metadata.
+        :return: Return (namespace, component_name)
+        """
+
+        # Choose default namespace for config data
+        if meta_type == "image":
+            namespace = "containers"
+        else:
+            namespace = "rpms"
+
+        # Allow config data to override namespace
+        if config_model.distgit.namespace is not Missing:
+            namespace = config_model.distgit.namespace
+
+        if namespace == "rpms":
+            # For RPMS, component names must match package name and be in metadata config
+            return namespace, config_model.name
+
+        # For RPMs, by default, the component is the name of the distgit,
+        # but this can be overridden in the config yaml.
+        component_name = meta_name
+
+        # For apbs, component name seems to have -apb appended.
+        # ex. http://dist-git.host.prod.eng.bos.redhat.com/cgit/apbs/openshift-enterprise-mediawiki/tree/Dockerfile?h=rhaos-3.7-rhel-7
+        if namespace == "apbs":
+            component_name = "%s-apb" % component_name
+
+        if namespace == "containers":
+            component_name = "%s-container" % component_name
+
+        if config_model.distgit.component is not Missing:
+            component_name = config_model.distgit.component
+
+        return namespace, component_name
+
+    def get_component_name(self) -> str:
+        """
+        :return: Returns the component name of the metadata. This is the name in the nvr
         that brew assigns to component build. Component name is synonymous with package name.
         For RPMs, spec files declare the package name. For images, it is usually based on
         the distgit repo name + '-container'.
         """
-        raise IOError('Subclass must implement')
+        return self._component_name
 
     def needs_rebuild(self):
         if self.config.targets:
@@ -455,11 +493,7 @@ class Metadata(object):
         # If a build fails, how long will we wait before trying again
         rebuild_interval = self.runtime.group_config.scan_freshness.threshold_hours or 6
 
-        component_name = self.get_component_name(default='')
-        if not component_name:
-            # This can happen for RPMs if they have never been rebased into distgit.
-            return RebuildHint(code=RebuildHintCode.NO_COMPONENT,
-                               reason='Could not determine component name; assuming it has never been built')
+        component_name = self.get_component_name()
 
         latest_build = self.get_latest_build(default=None, el_target=el_target)
 

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -207,20 +207,16 @@ class RPMMetadata(Metadata):
                 if (check_mode == "exact" and nevr[2] != first_nevr[2]) or (check_mode == "x.y" and nevr[2].split(".")[:2] != first_nevr[2].split(".")[:2]):
                     raise DoozerFatalError(f"Buildroot for target {target} has inconsistent golang compiler version {nevr[2]} while target {first_target} has {first_nevr[2]}.")
 
-    def get_package_name_from_spec(self, default=-1):
+    def get_package_name_from_spec(self):
         """
         Returns the brew package name for the distgit repository. Method requires
         a local clone. This differs from get_package_name because it will actually
         parse the .spec file in the distgit clone vs trusting the ocp-build-data.
-        :param default: If specified, this value will be returned if package name could not be found. If
-                        not specified, an exception will be raised instead.
         :return: The package name if detected in the distgit spec file. Otherwise, the specified default.
                 If default is not passed in, an exception will be raised if the package name can't be found.
         """
         specs = glob.glob(f'{self.distgit_repo().distgit_dir}/*.spec')
         if len(specs) != 1:
-            if default != -1:
-                return default
             raise IOError('Unable to find .spec file in RPM distgit: ' + self.qualified_name)
 
         spec_path = specs[0]
@@ -229,32 +225,18 @@ class RPMMetadata(Metadata):
                 if line.lower().startswith('name:'):
                     return line[5:].strip()  # Exclude "Name:" and then remove whitespace
 
-        if default != -1:
-            return default
-
         raise IOError(f'Unable to find Name: field in rpm spec: {spec_path}')
 
-    def get_package_name(self, default=-1):
+    def get_package_name(self) -> str:
         """
         Returns the brew package name for the distgit repository. Package names for RPMs
         do not necessarily match the distgit component name. The package name is controlled
         by the RPM's spec file. The 'name' field in the doozer metadata should match what is
         in the RPM's spec file.
-        :param default: If specified, this value will be returned if package name could not be found.
         :return: The package name - Otherwise, the specified default.
                 If default is not passed in, an exception will be raised if the package name can't be found.
         """
-        package_name = self.config.name  # This should be the package name for the RPM
-        if package_name:
-            return package_name
-
-        if default != -1:
-            return default
-
-        raise IOError(f'Missing package name in RPM doozer metadata: {self.distgit_key}')
-
-    def get_component_name(self, default=-1):
-        return self.get_package_name(default=default)
+        return self.get_component_name()
 
     def candidate_brew_tag(self):
         return self.targets[0]

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -618,7 +618,7 @@ class Runtime(object):
             self.brew_event = self.assembly_basis_event
             self.logger.warning(f'Constraining brew event to assembly basis for {self.assembly}: {self.brew_event}')
 
-        assembly_config_finalize(self.get_releases_config(), self.rpm_metas(), self.ordered_image_metas())
+        assembly_config_finalize(self.get_releases_config(), self.assembly, self.rpm_metas(), self.ordered_image_metas())
 
         if clone_distgits:
             self.clone_distgits()

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1,0 +1,232 @@
+import yaml
+
+from unittest import TestCase
+
+from doozerlib.assembly import merger, group_for_assembly, metadata_config_for_assembly
+from doozerlib.model import Model, Missing
+
+
+class TestAssembly(TestCase):
+
+    def setUp(self) -> None:
+        releases_yml = """
+releases:
+  ART_1:
+    assembly:
+      members:
+        rpms:
+        - distgit_key: openshift-kuryr
+          metadata:  # changes to make the metadata
+            content:
+              source:
+                git:
+                  url: git@github.com:jupierce/kuryr-kubernetes.git
+                  branch:
+                    target: 1_hash
+      group:
+        arches:
+        - x86_64
+        - ppc64le
+        - s390x
+        advisories:
+          image: 11
+          extras: 12
+
+  ART_2:
+    assembly:
+      members:
+        rpms:
+        - distgit_key: openshift-kuryr
+          metadata:  # changes to make the metadata
+            content:
+              source:
+                git:
+                  url: git@github.com:jupierce/kuryr-kubernetes.git
+                  branch:
+                    target: 2_hash
+      group:
+        arches:
+        - x86_64
+        - s390x
+        advisories:
+          image: 21
+
+  ART_3:
+    assembly:
+      basis:
+        assembly: ART_2
+      group:
+        advisories:
+          image: 31
+
+  ART_4:
+    assembly:
+      basis:
+        assembly: ART_3
+      group:
+        advisories!:
+          image: 41
+
+  ART_5:
+    assembly:
+      basis:
+        assembly: ART_4
+      group:
+        arches!:
+        - s390x
+        advisories!:
+          image: 51
+
+  ART_6:
+    assembly:
+      basis:
+        assembly: ART_5
+      members:
+        rpms:
+        - distgit_key: '*'
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: customer_6
+
+
+"""
+        self.releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+
+    def test_merger(self):
+        # First value dominates on primitive
+        self.assertEqual(merger(4, 5), 4)
+        self.assertEqual(merger('4', '5'), '4')
+        self.assertEqual(merger(None, '5'), None)
+        self.assertEqual(merger(True, None), True)
+
+        # Dicts are additive
+        self.assertEqual(
+            merger({'x': 5}, None),
+            {'x': 5}
+        )
+
+        self.assertEqual(
+            merger({'x': 5}, {'y': 6}),
+            {'x': 5, 'y': 6}
+        )
+
+        # Depth does not matter
+        self.assertEqual(
+            merger({'r': {'x': 5}}, {'r': {'y': 6}}),
+            {'r': {'x': 5, 'y': 6}}
+        )
+
+        self.assertEqual(
+            merger({'r': {'x': 5, 'y': 7}}, {'r': {'y': 6}}),
+            {'r': {'x': 5, 'y': 7}}
+        )
+
+        # ? key provides default only
+        self.assertEqual(
+            merger({'r': {'x': 5, 'y?': 7}}, {'r': {'y': 6}}),
+            {'r': {'x': 5, 'y': 6}}
+        )
+
+        # ! key dominates completely
+        self.assertEqual(
+            merger({'r!': {'x': 5}}, {'r': {'y': 6}}),
+            {'r': {'x': 5}}
+        )
+
+        # Lists are combined, dupes eliminated, and results sorted
+        self.assertEqual(
+            merger({'r': [1, 2]}, {'r': [1, 3, 4]}),
+            {'r': [1, 2, 3, 4]}
+        )
+
+        # ! key dominates completely
+        self.assertEqual(
+            merger({'r!': [1, 2]}, {'r': [3, 4]}),
+            {'r': [1, 2]}
+        )
+
+    def test_group_for_assembly(self):
+
+        group_config = Model(dict_to_model={
+            'arches': [
+                'x86_64'
+            ],
+            'advisories': {
+                'image': 1,
+                'extras': 1,
+            }
+        })
+
+        config = group_for_assembly(self.releases_config, 'ART_1', group_config)
+        self.assertEqual(len(config.arches), 3)
+
+        config = group_for_assembly(self.releases_config, 'ART_2', group_config)
+        self.assertEqual(len(config.arches), 2)
+
+        # 3 inherits from 2 an only overrides advisory value
+        config = group_for_assembly(self.releases_config, 'ART_3', group_config)
+        self.assertEqual(len(config.arches), 2)
+        self.assertEqual(config.advisories.image, 31)
+        self.assertEqual(config.advisories.extras, 1)  # Extras never override, so should be from group_config
+
+        # 4 inherits from 3, but sets "advsories!"
+        config = group_for_assembly(self.releases_config, 'ART_4', group_config)
+        self.assertEqual(len(config.arches), 2)
+        self.assertEqual(config.advisories.image, 41)
+        self.assertEqual(config.advisories.extras, Missing)
+
+        # 5 inherits from 4, but sets "advsories!" (overriding 4's !) and "arches!"
+        config = group_for_assembly(self.releases_config, 'ART_5', group_config)
+        self.assertEqual(len(config.arches), 1)
+        self.assertEqual(config.advisories.image, 51)
+
+        config = group_for_assembly(self.releases_config, 'not_defined', group_config)
+        self.assertEqual(len(config.arches), 1)
+
+    def test_metadata_config_for_assembly(self):
+
+        meta_config = Model(dict_to_model={
+            'owners': ['kuryr-team@redhat.com'],
+            'content': {
+                'source': {
+                    'git': {
+                        'url': 'git@github.com:openshift-priv/kuryr-kubernetes.git',
+                        'branch': {
+                            'target': 'release-4.8',
+                        }
+                    },
+                    'specfile': 'openshift-kuryr-kubernetes-rhel8.spec'
+                }
+            },
+            'name': 'openshift-kuryr'
+        })
+
+        config = metadata_config_for_assembly(self.releases_config, 'ART_1', 'rpm', 'openshift-kuryr', meta_config)
+        # Ensure no loss
+        self.assertEqual(config.name, 'openshift-kuryr')
+        self.assertEqual(len(config.owners), 1)
+        self.assertEqual(config.owners[0], 'kuryr-team@redhat.com')
+        # Check that things were overridden
+        self.assertEqual(config.content.source.git.url, 'git@github.com:jupierce/kuryr-kubernetes.git')
+        self.assertEqual(config.content.source.git.branch.target, '1_hash')
+
+        config = metadata_config_for_assembly(self.releases_config, 'ART_5', 'rpm', 'openshift-kuryr', meta_config)
+        # Ensure no loss
+        self.assertEqual(config.name, 'openshift-kuryr')
+        self.assertEqual(len(config.owners), 1)
+        self.assertEqual(config.owners[0], 'kuryr-team@redhat.com')
+        # Check that things were overridden
+        self.assertEqual(config.content.source.git.url, 'git@github.com:jupierce/kuryr-kubernetes.git')
+        self.assertEqual(config.content.source.git.branch.target, '2_hash')
+
+        config = metadata_config_for_assembly(self.releases_config, 'ART_6', 'rpm', 'openshift-kuryr', meta_config)
+        # Ensure no loss
+        self.assertEqual(config.name, 'openshift-kuryr')
+        self.assertEqual(len(config.owners), 1)
+        self.assertEqual(config.owners[0], 'kuryr-team@redhat.com')
+        # Check that things were overridden. 6 changes branches for all rpms
+        self.assertEqual(config.content.source.git.url, 'git@github.com:jupierce/kuryr-kubernetes.git')
+        self.assertEqual(config.content.source.git.branch.target, 'customer_6')

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -94,6 +94,20 @@ releases:
                     target: customer_6
 
 
+  ART_INFINITE:
+    assembly:
+      basis:
+        assembly: ART_INFINITE
+      members:
+        rpms:
+        - distgit_key: '*'
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: customer_6
+
 """
         self.releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
 
@@ -154,6 +168,14 @@ releases:
         self.assertEqual(assembly_basis_event(self.releases_config, 'ART_1'), None)
         self.assertEqual(assembly_basis_event(self.releases_config, 'ART_6'), 5)
 
+        try:
+            assembly_basis_event(self.releases_config, 'ART_INFINITE')
+            self.fail('Expected ValueError on assembly infinite recursion')
+        except ValueError:
+            pass
+        except Exception as e:
+            self.fail(f'Expected ValueError on assembly infinite recursion but got: {type(e)}: {e}')
+
     def test_assembly_group_config(self):
 
         group_config = Model(dict_to_model={
@@ -191,6 +213,14 @@ releases:
 
         config = assembly_group_config(self.releases_config, 'not_defined', group_config)
         self.assertEqual(len(config.arches), 1)
+
+        try:
+            assembly_group_config(self.releases_config, 'ART_INFINITE', group_config)
+            self.fail('Expected ValueError on assembly infinite recursion')
+        except ValueError:
+            pass
+        except Exception as e:
+            self.fail(f'Expected ValueError on assembly infinite recursion but got: {type(e)}: {e}')
 
     def test_asembly_metadata_config(self):
 
@@ -236,3 +266,11 @@ releases:
         # Check that things were overridden. 6 changes branches for all rpms
         self.assertEqual(config.content.source.git.url, 'git@github.com:jupierce/kuryr-kubernetes.git')
         self.assertEqual(config.content.source.git.branch.target, 'customer_6')
+
+        try:
+            assembly_metadata_config(self.releases_config, 'ART_INFINITE', 'rpm', 'openshift-kuryr', meta_config)
+            self.fail('Expected ValueError on assembly infinite recursion')
+        except ValueError:
+            pass
+        except Exception as e:
+            self.fail(f'Expected ValueError on assembly infinite recursion but got: {type(e)}: {e}')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -118,7 +118,7 @@ class TestMetadata(TestCase):
         runtime = self.runtime
         meta = self.meta
         koji_mock = self.koji_mock
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
             return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
@@ -214,7 +214,7 @@ class TestMetadata(TestCase):
     def test_get_latest_build_multi_target(self):
         meta = self.meta
         koji_mock = self.koji_mock
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
             return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
@@ -255,7 +255,7 @@ class TestMetadata(TestCase):
         runtime = self.runtime
         meta = self.meta
         koji_mock = self.koji_mock
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         then = now - datetime.timedelta(hours=5)
 
         def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
@@ -319,7 +319,7 @@ class TestMetadata(TestCase):
         runtime = self.runtime
         meta = self.meta
         koji_mock = self.koji_mock
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         then = now - datetime.timedelta(hours=5)
 
         def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
@@ -392,7 +392,7 @@ class TestMetadata(TestCase):
         runtime = self.runtime
         meta = self.meta
         koji_mock = self.koji_mock
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         then = now - datetime.timedelta(hours=5)
 
         def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):


### PR DESCRIPTION
Implements the logic to load releases.yml and to have doozer interpret group and member metadata through assemblies defined in that file. 
Also eliminates some messy defaulting logic that used to be required before requiring that rpm metadata include package name in the its ocp-build-data file.