### PR TITLE
[ART-3155] Conditionally add `ose-` prefix to bundle image name

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -103,7 +103,8 @@ class OLMBundle(object):
         return build['nvr']
 
     def get_bundle_image_name(self):
-        return 'openshift/ose-{}'.format(self.bundle_name)
+        prefix = '' if self.bundle_name.startswith('ose-') else 'ose-'
+        return 'openshift/{}{}'.format(prefix, self.bundle_name)
 
     def get_operator_buildinfo(self, nvr=None):
         """Get operator distgit repository name and commit hash used to build given operator NVR

--- a/tests/test_olm_bundle.py
+++ b/tests/test_olm_bundle.py
@@ -1,0 +1,14 @@
+import unittest
+import flexmock
+from doozerlib.olm.bundle import OLMBundle
+
+
+class TestOLMBundle(unittest.TestCase):
+
+    def test_get_bundle_image_name_no_ose_prefix(self):
+        obj = flexmock(OLMBundle(None), bundle_name='foo')
+        self.assertEqual(obj.get_bundle_image_name(), 'openshift/ose-foo')
+
+    def test_get_bundle_image_name_with_ose_prefix(self):
+        obj = flexmock(OLMBundle(None), bundle_name='ose-foo')
+        self.assertEqual(obj.get_bundle_image_name(), 'openshift/ose-foo')


### PR DESCRIPTION
Don't blindly prepend `ose-` if bundle name already starts with `ose-`