### PR TITLE
[ART-3075] Add plashet subverb "for-assembly"

### DIFF
--- a/doozerlib/plashet.py
+++ b/doozerlib/plashet.py
@@ -1,4 +1,5 @@
 import logging
+from collections import OrderedDict
 from logging import Logger
 from typing import Dict, Iterable, List, Optional, Union
 
@@ -6,7 +7,8 @@ from kobo.rpmlib import parse_nvr
 from koji import ClientSession
 
 from doozerlib.assembly import assembly_metadata_config
-from doozerlib.brew import get_build_objects
+from doozerlib.brew import get_build_objects, list_archives_by_builds
+from doozerlib.image import ImageMetadata
 from doozerlib.model import Model
 from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.util import find_latest_builds, strip_epoch, to_nvre
@@ -117,6 +119,62 @@ class PlashetBuilder:
             art_rpms_in_group_deps = {dep_build["name"] for dep_build in dep_builds} & {meta.rpm_name for meta in rpm_map.values()}
             if art_rpms_in_group_deps:
                 raise ValueError(f"Unable to build plashet. Group dependencies cannot have ART managed RPMs: {art_rpms_in_group_deps}")
+            for dep_build in dep_builds:
+                component_builds[dep_build["name"]] = dep_build
+        return component_builds
+
+    def from_images(self, image_map: Dict[str, ImageMetadata]) -> Dict[str, List[Dict]]:
+        """ Returns RPM builds used in images
+        :param image_map: Map of image_distgit_key -> ImageMetadata
+        :return: a dict; keys are image distgit keys, values are lists of RPM build dicts
+        """
+        image_builds: Dict[str, Dict] = OrderedDict()  # keys are image distgit keys, values are brew build dicts
+        image_rpm_builds: Dict[str, List[Dict]] = OrderedDict()  # rpms in images; keys are image distgit keys, values are rpm build dicts used in that image
+
+        self._logger.info("Finding image builds...")
+        for distgit_key, image_meta in image_map.items():
+            build = image_meta.get_latest_build(default=None, honor_is=False)
+            if build:  # Ignore None in case we build for an basis event that is prior to the first build of an image
+                image_builds[distgit_key] = build
+
+        self._logger.info("Finding RPMs used in %s image builds...", len(image_builds))
+        archive_lists = list_archives_by_builds([b["build_id"] for b in image_builds.values()], "image", self._koji_api)
+
+        rpm_build_ids = {rpm["build_id"] for archives in archive_lists for ar in archives for rpm in ar["rpms"]}
+        self._logger.info("Querying Brew build infos for %s RPM builds...", len(rpm_build_ids))
+        rpm_builds = self._get_builds(rpm_build_ids)
+        build_map = {b["build_id"]: b for b in rpm_builds}  # Maps rpm_build_id to build object from brew
+
+        for distgit_key, archives in zip(image_builds.keys(), archive_lists):
+            rpm_build_ids = {rpm["build_id"] for ar in archives for rpm in ar["rpms"]}
+            image_rpm_builds[distgit_key] = [build_map[build_id] for build_id in rpm_build_ids]
+        return image_rpm_builds
+
+    def from_image_member_deps(self, el_version: int, assembly: str, releases_config: Model, image_meta: ImageMetadata, rpm_map: Dict[str, RPMMetadata]) -> Dict[str, Dict]:
+        """ Returns RPM builds defined in image member dependencies
+        :param el_version: RHEL version
+        :param assembly: Assembly name to query. If None, this method will return true latest builds.
+        :param releases_config: a Model for releases.yaml
+        :param image_meta: An instance of ImageMetadata
+        :param rpm_map: Map of rpm_distgit_key -> RPMMetadata
+        :return: a dict; keys are component names, values are Brew build dicts
+        """
+        component_builds: Dict[str, Dict] = {}  # rpms pinned to the runtime assembly; keys are rpm component names, values are brew build dicts
+
+        meta_config = assembly_metadata_config(releases_config, assembly, 'image', image_meta.distgit_key, image_meta.config)
+        # honor image member dependencies
+        dep_nvrs = {parse_nvr(dep[f"el{el_version}"])["name"]: dep[f"el{el_version}"] for dep in meta_config.dependencies.rpms if dep[f"el{el_version}"]}  # rpms for this rhel version listed in member dependencies; keys are rpm component names, values are nvrs
+        if dep_nvrs:
+            dep_nvr_list = list(dep_nvrs.values())
+            self._logger.info("Found %s NVRs defined in image member '%s' dependencies. Fetching build infos from Brew...", len(dep_nvr_list), image_meta.distgit_key)
+            dep_builds = self._get_builds(dep_nvr_list)
+            missing_nvrs = [nvr for nvr, build in zip(dep_nvr_list, dep_builds) if not build]
+            if missing_nvrs:
+                raise IOError(f"The following group dependency NVRs don't exist: {missing_nvrs}")
+            # Make sure image member dependencies have no ART managed rpms.
+            art_rpms_in_deps = {dep_build["name"] for dep_build in dep_builds} & {meta.rpm_name for meta in rpm_map.values()}
+            if art_rpms_in_deps:
+                raise ValueError(f"Unable to build plashet. Image member dependencies cannot have ART managed RPMs: {art_rpms_in_deps}")
             for dep_build in dep_builds:
                 component_builds[dep_build["name"]] = dep_build
         return component_builds


### PR DESCRIPTION
This adds plashet subverb "for-assembly" to creates a plashet containing arch specific yum repository subdirectories based on a complete set of RPMs required for image builds.
When doozer runs brew builds for an assembly image, it should only need to pass in a single repository created by for-assembly in order for the image to build successfully.
    
Implemented use cases:
1. The subverb is run against a runtime.assembly that does have a basis event.
2. The subverb is run against an assembly with a basis event and an "--image" argument.
    
Running against an assembly with a basis event and an "--rhcos" argument will be covered in a separate PR.

NOTE:
1. Includes https://github.com/openshift/doozer/pull/439.
2. Test `releases.yml`:
```yaml
releases:
  art1:
    assembly:
      basis: 
        brew_event: 39473862
      group:
        dependencies:
          rpms:
          - el8: cri-o-1.21.0-88.rhaos4.8.gitfd485de.el8
      members:
        rpms:
        - distgit_key: openshift-clients
          metadata:
            is:
              el8: openshift-clients-4.9.0-202106031118.p0.git.714295d.assembly.stream.el8
        - distgit_key: openshift-kuryr
          metadata:
            is:
              el8: openshift-kuryr-4.9.0-202105211327.p0.git.be00acd.el8
        images:
        - distgit_key: openshift-enterprise-cli
          metadata:
            dependencies:
              rpms:
              - el8: bash-4.4.20-1.el8_4
```
