### PR TITLE
Always build against -candidate target then tag into -hotfix if needed

### DIFF
--- a/doozerlib/cli/rpms_build.py
+++ b/doozerlib/cli/rpms_build.py
@@ -213,9 +213,8 @@ async def _build_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata):
     task_ids = []
     task_urls = []
     try:
-        task_ids, task_urls = await builder.build(rpm)
-        record["version"] = rpm.version
-        record["release"] = rpm.release
+        task_ids, task_urls, nvrs = await builder.build(rpm)
+        record["nvrs"] = ",".join(nvrs)
         record["specfile"] = rpm.specfile
         record["status"] = 0
         record["message"] = "Success"

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1207,7 +1207,8 @@ class ImageDistGitRepo(DistGitRepo):
                 return False
 
             with self.runtime.shared_koji_client_session() as koji_api:
-                build_info = koji_api.listBuilds(taskID=task_id)[0]
+                koji_api.gssapi_login()
+                build_info = koji_api.listBuilds(taskID=task_id, completeBefore=None)[0]  # this call should not be constrained by brew event
                 record["nvrs"] = build_info["nvr"]
                 if self.runtime.hotfix:
                     # Tag the image so they don't get garbage collected.

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import aiofiles
 import bashlex
+from kobo.rpmlib import parse_nvr
 import requests
 import yaml
 from dockerfile_parse import DockerfileParser
@@ -912,12 +913,9 @@ class ImageDistGitRepo(DistGitRepo):
             # subsequent builds.
             push_version, push_release = ('', '')
             if not dry_run and not scratch:
-                # Use tag based get_latest_build because golang builder images don't follow the version numbering scheme like normal OCP images.
-                with self.runtime.shared_koji_client_session() as koji_api:
-                    builds = koji_api.listTagged(self.metadata.default_brew_tag(), package=self.metadata.get_component_name(), type="image", inherit=False)
-                    latest_build = util.find_latest_build(builds, self.runtime.assembly)
-                    push_version = latest_build["version"]
-                    push_release = latest_build["release"]
+                nvr = parse_nvr[record["nvrs"].split(",")[0]]
+                push_version = nvr["version"]
+                push_release = nvr["release"]
             record["message"] = "Success"
             record["status"] = 0
             self.build_status = True
@@ -1207,6 +1205,14 @@ class ImageDistGitRepo(DistGitRepo):
                 self.update_build_db(False, task_id=task_id, scratch=scratch)
                 self.logger.info("Error building image: {}, {}".format(task_url, error))
                 return False
+
+            with self.runtime.shared_koji_client_session() as koji_api:
+                build_info = koji_api.listBuilds(taskID=task_id)[0]
+                record["nvrs"] = build_info["nvr"]
+                if self.runtime.hotfix:
+                    # Tag the image so they don't get garbage collected.
+                    self.runtime.logger.info(f'Tagging {self.metadata.get_component_name()} build {build_info["nvr"]} with {self.metadata.hotfix_brew_tag()} to prevent garbage collection')
+                    koji_api.tagBuild(self.metadata.hotfix_brew_tag(), build_info["nvr"])
 
             self.update_build_db(True, task_id=task_id, scratch=scratch)
             self.logger.info("Successfully built image: {} ; {}".format(target_image, task_url))
@@ -2248,7 +2254,7 @@ class ImageDistGitRepo(DistGitRepo):
                     "set_env": {
                         "PATH": path,
                         "BREW_EVENT": f'{self.runtime.brew_event}',
-                        "BREW_TAG": f'{self.metadata.default_brew_tag()}'
+                        "BREW_TAG": f'{self.metadata.candidate_brew_tag()}'
                     },
                     "distgit_path": self.dg_path,
                 }

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -405,12 +405,10 @@ class ImageMetadata(Metadata):
         digest = hashlib.sha256(json.dumps(message, sort_keys=True, default=default).encode("utf-8")).hexdigest()
         return "sha256:" + digest
 
-    def default_brew_target(self):
-        if self.runtime.hotfix:
-            target = f"{self.branch()}-containers-hotfix"
-        else:
-            target = f"{self.branch()}-containers-candidate"
-        return target
+    def _default_brew_target(self):
+        """ Returns derived brew target name from the distgit branch name
+        """
+        return f"{self.branch()}-containers-candidate"
 
 
 def is_image_older_than_package_build_tagging(image_meta, image_build_event_id, package_build, newest_image_event_ts, oldest_image_event_ts) -> RebuildHint:

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -140,16 +140,15 @@ class Metadata(object):
     def determine_targets(self) -> List[str]:
         """ Determine Brew targets for building this component
         """
-        key = 'targets' if not self.runtime.hotfix else "hotfix_targets"
-        targets = self.config.get(key)
+        targets = self.config.get("targets")
         if not targets:
-            # If not specified in rpm meta, load from group config
+            # If not specified in meta config, load from group config
             profile_name = self.runtime.profile or self.runtime.group_config.get(f"default_{self.meta_type}_build_profile")
             if profile_name:
-                targets = self.runtime.group_config.build_profiles.primitive()[self.meta_type][profile_name].get(key)
+                targets = self.runtime.group_config.build_profiles.primitive()[self.meta_type][profile_name].get("targets")
         if not targets:
             # If group config doesn't define the targets either, the target name will be derived from the distgit branch name
-            targets = [self.default_brew_target()]
+            targets = [self._default_brew_target()]
         return targets
 
     def save(self):
@@ -189,10 +188,9 @@ class Metadata(object):
     def hotfix_brew_tag(self):
         return f'{self.branch()}-hotfix'
 
-    def default_brew_tag(self):
-        return self.hotfix_brew_tag() if self.runtime.hotfix else self.candidate_brew_tag()
-
-    def default_brew_target(self):
+    def _default_brew_target(self):
+        """ Returns derived brew target name from the distgit branch name
+        """
         return NotImplementedError()
 
     def candidate_brew_tags(self):

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -242,8 +242,9 @@ class RPMBuilder:
             if not failed_tasks:
                 # All tasks complete.
                 koji_api = self._runtime.build_retrying_koji_client()
+                koji_api.gssapi_login()
                 with koji_api.multicall(strict=True) as m:
-                    multicall_tasks = [m.listBuilds(taskID=task_id) for task_id in task_ids]
+                    multicall_tasks = [m.listBuilds(taskID=task_id, completeBefore=None) for task_id in task_ids]    # this call should not be constrained by brew event
                 nvrs = [task.result[0]["nvr"] for task in multicall_tasks]
                 if self._runtime.hotfix:
                     # Tag rpms so they don't get garbage collected.

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -210,6 +210,7 @@ class RPMBuilder:
             # errors, task_ids, task_urls = await self._create_build_tasks(dg)
             task_ids = []
             task_urls = []
+            nvrs = []
             logger.info("Creating Brew tasks...")
             for task_id, task_url in await asyncio.gather(
                 *[self._build_target_async(rpm, target) for target in rpm.targets]
@@ -239,6 +240,18 @@ class RPMBuilder:
                     logger.warning("DRY RUN - Would have downloaded Brew logs with %s", cmd)
             failed_tasks = {task_id for task_id, error in errors.items() if error is not None}
             if not failed_tasks:
+                # All tasks complete.
+                koji_api = self._runtime.build_retrying_koji_client()
+                with koji_api.multicall(strict=True) as m:
+                    multicall_tasks = [m.listBuilds(taskID=task_id) for task_id in task_ids]
+                nvrs = [task.result[0]["nvr"] for task in multicall_tasks]
+                if self._runtime.hotfix:
+                    # Tag rpms so they don't get garbage collected.
+                    self._runtime.logger.info(f'Tagging build(s) {nvrs} with {rpm.hotfix_brew_tag()} to prevent garbage collection')
+                    with koji_api.multicall(strict=True) as m:
+                        for nvr in nvrs:
+                            m.tagBuild(rpm.hotfix_brew_tag(), nvr)
+
                 logger.info("Successfully built rpm: %s", rpm.rpm_name)
                 rpm.build_status = True
                 break
@@ -261,7 +274,7 @@ class RPMBuilder:
                 f"Giving up after {retries} failed attempt(s): {message}",
                 (task_ids, task_urls),
             )
-        return task_ids, task_urls
+        return task_ids, task_urls, nvrs
 
     async def _golang_required(self, specfile: PathLike):
         """Returns True if this RPM requires a golang compiler"""

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -244,9 +244,7 @@ class RPMMetadata(Metadata):
     def candidate_brew_tags(self):
         return self.targets.copy()
 
-    def default_brew_target(self):
-        if self.runtime.hotfix:
-            target = f"{self.branch()}-hotfix"
-        else:
-            target = f"{self.branch()}-candidate"
-        return target
+    def _default_brew_target(self):
+        """ Returns derived brew target name from the distgit branch name
+        """
+        return f"{self.branch()}-candidate"

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1405,9 +1405,6 @@ class Runtime(object):
         pool.join()
         return ret
 
-    def get_default_brew_tag(self):
-        return self.branch
-
     def get_default_candidate_brew_tag(self):
         return self.branch + '-candidate' if self.branch else None
 

--- a/tests/cli/test_rpms_build.py
+++ b/tests/cli/test_rpms_build.py
@@ -56,7 +56,7 @@ class TestRPMsBuildCli(TestCase):
 
         runtime.rpm_metas.return_value = rpms
         builder = MockedRPMBuilder.return_value = AsyncMock()
-        builder.build.return_value = ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"])
+        builder.build.return_value = ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"], ["foo-1.2.3-1.el8", "foo-1.2.3-1.el7"])
 
         result = asyncio.get_event_loop().run_until_complete(_rpms_rebase_and_build(runtime, version, release, embargoed, scratch, dry_run))
 

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -143,7 +143,7 @@ class TestRPMBuilder(unittest.TestCase):
         mocked_cmd_gather_async.return_value = (0, "some stdout", "some stderr")
         dg.resolve_specfile_async = mock.AsyncMock(return_value=(dg.dg_path / "foo.spec", ("foo", "1.2.3", "1"), source_sha))
         koji_api = runtime.build_retrying_koji_client.return_value
-        koji_api.multicall.return_value.__enter__.return_value.listBuilds.side_effect = lambda taskID: {
+        koji_api.multicall.return_value.__enter__.return_value.listBuilds.side_effect = lambda taskID, completeBefore: {
             10001: mock.MagicMock(result=[{"nvr": "foo-1.2.3-1.el8"}]),
             10002: mock.MagicMock(result=[{"nvr": "foo-1.2.3-1.el7"}]),
         }[taskID]

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -128,6 +128,7 @@ class TestRPMBuilder(unittest.TestCase):
         source_sha = "3f17b42b8aa7d294c0d2b6f946af5fe488f3a722"
         distgit_sha = "4cd7f576ad005aadd3c25ea56c7986bc6a7e7340"
         runtime = self._make_runtime()
+        runtime.hotfix = True
         rpm = self._make_rpm_meta(runtime, source_sha, distgit_sha)
         rpm.assert_golang_versions = mock.MagicMock()
         dg = rpm.distgit_repo()
@@ -141,9 +142,14 @@ class TestRPMBuilder(unittest.TestCase):
             task_id: None for task_id in task_ids})
         mocked_cmd_gather_async.return_value = (0, "some stdout", "some stderr")
         dg.resolve_specfile_async = mock.AsyncMock(return_value=(dg.dg_path / "foo.spec", ("foo", "1.2.3", "1"), source_sha))
+        koji_api = runtime.build_retrying_koji_client.return_value
+        koji_api.multicall.return_value.__enter__.return_value.listBuilds.side_effect = lambda taskID: {
+            10001: mock.MagicMock(result=[{"nvr": "foo-1.2.3-1.el8"}]),
+            10002: mock.MagicMock(result=[{"nvr": "foo-1.2.3-1.el7"}]),
+        }[taskID]
 
         actual = asyncio.get_event_loop().run_until_complete(builder.build(rpm, retries=3))
-        expected = ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"])
+        expected = ([10001, 10002], ["https://brewweb.example.com/brew/taskinfo?taskID=10001", "https://brewweb.example.com/brew/taskinfo?taskID=10002"], ["foo-1.2.3-1.el8", "foo-1.2.3-1.el7"])
         self.assertEqual(actual, expected)
         self.assertTrue(rpm.build_status)
         builder._golang_required.assert_called_once_with(rpm.specfile)


### PR DESCRIPTION
When building for non-stream assembly, tag the build into `-hotfix`
after build completes.

Also writes build NVRs to record.log so that our Jenkins job like
`rebuild` won't have to query Brew for NVRs by task IDs.