### PR TITLE
[ART-3093] Allow assemblies to specify machine-os-content in gen-payload

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -1,7 +1,14 @@
 import typing
 import copy
 
+from enum import Enum
+
 from doozerlib.model import Missing, Model
+
+
+class AssemblyTypes(Enum):
+    STANDARD = 0  # All constraints / checks enforced (e.g. consistent RPMs / siblings)
+    CUSTOM = 1  # No constraints enforced
 
 
 def merger(a, b):
@@ -62,6 +69,22 @@ def _check_recursion(releases_config: Model, assembly: str):
         found.append(next_assembly)
         target_assembly = releases_config.releases[next_assembly].assembly
         next_assembly = target_assembly.basis.assembly
+
+
+def assembly_type(releases_config: Model, assembly: str) -> AssemblyTypes:
+
+    if not assembly or not isinstance(releases_config, Model):
+        return AssemblyTypes.STANDARD
+
+    target_assembly = releases_config.releases[assembly].assembly
+    str_type = target_assembly['type']
+    if not str_type or str_type == "standard":
+        # Assemblies are standard by default
+        return AssemblyTypes.STANDARD
+    elif str_type == "custom":
+        return AssemblyTypes.CUSTOM
+    else:
+        raise ValueError(f'Unknown assembly type: {str_type}')
 
 
 def assembly_group_config(releases_config: Model, assembly: str, group_config: Model) -> Model:

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1577,10 +1577,11 @@ def config_read_group(runtime, key, as_len, as_yaml, permit_missing_group, defau
             exit(0)
         raise
 
+    group_primitive = runtime.get_group_config().primitive()
     if key is None:
-        value = runtime.raw_group_config
+        value = group_primitive
     else:
-        value = dict_get(runtime.raw_group_config, key, None)
+        value = dict_get(group_primitive, key, None)
         if value is None:
             if default is not None:
                 print(default)

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -96,7 +96,7 @@ read and propagate/expose this annotation in its display of the release image.
         istream_namespace=is_namespace if is_namespace else default_is_base_namespace()
     )
 
-    if runtime.assembly != 'stream' and 'art-latest' in base_target.istream_name:
+    if runtime.assembly and runtime.assembly != 'stream' and 'art-latest' in base_target.istream_name:
         raise ValueError('The art-latest imagestreams should not be used for non-stream assemblies')
 
     gen = PayloadGenerator(runtime, brew_session, base_target, exclude_arch, skip_gc_tagging=skip_gc_tagging)
@@ -163,7 +163,7 @@ class PayloadGenerator:
         self._designate_privacy(latest_builds, images)
 
         mismatched_siblings = self._find_mismatched_siblings(latest_builds)
-        if self.runtime.assembly_type == assembly.AssemblyTypes.CUSTOM:
+        if mismatched_siblings and self.runtime.assembly_type == assembly.AssemblyTypes.CUSTOM:
             self.runtime.logger.warning(f'There are mismatched siblings in this assembly, but it is "custom"; ignoring: {mismatched_siblings}')
             mismatched_siblings = set()
 

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -255,6 +255,12 @@ class PayloadGenerator:
             # when public_upstreams are not configured, we assume there is no private content.
             return
 
+        if self.runtime.assembly_basis_event:
+            # If an assembly has a basis event, its content is not going to go out
+            # to a release controller. Nothing we write is going to be publicly
+            # available.
+            return
+
         # store RPM archives to BuildStatusDetector cache to limit Brew queries
         for r in latest_builds:
             self.bs_detector.archive_lists[r.build["id"]] = r.archives
@@ -284,6 +290,11 @@ class PayloadGenerator:
 
         for dest, source_for_name in mirror_src_for_arch_and_name.items():
             brew_arch, private = dest
+
+            if self.runtime.assembly_basis_event and private:
+                self.runtime.logger.info(f"Skipping private mirroring list / imagestream for asssembly: {self.runtime.assembly}")
+                continue
+
             dest = f"{brew_arch}{'-priv' if private else ''}"
 
             # Save the default SRC=DEST input to a file for syncing by 'oc image mirror'

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -44,7 +44,7 @@ from doozerlib.exceptions import DoozerFatalError
 from doozerlib import constants
 from doozerlib import util
 from doozerlib import brew
-from doozerlib.assembly import assembly_group_config, assembly_config_finalize, assembly_basis_event
+from doozerlib.assembly import assembly_group_config, assembly_config_finalize, assembly_basis_event, assembly_type
 
 # Values corresponds to schema for group.yml: freeze_automation. When
 # 'yes', doozer itself will inhibit build/rebase related activity
@@ -149,6 +149,7 @@ class Runtime(object):
         self.session_pool_available = {}
         self.brew_event = None
         self.assembly_basis_event = None
+        self.assembly_type = None
         self.releases_config = None
         self.assembly = 'test'
 
@@ -617,6 +618,8 @@ class Runtime(object):
             # If the assembly has a basis event, we constrain all brew calls to that event.
             self.brew_event = self.assembly_basis_event
             self.logger.warning(f'Constraining brew event to assembly basis for {self.assembly}: {self.brew_event}')
+
+        self.assembly_type = assembly_type(self.get_releases_config(), self.assembly)
 
         assembly_config_finalize(self.get_releases_config(), self.assembly, self.rpm_metas(), self.ordered_image_metas())
 

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -274,7 +274,7 @@ class Runtime(object):
 
         return self.releases_config
 
-    def get_group_config(self):
+    def get_group_config(self) -> Model:
         # group.yml can contain a `vars` section which should be a
         # single level dict containing keys to str.format(**dict) replace
         # into the YAML content. If `vars` found, the format will be


### PR DESCRIPTION
- Allows assemblies to define machine-os-content
- Tag images that might otherwise be garbage collected
- Don't generate -priv when the content is for a non-stream assembly