### PR TITLE
Set default assembly name to "stream"

### DIFF
--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -50,7 +50,7 @@ def print_version(ctx, param, value):
               help="Username for rhpkg. Env var: DOOZER_USER")
 @click.option("-g", "--group", default=None, metavar='NAME[@commitish]',
               help="The group of images on which to operate. Env var: DOOZER_GROUP")
-@click.option("--assembly", metavar="ASSEMBLY_NAME", default='test',
+@click.option("--assembly", metavar="ASSEMBLY_NAME", default='stream',
               help="The name of an assembly to rebase & build for. Assemblies must be enabled in group.yml or with --enable-assemblies.")
 @click.option('--enable-assemblies', default=False, is_flag=True, help='Enable assemblies even if not enabled in group.yml. Primarily for testing purposes.')
 @click.option("--branch", default=None, metavar='BRANCH',


### PR DESCRIPTION
I'd expect this command to produce a working and sensible link:

```
⫸  doozer --group openshift-4.7 config:read-group --yaml repos.rhel-8-server-ose-rpms-embargoed.conf.baseurl.x86_64 2>/dev/null
http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/4.7-el8/test/building-embargoed/x86_64/os
```

With `--assembly stream` to the global options this becomes clickable.
This sets the default assembly name to the one that is used in the
common case.