### PR TITLE
ART-3050: add plashet from-tags --rhcos

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -1,7 +1,7 @@
 import typing
 import copy
 
-from doozerlib.model import Model
+from doozerlib.model import Missing, Model
 
 
 def merger(a, b):
@@ -119,6 +119,25 @@ def assembly_metadata_config(releases_config: Model, assembly: str, meta_type: s
             config_dict = merger(component_entry.metadata.primitive(), config_dict)
 
     return Model(dict_to_model=config_dict)
+
+
+def assembly_rhcos_config(releases_config: Model, assembly: str) -> Model:
+    """
+    :param releases_config: The content of releases.yml in Model form.
+    :param assembly: The name of the assembly to assess
+    Returns the a computed rhcos config model for a given assembly.
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return Missing
+
+    _check_recursion(releases_config, assembly)
+    target_assembly = releases_config.releases[assembly].assembly
+    rhcos_config_dict = target_assembly.get("rhcos", {})
+    if target_assembly.basis.assembly:  # Does this assembly inherit from another?
+        # Recursive apply ancestor assemblies
+        basis_rhcos_config = assembly_rhcos_config(releases_config, target_assembly.basis.assembly)
+        rhcos_config_dict = merger(rhcos_config_dict, basis_rhcos_config.primitive())
+    return Model(dict_to_model=rhcos_config_dict)
 
 
 def assembly_basis_event(releases_config: Model, assembly: str) -> typing.Optional[int]:

--- a/doozerlib/plashet.py
+++ b/doozerlib/plashet.py
@@ -184,7 +184,7 @@ class PlashetBuilder:
         :param el_version: RHEL version
         :param assembly: Assembly name to query. If None, this method will return true latest builds.
         :param releases_config: a Model for releases.yaml
-         :param rpm_map: Map of rpm_distgit_key -> RPMMetadata
+        :param rpm_map: Map of rpm_distgit_key -> RPMMetadata
         :return: a dict; keys are component names, values are Brew build dicts
         """
         component_builds: Dict[str, Dict] = {}  # keys are rpm component names, values are brew build dicts

--- a/doozerlib/plashet.py
+++ b/doozerlib/plashet.py
@@ -179,7 +179,7 @@ class PlashetBuilder:
                 component_builds[dep_build["name"]] = dep_build
         return component_builds
 
-    def from_rhcos_deps(self, el_version: int, assembly: str, releases_config: Model, rpm_map: Dict[str, RPMMetadata]):
+    def from_rhcos_deps(self, el_version: int, assembly: str, releases_config: Model, rpm_map: Dict[str, Dict]):
         """ Returns RPM builds defined in RHCOS config dependencies
         :param el_version: RHEL version
         :param assembly: Assembly name to query. If None, this method will return true latest builds.

--- a/doozerlib/plashet.py
+++ b/doozerlib/plashet.py
@@ -6,7 +6,7 @@ from typing import Dict, Iterable, List, Optional, Union
 from kobo.rpmlib import parse_nvr
 from koji import ClientSession
 
-from doozerlib.assembly import assembly_metadata_config
+from doozerlib.assembly import assembly_metadata_config, assembly_rhcos_config
 from doozerlib.brew import get_build_objects, list_archives_by_builds
 from doozerlib.image import ImageMetadata
 from doozerlib.model import Model
@@ -170,11 +170,39 @@ class PlashetBuilder:
             dep_builds = self._get_builds(dep_nvr_list)
             missing_nvrs = [nvr for nvr, build in zip(dep_nvr_list, dep_builds) if not build]
             if missing_nvrs:
-                raise IOError(f"The following group dependency NVRs don't exist: {missing_nvrs}")
+                raise IOError(f"The following image member dependency NVRs don't exist: {missing_nvrs}")
             # Make sure image member dependencies have no ART managed rpms.
             art_rpms_in_deps = {dep_build["name"] for dep_build in dep_builds} & {meta.rpm_name for meta in rpm_map.values()}
             if art_rpms_in_deps:
                 raise ValueError(f"Unable to build plashet. Image member dependencies cannot have ART managed RPMs: {art_rpms_in_deps}")
+            for dep_build in dep_builds:
+                component_builds[dep_build["name"]] = dep_build
+        return component_builds
+
+    def from_rhcos_deps(self, el_version: int, assembly: str, releases_config: Model, rpm_map: Dict[str, RPMMetadata]):
+        """ Returns RPM builds defined in RHCOS config dependencies
+        :param el_version: RHEL version
+        :param assembly: Assembly name to query. If None, this method will return true latest builds.
+        :param releases_config: a Model for releases.yaml
+         :param rpm_map: Map of rpm_distgit_key -> RPMMetadata
+        :return: a dict; keys are component names, values are Brew build dicts
+        """
+        component_builds: Dict[str, Dict] = {}  # keys are rpm component names, values are brew build dicts
+        rhcos_config = assembly_rhcos_config(releases_config, assembly)
+        # honor RHCOS dependencies
+        # rpms for this rhel version listed in RHCOS dependencies; keys are rpm component names, values are nvrs
+        dep_nvrs = {parse_nvr(dep[f"el{el_version}"])["name"]: dep[f"el{el_version}"] for dep in rhcos_config.dependencies.rpms if dep[f"el{el_version}"]}
+        if dep_nvrs:
+            dep_nvr_list = list(dep_nvrs.values())
+            self._logger.info("Found %s NVRs defined in RHCOS dependencies. Fetching build infos from Brew...", len(dep_nvr_list))
+            dep_builds = self._get_builds(dep_nvr_list)
+            missing_nvrs = [nvr for nvr, build in zip(dep_nvr_list, dep_builds) if not build]
+            if missing_nvrs:
+                raise IOError(f"The following RHCOS dependency NVRs don't exist: {missing_nvrs}")
+            # Make sure RHCOS dependencies have no ART managed rpms.
+            art_rpms_in_rhcos_deps = {dep_build["name"] for dep_build in dep_builds} & {meta.rpm_name for meta in rpm_map.values()}
+            if art_rpms_in_rhcos_deps:
+                raise ValueError(f"Unable to build plashet. Group dependencies cannot have ART managed RPMs: {art_rpms_in_rhcos_deps}")
             for dep_build in dep_builds:
                 component_builds[dep_build["name"]] = dep_build
         return component_builds

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -2,7 +2,7 @@ import yaml
 
 from unittest import TestCase
 
-from doozerlib.assembly import merger, assembly_group_config, assembly_metadata_config, assembly_basis_event
+from doozerlib.assembly import assembly_rhcos_config, merger, assembly_group_config, assembly_metadata_config, assembly_basis_event
 from doozerlib.model import Model, Missing
 
 
@@ -117,6 +117,16 @@ releases:
           rpms:
             - el7: some-nvr-3
               non_gc_tag: some-tag-3
+      rhcos:
+        machine-os-content:
+          images:
+            x86_64: registry.example.com/rhcos-x86_64:test
+        dependencies:
+          rpms:
+            - el7: some-nvr-4
+              non_gc_tag: some-tag-4
+            - el8: some-nvr-5
+              non_gc_tag: some-tag-4
 
   ART_8:
     assembly:
@@ -136,6 +146,13 @@ releases:
           rpms:
             - el7: some-nvr-4
               non_gc_tag: some-tag-4
+      rhcos:
+        machine-os-content:
+          images: {}
+        dependencies:
+          rpms:
+            - el8: some-nvr-6
+              non_gc_tag: some-tag-6
 
   ART_INFINITE:
     assembly:
@@ -333,3 +350,7 @@ releases:
             pass
         except Exception as e:
             self.fail(f'Expected ValueError on assembly infinite recursion but got: {type(e)}: {e}')
+
+    def test_assembly_rhcos_config(self):
+        rhcos_config = assembly_rhcos_config(self.releases_config, "ART_8")
+        self.assertEqual(len(rhcos_config.dependencies.rpms), 3)

--- a/tests/test_plashet.py
+++ b/tests/test_plashet.py
@@ -181,3 +181,28 @@ class TestPlashetBuilder(TestCase):
         self.assertEqual([b["nvr"] for b in actual.values()], ["fake1-1.2.3-1.el8", "fake2-1.2.3-1.el8", "fake3-1.2.3-1.el8"])
         builder._get_builds.assert_called_once_with(["fake1-1.2.3-1.el8", "fake2-1.2.3-1.el8", "fake3-1.2.3-1.el8"])
         assembly_metadata_config.assert_called_once()
+
+    @patch("doozerlib.plashet.assembly_rhcos_config")
+    def test_from_rhcos_deps(self, assembly_rhcos_config: Mock):
+        builder = PlashetBuilder(MagicMock())
+
+        builder._get_builds = MagicMock(return_value=[
+            {"id": 1, "build_id": 1, "name": "fake1", "nvr": "fake1-1.2.3-1.el8"},
+            {"id": 2, "build_id": 2, "name": "fake2", "nvr": "fake2-1.2.3-1.el8"},
+            {"id": 3, "build_id": 3, "name": "fake3", "nvr": "fake3-1.2.3-1.el8"},
+        ])
+        assembly_rhcos_config.return_value = Model({
+            "dependencies": {
+                "rpms": [
+                    {"el8": "fake1-1.2.3-1.el8"},
+                    {"el8": "fake2-1.2.3-1.el8"},
+                    {"el8": "fake3-1.2.3-1.el8"},
+                    {"el7": "fake2-1.2.3-1.el7"},
+                    {"el7": "fake2-1.2.3-1.el7"},
+                ]
+            }
+        })
+        actual = builder.from_rhcos_deps(8, "art1", Model(), {})
+        self.assertEqual([b["nvr"] for b in actual.values()], ["fake1-1.2.3-1.el8", "fake2-1.2.3-1.el8", "fake3-1.2.3-1.el8"])
+        builder._get_builds.assert_called_once_with(["fake1-1.2.3-1.el8", "fake2-1.2.3-1.el8", "fake3-1.2.3-1.el8"])
+        assembly_rhcos_config.assert_called_once()


### PR DESCRIPTION
This PR adds `--rhcos` option to Plashet from-tags subverb.
When "--rhcos" argument is specified, the final list of package NVRs should include any dependencies specified in the assembly's assembly.rhcos.dependencies field.