### PR TITLE
Allow --repo to take precedence over --repo-type defaults

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -868,7 +868,7 @@ def print_build_metrics(runtime):
               default='',
               help="Repo type (e.g. signed, unsigned).")
 @click.option("--repo", default=[], metavar="REPO_URL",
-              multiple=True, help="Custom repo URL to supply to brew build.")
+              multiple=True, help="Custom repo URL to supply to brew build. If specified, defaults from --repo-type will be ignored.")
 @click.option('--push-to-defaults', default=False, is_flag=True,
               help='Push to default registries when build completes.')
 @click.option("--push-to", default=[], metavar="REGISTRY", multiple=True,

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1115,13 +1115,12 @@ class ImageDistGitRepo(DistGitRepo):
             cmd_list.append('--signing-intent')
             cmd_list.append(signing_intent)
         else:
-            if repo_type:
+            if repo_type and not repo_list:  # If --repo was not specified on the command line
                 repo_file = f".oit/{repo_type}.repo"
                 existence, repo_url = self.cgit_file_available(repo_file)
                 if not existence:
                     raise FileNotFoundError(f"Repo file {repo_file} is not available on cgit; cgit cache may not be reflecting distgit in a timely manner.")
-                repo_list = list(repo_list)  # In case we get a tuple
-                repo_list.append(repo_url)
+                repo_list = [repo_url]
 
             if repo_list:
                 # rhpkg supports --repo-url [URL [URL ...]]


### PR DESCRIPTION
In order to image rebuilds for assemblies to function as designed, we need to be able to point brew to one more more explicit repos instead of depending on the defaults implied by `--repo-type`. Previously, `--repo` would be one element added to the defaults, but it will now be treated as the complete list of repos to send to brew.

Related to: https://issues.redhat.com/browse/ART-3091