### PR TITLE
Correct click setup

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1648,7 +1648,7 @@ def config_mode(runtime, mode, push, message):
 
 
 @cli.command("config:print", short_help="View config for given images / rpms")
-@click.option("-n", "--name-only", default=False, is_flag=True, multiple=True,
+@click.option("-n", "--name-only", default=False, is_flag=True,
               help="Just print name of matched configs. Overrides --key")
 @click.option("--key", help="Specific key in config to print", default=None)
 @click.option("--yaml", "as_yaml", default=False, is_flag=True, help='Print results in a yaml block')


### PR DESCRIPTION
Since click 8.0, it is a fatal error to have multiple=True and a Default
that is not a list. This allows for a new click.