### PR TITLE
olm-bundles: make --force work, also not require user config

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -2312,7 +2312,7 @@ def rebase_and_build_olm_bundle(runtime, operator_nvrs, force=False):
 
             did_rebase = olm_bundle.rebase(nvr)
             return {
-                'success': olm_bundle.build() if did_rebase else True,
+                'success': olm_bundle.build() if did_rebase or force else True,
                 'task_url': olm_bundle.task_url if hasattr(olm_bundle, 'task_url') else None,
                 'bundle_nvr': olm_bundle.get_latest_bundle_build_nvr(),
             }

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -123,7 +123,7 @@ class OLMBundle(object):
         """
         exectools.cmd_assert('rm -rf {}'.format(self.operator_clone_path))
         exectools.cmd_assert('mkdir -p {}'.format(os.path.dirname(self.operator_clone_path)))
-        exectools.cmd_assert('rhpkg{}clone --branch {} {} {}'.format(
+        exectools.cmd_assert('rhpkg {} clone --branch {} {} {}'.format(
             self.rhpkg_opts, self.branch, self.operator_repo_name, self.operator_clone_path
         ), retries=3)
 
@@ -138,7 +138,7 @@ class OLMBundle(object):
         """
         exectools.cmd_assert('rm -rf {}'.format(self.bundle_clone_path))
         exectools.cmd_assert('mkdir -p {}'.format(os.path.dirname(self.bundle_clone_path)))
-        exectools.cmd_assert('rhpkg{}clone --branch {} {} {}'.format(
+        exectools.cmd_assert('rhpkg {} clone --branch {} {} {}'.format(
             self.rhpkg_opts, self.branch, self.bundle_repo_name, self.bundle_clone_path
         ), retries=3)
 
@@ -241,8 +241,8 @@ class OLMBundle(object):
         with pushd.Dir(self.bundle_clone_path):
             try:
                 exectools.cmd_assert('git add .')
-                exectools.cmd_assert('rhpkg{}commit -m "{}"'.format(self.rhpkg_opts, commit_msg))
-                rc, out, err = exectools.cmd_gather('rhpkg{}push'.format(self.rhpkg_opts))
+                exectools.cmd_assert('rhpkg {} commit -m "{}"'.format(self.rhpkg_opts, commit_msg))
+                rc, out, err = exectools.cmd_gather('rhpkg {} push'.format(self.rhpkg_opts))
                 return True
             except Exception:
                 return False  # Bundle repository might be already up-to-date, nothing new to commit
@@ -254,7 +254,7 @@ class OLMBundle(object):
         """
         with pushd.Dir(self.bundle_clone_path):
             rc, out, err = exectools.cmd_gather(
-                'rhpkg{}container-build --nowait --target {}'.format(self.rhpkg_opts, self.target)
+                'rhpkg {} container-build --nowait --target {}'.format(self.rhpkg_opts, self.target)
             )
 
         if rc != 0:


### PR DESCRIPTION
`--force` on this now will actually rebuild.
spaced out the `rhpkg{}clone` pattern which comes out `rhpkgclone` in my normal usage.