### PR TITLE
ART-3050: full assembly awareness for plashet from-tags

### DIFF
--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -439,6 +439,8 @@ class KojiWrapper(koji.ClientSession):
         'listRPMs',
         'getPackage',
         'listTags',
+        'gssapi_login',
+        'sslLogin',
     ])
 
     def __init__(self, koji_session_args, brew_event=None):

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -18,7 +18,7 @@ from doozerlib.cli.images_health import images_health
 from doozerlib.cli.images_streams import images_streams, images_streams_mirror, images_streams_gen_buildconfigs
 from doozerlib.cli.scan_sources import config_scan_source_changes
 from doozerlib.cli.rpms_build import rpms_build
-from doozerlib.cli.plashet import config_plashet
+from doozerlib.cli.config_plashet import config_plashet
 from doozerlib import coverity
 
 from doozerlib.exceptions import DoozerFatalError

--- a/doozerlib/plashet.py
+++ b/doozerlib/plashet.py
@@ -1,0 +1,122 @@
+import logging
+from logging import Logger
+from typing import Dict, Iterable, List, Optional, Union
+
+from kobo.rpmlib import parse_nvr
+from koji import ClientSession
+
+from doozerlib.assembly import assembly_metadata_config
+from doozerlib.brew import get_build_objects
+from doozerlib.model import Model
+from doozerlib.rpmcfg import RPMMetadata
+from doozerlib.util import find_latest_builds, strip_epoch, to_nvre
+
+
+class PlashetBuilder:
+    def __init__(self, koji_api: ClientSession, logger: Optional[Logger] = None) -> None:
+        self._koji_api = koji_api
+        self._logger = logger or logging.getLogger(__name__)
+        self._build_cache: Dict[str, Optional[Dict]] = {}  # Cache build_id/nvre -> build_dict to prevent unnecessary queries.
+
+    def _get_builds(self, ids_or_nvrs: Iterable[Union[int, str]]) -> List[Dict]:
+        """ Get build dicts from Brew. This method uses an internal cache to avoid unnecessary queries.
+        :params ids_or_nvrs: list of build IDs or NVRs
+        :return: a list of Brew build dicts
+        """
+        cache_miss = set(ids_or_nvrs) - self._build_cache.keys()
+        if cache_miss:
+            cache_miss = [strip_epoch(item) if isinstance(item, str) else item for item in cache_miss]
+            builds = get_build_objects(cache_miss, self._koji_api)
+            for id_or_nvre, build in zip(cache_miss, builds):
+                if build:
+                    self._cache_build(build)
+                else:
+                    self._build_cache[id_or_nvre] = None  # None indicates the build ID or NVRE doesn't exist
+        return [self._build_cache[id] for id in ids_or_nvrs]
+
+    def _cache_build(self, build: Dict):
+        """ Save build dict to cache """
+        self._build_cache[build["build_id"]] = build
+        self._build_cache[build["nvr"]] = build
+        if "epoch" in build:
+            self._build_cache[to_nvre(build)] = build
+
+    def from_tag(self, tag: str, inherit: bool, assembly: Optional[str], event: Optional[int] = None) -> Dict[str, Dict]:
+        """ Returns RPM builds from the specified brew tag
+        :param tag: Brew tag name
+        :param inherit: Descend into brew tag inheritance
+        :param assembly: Assembly name to query. If None, this method will return true latest builds.
+        :param event: Brew event ID
+        :return: a dict; keys are component names, values are Brew build dicts
+        """
+        if not assembly:
+            # Assemblies are disabled. We need the true latest tagged builds in the brew tag
+            self._logger.info("Finding latest RPM builds in Brew tag %s...", tag)
+            builds = self._koji_api.listTagged(tag, latest=True, inherit=inherit, event=event, type='rpm')
+        else:
+            # Assemblies are enabled. We need all tagged builds in the brew tag then find the latest ones for the assembly.
+            self._logger.info("Finding RPM builds specific to assembly %s in Brew tag %s...", assembly, tag)
+            tagged_builds = self._koji_api.listTagged(tag, latest=False, inherit=inherit, event=event, type='rpm')
+            builds = find_latest_builds(tagged_builds, assembly)
+        component_builds = {build["name"]: build for build in builds}
+        self._logger.info("Found %s RPM builds.", len(component_builds))
+        for build in component_builds.values():  # Save to cache
+            self._cache_build(build)
+        return component_builds
+
+    def from_pinned_by_is(self, el_version: int, assembly: str, releases_config: Model, rpm_map: Dict[str, RPMMetadata]) -> Dict[str, Dict]:
+        """ Returns RPM builds pinned by "is" in assembly config
+        :param el_version: RHEL version
+        :param assembly: Assembly name to query. If None, this method will return true latest builds.
+        :param releases_config: a Model for releases.yaml
+        :param rpm_map: Map of rpm_distgit_key -> RPMMetadata
+        :return: a dict; keys are component names, values are Brew build dicts
+        """
+        pinned_nvrs: Dict[str, str] = {}  # rpms pinned to the runtime assembly; keys are rpm component names, values are nvrs
+        component_builds: Dict[str, Dict] = {}  # rpms pinned to the runtime assembly; keys are rpm component names, values are brew build dicts
+
+        # Honor pinned rpm nvrs pinned by "is"
+        for distgit_key, rpm_meta in rpm_map.items():
+            meta_config = assembly_metadata_config(releases_config, assembly, 'rpm', distgit_key, rpm_meta.config)
+            nvr = meta_config["is"][f"el{el_version}"]
+            if not nvr:
+                continue
+            nvre_obj = parse_nvr(str(nvr))
+            if nvre_obj["name"] != rpm_meta.rpm_name:
+                raise ValueError(f"RPM {nvr} is pinned to assembly {assembly} for distgit key {distgit_key}, but its package name is not {rpm_meta.rpm_name}.")
+            pinned_nvrs[nvre_obj["name"]] = nvr
+        if pinned_nvrs:
+            pinned_nvr_list = list(pinned_nvrs.values())
+            self._logger.info("Found %s NVRs pinned to the runtime assembly %s. Fetching build infos from Brew...", len(pinned_nvr_list), assembly)
+            pinned_builds = self._get_builds(pinned_nvr_list)
+            missing_nvrs = [nvr for nvr, build in zip(pinned_nvr_list, pinned_builds) if not build]
+            if missing_nvrs:
+                raise IOError(f"The following NVRs pinned by 'is' don't exist: {missing_nvrs}")
+            for pinned_build in pinned_builds:
+                component_builds[pinned_build["name"]] = pinned_build
+        return component_builds
+
+    def from_group_deps(self, el_version: int, group_config: Model, rpm_map: Dict[str, RPMMetadata]) -> Dict[str, Dict]:
+        """ Returns RPM builds defined in group config dependencies
+        :param el_version: RHEL version
+        :param group_config: a Model for group config
+        :param rpm_map: Map of rpm_distgit_key -> RPMMetadata
+        :return: a dict; keys are component names, values are Brew build dicts
+        """
+        component_builds: Dict[str, Dict] = {}  # rpms pinned to the runtime assembly; keys are rpm component names, values are brew build dicts
+        # honor group dependencies
+        dep_nvrs = {parse_nvr(dep[f"el{el_version}"])["name"]: dep[f"el{el_version}"] for dep in group_config.dependencies.rpms if dep[f"el{el_version}"]}  # rpms for this rhel version listed in group dependencies; keys are rpm component names, values are nvrs
+        if dep_nvrs:
+            dep_nvr_list = list(dep_nvrs.values())
+            self._logger.info("Found %s NVRs defined in group dependencies. Fetching build infos from Brew...", len(dep_nvr_list))
+            dep_builds = self._get_builds(dep_nvr_list)
+            missing_nvrs = [nvr for nvr, build in zip(dep_nvr_list, dep_builds) if not build]
+            if missing_nvrs:
+                raise IOError(f"The following group dependency NVRs don't exist: {missing_nvrs}")
+            # Make sure group dependencies have no ART managed rpms.
+            art_rpms_in_group_deps = {dep_build["name"] for dep_build in dep_builds} & {meta.rpm_name for meta in rpm_map.values()}
+            if art_rpms_in_group_deps:
+                raise ValueError(f"Unable to build plashet. Group dependencies cannot have ART managed RPMs: {art_rpms_in_group_deps}")
+            for dep_build in dep_builds:
+                component_builds[dep_build["name"]] = dep_build
+        return component_builds

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -190,10 +190,10 @@ class Runtime(object):
         self.flags_dir = None
 
         # Map of dist-git repo name -> ImageMetadata object. Populated when group is set.
-        self.image_map = {}
+        self.image_map: Dict[str, ImageMetadata] = {}
 
         # Map of dist-git repo name -> RPMMetadata object. Populated when group is set.
-        self.rpm_map = {}
+        self.rpm_map: Dict[str, RPMMetadata] = {}
 
         # Map of source code repo aliases (e.g. "ose") to a tuple representing the source resolution cache.
         # See registry_repo.

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -620,6 +620,13 @@ class Runtime(object):
 
         assembly_config_finalize(self.get_releases_config(), self.assembly, self.rpm_metas(), self.ordered_image_metas())
 
+        if not self.brew_event:
+            with self.shared_koji_client_session() as koji_session:
+                # If brew event is not set as part of the assembly and not specified on the command line,
+                # lock in an event so that there are no race conditions.
+                event_info = koji_session.getLastEvent()
+                self.brew_event = event_info['id']
+
         if clone_distgits:
             self.clone_distgits()
 

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -386,6 +386,29 @@ def isolate_assembly_in_release(release: str) -> str:
     return None
 
 
+def isolate_el_version_in_release(release: str) -> Optional[int]:
+    """
+    Given a release field, determines whether is contains
+    a RHEL version. If it does, it returns the version value.
+    If it is not found, None is returned.
+    """
+    match = re.match(r'.*\.el(\d+)(?:\.+|$)', release)
+    if match:
+        return int(match.group(1))
+
+    return None
+
+
+def isolate_el_version_in_brew_tag(tag: str) -> Optional[int]:
+    """
+    Given a brew tag (target) name, determines whether is contains
+    a RHEL version. If it does, it returns the version value.
+    If it is not found, None is returned.
+    """
+    el_version_match = re.search(r"rhel-(\d+)", tag)
+    return int(el_version_match[1]) if el_version_match else None
+
+
 # https://code.activestate.com/recipes/577504/
 def total_size(o, handlers={}, verbose=False):
     """ Returns the approximate memory footprint an object and all of its contents.
@@ -501,3 +524,22 @@ def find_latest_builds(brew_builds: Iterable[Dict], assembly: Optional[str]) -> 
         chosen_build = find_latest_build(builds, assembly)
         if chosen_build:
             yield chosen_build
+
+
+def to_nvre(build_record: Dict):
+    """
+    From a build record object (such as an entry returned by listTagged),
+    returns the full nvre in the form n-v-r:E.
+    """
+    nvr = build_record['nvr']
+    if 'epoch' in build_record and build_record["epoch"] and build_record["epoch"] != 'None':
+        return f'{nvr}:{build_record["epoch"]}'
+    return nvr
+
+
+def strip_epoch(nvr: str):
+    """
+    If an NVR string is N-V-R:E, returns only the NVR portion. Otherwise
+    returns NVR exactly as-is.
+    """
+    return nvr.split(':')[0]

--- a/tests/test_plashet.py
+++ b/tests/test_plashet.py
@@ -1,0 +1,128 @@
+from unittest import TestCase
+
+from mock import MagicMock, Mock
+from mock.mock import patch
+
+from doozerlib.model import Model
+from doozerlib.plashet import PlashetBuilder
+
+
+class TestPlashetBuilder(TestCase):
+    @patch("doozerlib.plashet.get_build_objects")
+    def test_get_builds(self, get_build_objects: Mock):
+        builder = PlashetBuilder(MagicMock())
+        builder._build_cache = {
+            1: {"id": 1, "build_id": 1, "nvr": "fake1-1.2.3-1.el8"},
+            "bar-1.2.3-1.el8": {"id": 3, "build_id": 3, "nvr": "bar-1.2.3-1.el8"},
+        }
+        get_build_objects.return_value = [
+            {"id": 2, "build_id": 2, "nvr": "fake2-1.2.3-1.el8"},
+            {"id": 4, "build_id": 4, "nvr": "foo-1.2.3-1.el8", "epoch": "2"},
+        ]
+        actual = builder._get_builds([1, 2, "foo-1.2.3-1.el8:2", "bar-1.2.3-1.el8"])
+        get_build_objects.assert_called_once()
+        self.assertListEqual([b["id"] for b in actual], [1, 2, 4, 3])
+
+    def test_cache_build(self):
+        builder = PlashetBuilder(MagicMock())
+        builder._build_cache = {
+            1: {"id": 1, "build_id": 1, "nvr": "fake1-1.2.3-1.el8"},
+            "bar-1.2.3-1.el8": {"id": 3, "build_id": 3, "nvr": "bar-1.2.3-1.el8"},
+        }
+        builder._cache_build({"id": 4, "build_id": 4, "nvr": "foo-1.2.3-1.el8", "epoch": "2"})
+        self.assertEqual(set(builder._build_cache.keys()), {1, "bar-1.2.3-1.el8", 4, "foo-1.2.3-1.el8", "foo-1.2.3-1.el8:2"})
+
+    def test_from_tag_with_assembly_disabled(self):
+        koji_api = MagicMock()
+        koji_api.listTagged.return_value = [
+            {"id": 1, "build_id": 1, "nvr": "fake2-1.2.4-1.assembly.stream.el8", "name": "fake2", "release": "1.assembly.stream.el8", "tag_name": "fake-rhel-8-candidate"},
+            {"id": 4, "build_id": 4, "nvr": "foo-1.2.3-1.assembly.stream.el8", "epoch": "2", "name": "foo", "release": "1.assembly.stream.el8", "tag_name": "fake-rhel-8-candidate"},
+        ]
+        builder = PlashetBuilder(koji_api)
+        actual = builder.from_tag("fake-rhel-8-candidate", True, None, None)
+        expected = {1, 4}
+        self.assertEqual({b["id"] for b in actual.values()}, expected)
+
+    def test_from_tag_with_assembly_enabled(self):
+        koji_api = MagicMock()
+        koji_api.listTagged.return_value = [
+            {"id": 1, "build_id": 1, "nvr": "fake2-1.2.4-1.assembly.stream.el8", "name": "fake2", "release": "1.assembly.stream.el8", "tag_name": "fake-rhel-8-candidate"},
+            {"id": 2, "build_id": 2, "nvr": "fake2-1.2.3-1.assembly.art1.el8", "name": "fake2", "release": "1.assembly.art1.el8", "tag_name": "fake-rhel-8-candidate"},
+            {"id": 4, "build_id": 4, "nvr": "foo-1.2.3-1.assembly.stream.el8", "epoch": "2", "name": "foo", "release": "1.assembly.stream.el8", "tag_name": "fake-rhel-8-candidate"},
+        ]
+        builder = PlashetBuilder(koji_api)
+        actual = builder.from_tag("fake-rhel-8-candidate", True, "art1", None)
+        expected = {2, 4}
+        self.assertEqual({b["id"] for b in actual.values()}, expected)
+
+    def test_from_group_deps(self):
+        builder = PlashetBuilder(MagicMock())
+        group_config = Model({
+            "dependencies": {
+                "rpms": [
+                    {"el8": "fake1-1.2.3-1.el8"},
+                    {"el8": "fake2-1.2.3-1.el8"},
+                    {"el7": "fake2-1.2.3-1.el7"},
+                    {"el7": "fake2-1.2.3-1.el7"},
+                ]
+            }
+        })
+        builder._get_builds = MagicMock(return_value=[
+            {"id": 1, "build_id": 1, "name": "fake1", "nvr": "fake1-1.2.3-1.el8"},
+            {"id": 2, "build_id": 2, "name": "fake2", "nvr": "fake2-1.2.3-1.el8"},
+        ])
+        actual = builder.from_group_deps(8, group_config, {})
+        self.assertEqual([b["nvr"] for b in actual.values()], ["fake1-1.2.3-1.el8", "fake2-1.2.3-1.el8"])
+        builder._get_builds.assert_called_once()
+
+    def test_from_group_deps_with_art_managed_rpms(self):
+        builder = PlashetBuilder(MagicMock())
+        group_config = Model({
+            "dependencies": {
+                "rpms": [
+                    {"el8": "fake1-1.2.3-1.el8"},
+                    {"el8": "fake2-1.2.3-1.el8"},
+                    {"el8": "fake3-1.2.3-1.el8"},
+                    {"el7": "fake2-1.2.3-1.el7"},
+                    {"el7": "fake2-1.2.3-1.el7"},
+                ]
+            }
+        })
+        builder._get_builds = MagicMock(return_value=[
+            {"id": 1, "build_id": 1, "name": "fake1", "nvr": "fake1-1.2.3-1.el8"},
+            {"id": 2, "build_id": 2, "name": "fake2", "nvr": "fake2-1.2.3-1.el8"},
+            {"id": 3, "build_id": 3, "name": "fake3", "nvr": "fake3-1.2.3-1.el8"},
+        ])
+        with self.assertRaises(ValueError) as ex:
+            builder.from_group_deps(8, group_config, {"fake3": MagicMock(rpm_name="fake3")})
+        self.assertIn("Group dependencies cannot have ART managed RPMs", str(ex.exception))
+        builder._get_builds.assert_called_once()
+
+    @patch("doozerlib.plashet.assembly_metadata_config")
+    def test_from_pinned_by_is(self, assembly_metadata_config: Mock):
+        builder = PlashetBuilder(MagicMock())
+        releases_config = Model()
+        rpm_metas = {
+            "fake1": MagicMock(rpm_name="fake1"),
+            "fake2": MagicMock(rpm_name="fake2"),
+        }
+        meta_configs = {
+            "fake1": Model({
+                "is": {
+                    "el8": "fake1-1.2.3-1.el8"
+                }
+            }),
+            "fake2": Model({
+                "is": {
+                    "el8": "fake2-1.2.3-1.el8"
+                }
+            }),
+        }
+        builder._get_builds = MagicMock(return_value=[
+            {"id": 1, "build_id": 1, "name": "fake1", "nvr": "fake1-1.2.3-1.el8"},
+            {"id": 2, "build_id": 2, "name": "fake2", "nvr": "fake2-1.2.3-1.el8"},
+        ])
+        assembly_metadata_config.side_effect = lambda *args: meta_configs[args[3]]
+        actual = builder.from_pinned_by_is(8, "art1", releases_config, rpm_metas)
+        self.assertEqual([b["nvr"] for b in actual.values()], ["fake1-1.2.3-1.el8", "fake2-1.2.3-1.el8"])
+        builder._get_builds.assert_called_once()


### PR DESCRIPTION
When an artist is trying to refine an assembly with a basis event, existing assembly-specific builds for that assembly are not canonically part of the assembly until the artist pins then in the assembly metadata with "is". It follows that plashet should honor "is" when set for RPMs in the assembly metadata when constructing a repo.
    
Another change in behavior is that plashet should honor group "dependencies" defined in the assembly configuration. 431 takes care of determining what a group configuration should look like in light of a given assembly name on the command line. Unlike normal group.yml, assembly group definitions in releases.yml can add "dependencies" to the loaded models.

NOTE:
1. Plashet are able to create both rhel8 and rhel7 repos, but rpm nvrs defined in assembly config don't specify which repo they should go. I think we can assume assembly-specific nvrs either pinned by "is" or given by group dependencies are always for RHEL8. Let me know if this is wrong. Update: Now we have per rhel version dependencies in releases.yml.
2. It seems to me that we shouldn't allow "is" in a wildcard rpm member entry. Let me know if this is wrong. Update: This is now handled by `assembly_metadata_config()`
3. If the nvr pinned by "is" is embargoed but we are building an non-embargoed plashet, an error will be raised.
4. Remove `--brew-event` command line argument from `from-tags` subverb since we need to honor the event id defined in the basis.
5. This PR requires https://github.com/openshift/doozer/pull/431.
6. I used the following `releases.yml` for testing:

```yaml
releases:
  art1:
    assembly:
      basis: 
        brew_event: 39473862
      group:
        dependencies:
          rpms:
          - el8: cri-o-1.21.0-88.rhaos4.8.gitfd485de.el8
      members:
        rpms:
        - distgit_key: openshift-clients
          metadata:
            is:
              el8: openshift-clients-4.9.0-202106031118.p0.git.714295d.assembly.stream.el8
        - distgit_key: openshift-kuryr
          metadata:
            is:
              el8: openshift-kuryr-4.9.0-202105211327.p0.git.be00acd.el8
```