### PR TITLE
Open PRs for base images

### DIFF
--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -576,8 +576,8 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
             logger.info('The image has alignment PRs disabled; ignoring')
             continue
 
-        if image_meta.config.for_release is False:
-            logger.info('Skipping PR check since image is for_release: false')
+        if image_meta.config.content.source.ci_alignment.upstream_image:
+            logger.info(f'Skipping PR check since image has alternative upstream representation: {image_meta.config.content.source.ci_alignment.upstream_image}')
             continue
 
         from_config = image_meta.config['from']


### PR DESCRIPTION
We used to avoid opening prs for anything not for a release, but this excluded base-only images that are managed upstream. Critically, openshift-enterprise-base.