### PR TITLE
Scan sources fix assembly

### DIFF
--- a/doozerlib/cli/scan_sources.py
+++ b/doozerlib/cli/scan_sources.py
@@ -119,8 +119,8 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
                     source_url = info['source']  # git://pkgs.devel.redhat.com/containers/atomic-openshift-descheduler#6fc9c31e5d9437ac19e3c4b45231be8392cdacac
                     source_commit = source_url.split('#')[1]  # isolate the commit hash
                     # Look at the digest that created THIS build. What is in head does not matter.
-                    prev_digest = meta.fetch_cgit_file('.oit/config_digest', commit_hash=source_commit).decode('utf-8')
-                    current_digest = meta.calculate_config_digest(runtime.group_config, runtime.streams)
+                    prev_digest = image_meta.fetch_cgit_file('.oit/config_digest', commit_hash=source_commit).decode('utf-8')
+                    current_digest = image_meta.calculate_config_digest(runtime.group_config, runtime.streams)
                     if current_digest.strip() != prev_digest.strip():
                         runtime.logger.info('%s config_digest %s is differing from %s', dgk, prev_digest, current_digest)
                         add_image_meta_change(image_meta, RebuildHint(RebuildHintCode.CONFIG_CHANGE, 'Metadata configuration change'))

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -286,8 +286,14 @@ class Metadata(object):
             ret += "?" + urllib.parse.urlencode(params)
         return ret
 
-    def fetch_cgit_file(self, filename):
-        url = self.cgit_file_url(filename)
+    def fetch_cgit_file(self, filename, commit_hash: Optional[str] = None, branch: Optional[str] = None):
+        """ Retrieve the content of a cgit URL to a given file associated with the commit hash pushed to distgit
+        :param filename: a relative path
+        :param commit_hash: commit hash; None implies the current HEAD
+        :param branch: branch name; None implies the branch specified in ocp-build-data
+        :return: the content of the file
+        """
+        url = self.cgit_file_url(filename, commit_hash=commit_hash, branch=branch)
         req = exectools.retry(
             3, lambda: urllib.request.urlopen(url),
             check_f=lambda req: req.code == 200)


### PR DESCRIPTION
Together, these changes should stop unnecessary rebuilds being suggested by scan-sources when a different assembly builds and RPM or image. 
- The metadata digest check is now performed relative to the image's actual build commit - not HEAD.
- The RPM check will ignore RPMs which are part of the group and are the latest NVR associated with the current assembly.