### PR TITLE
[ART-3108] Add release:gen-assembly verb

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -16,6 +16,7 @@ from doozerlib.cli.release_gen_payload import release_gen_payload
 from doozerlib.cli.detect_embargo import detect_embargo
 from doozerlib.cli.images_health import images_health
 from doozerlib.cli.images_streams import images_streams, images_streams_mirror, images_streams_gen_buildconfigs
+from doozerlib.cli.release_gen_assembly import releases_gen_assembly, gen_assembly_from_releases
 from doozerlib.cli.scan_sources import config_scan_source_changes
 from doozerlib.cli.rpms_build import rpms_build
 from doozerlib.cli.config_plashet import config_plashet

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -16,7 +16,7 @@ from doozerlib.cli.release_gen_payload import release_gen_payload
 from doozerlib.cli.detect_embargo import detect_embargo
 from doozerlib.cli.images_health import images_health
 from doozerlib.cli.images_streams import images_streams, images_streams_mirror, images_streams_gen_buildconfigs
-from doozerlib.cli.release_gen_assembly import releases_gen_assembly, gen_assembly_from_releases
+from doozerlib.cli.release_gen_assembly import releases_gen_assembly, gen_assembly_from_nightlies
 from doozerlib.cli.scan_sources import config_scan_source_changes
 from doozerlib.cli.rpms_build import rpms_build
 from doozerlib.cli.config_plashet import config_plashet

--- a/doozerlib/cli/release_gen_assembly.py
+++ b/doozerlib/cli/release_gen_assembly.py
@@ -1,0 +1,296 @@
+import click
+import sys
+import json
+import yaml
+from typing import Dict, List, Set
+
+from doozerlib import util
+from doozerlib.cli import cli, pass_runtime
+from doozerlib import exectools
+from doozerlib.model import Model
+from doozerlib import brew
+from doozerlib.rpmcfg import RPMMetadata
+from doozerlib.image import ImageMetadata
+
+
+@cli.group("release:gen-assembly", short_help="Output assembly metadata based on inputs")
+@click.option('--name', metavar='ASSEMBLY_NAME', required=True, help='The name of the assembly (e.g. "4.9.99", "art1234") to scaffold')
+@click.pass_context
+def releases_gen_assembly(ctx, name):
+    ctx.ensure_object(dict)
+    ctx.obj['ASSEMBLY_NAME'] = name
+    pass
+
+
+@releases_gen_assembly.command('from-releases', short_help='Outputs assembly metadata based on a set of speified nightlies')
+@click.option('--nightly', 'nightlies', metavar='RELEASE_NAME', default=[], multiple=True, help='A nightly release name for each architecture (e.g. 4.7.0-0.nightly-2021-07-07-214918)')
+@pass_runtime
+@click.pass_context
+def gen_assembly_from_releases(ctx, runtime, nightlies):
+    runtime.initialize(mode='both', clone_distgits=False, clone_source=False, prevent_cloning=True)
+    logger = runtime.logger
+    gen_assembly_name = ctx.obj['ASSEMBLY_NAME']  # The name of the assembly we are going to output
+
+    # Create a map of package_name to RPMMetadata
+    package_rpm_meta: Dict[str, RPMMetadata] = {rpm_meta.get_package_name(): rpm_meta for rpm_meta in runtime.rpm_metas()}
+    # Same for images
+    package_image_meta: Dict[str, ImageMetadata] = {image_meta.get_component_name(): image_meta for image_meta in runtime.image_metas()}
+
+    def exit_with_error(msg):
+        print(msg, file=sys.stderr)
+        exit(1)
+
+    if runtime.assembly != 'stream':
+        exit_with_error('--assembly must be "stream" in order to populate an assembly definition from nightlies')
+
+    if not nightlies:
+        exit_with_error('At least one nightly must be specified')
+
+    if len(runtime.arches) != len(nightlies):
+        exit_with_error(f'Expected at least {len(runtime.arches)} nightlies; one for each group arch: {runtime.arches}')
+
+    reference_releases_by_arch: Dict[str, str] = dict()  # Maps brew arch name to nightly name
+    mosc_by_arch: Dict[str, str] = dict()  # Maps brew arch name to machine-os-content pullspec from nightly
+    component_image_builds: Dict[str, Dict] = dict()  # Maps component package_name to brew build dict found for nightly
+    component_rpm_builds: Dict[str, Dict[int, Dict]] = dict()  # package_name -> Dict[ el? -> brew build dict ]
+    basis_event_ts: float = 0.0
+    for nightly in nightlies:
+        runtime.logger.info(f'Processing nightly: {nightly}')
+        major_minor, brew_cpu_arch, priv = util.isolate_nightly_name_components(nightly)
+        reference_releases_by_arch[brew_cpu_arch] = nightly
+
+        if major_minor != runtime.get_minor_version():
+            exit_with_error(f'Specified nightly {nightly} does not match group major.minor')
+
+        rc_suffix = util.go_suffix_for_arch(brew_cpu_arch, priv)
+
+        release_json_str, _ = exectools.cmd_assert(f'oc adm release info registry.ci.openshift.org/ocp{rc_suffix}/release{rc_suffix}:{nightly} -o=json', retries=3)
+        release_info = Model(dict_to_model=json.loads(release_json_str))
+
+        if not release_info.references.spec.tags:
+            exit_with_error(f'Could not find tags in nightly {nightly}')
+
+        for component_tags in release_info.references.spec.tags:
+            payload_tag_name = component_tags.name  # e.g. "aws-ebs-csi-driver"
+            payload_tag_pullspec = component_tags['from'].name  # quay pullspec
+
+            if payload_tag_name == 'machine-os-content':
+                mosc_by_arch[brew_cpu_arch] = payload_tag_pullspec
+                continue
+
+            image_json_str, _ = exectools.cmd_assert(f'oc image info {payload_tag_pullspec} -o=json')
+            image_info = json.loads(image_json_str)
+            image_labels = image_info['config']['config']['Labels']
+            image_nvr = image_labels['com.redhat.component'] + '-' + image_labels['version'] + '-' + image_labels['release']
+            with runtime.shared_koji_client_session() as koji_api:
+                image_build = koji_api.getBuild(image_nvr)
+
+                if not image_build:
+                    exit_with_error(f'Unable to find brew build record for {image_nvr} (from {nightly})')
+
+                package_name = image_build['package_name']
+                build_nvr = image_build['nvr']
+                if package_name in component_image_builds:
+                    # If we have already encountered this package once in the list of nightlies we are
+                    # processing, then make sure that the original NVR we found matches the new NVR.
+                    # We want the nightlies to be populated with identical builds.
+                    existing_nvr = component_image_builds[package_name]['nvr']
+                    if build_nvr != existing_nvr:
+                        exit_with_error(f'Found disparate nvrs between nightlies; {existing_nvr} in processed and {build_nvr} in nightly')
+                else:
+                    # Otherwise, record the build as the first time we've seen an NVR for this
+                    # package.
+                    component_image_builds[package_name] = image_build
+
+                # We now try to determine a basis brew event that will
+                # find this image during get_latest_build-like operations
+                # for the assembly. At the time of this writing, metadata.get_latest_build
+                # will only look for builds *completed* before the basis event. This could
+                # be changed to *created* before the basis event in the future. However,
+                # other logic that is used to find latest builds requires the build to be
+                # tagged into an rhaos tag before the basis brew event.
+                # To choose a safe / reliable basis brew event, we first find the
+                # time at which a build was completed, then add 5 minutes.
+                # That extra 5 minutes ensures brew will have had time to tag the
+                # build appropriately for its build target. The 5 minutes is also
+                # short enough to ensure that no other build of this image could have
+                # completed before the basis event.
+
+                completion_ts: float = image_build['completion_ts']
+                # If the basis event for this image is > the basis_event capable of
+                # sweeping images we've already analyzed, increase the basis_event_ts.
+                basis_event_ts = max(basis_event_ts, completion_ts + (60.0 * 5))
+
+    # basis_event_ts should now be greater than the build completion / target tagging operation
+    # for any (non machin-os-content) image in the nightlies. Because images are built after RPMs,
+    # it must also hold that the basis_event_ts is also greater than build completion & tagging
+    # of any member RPM.
+
+    # Let's now turn the approximate basis_event_ts into a brew event number
+    with runtime.shared_koji_client_session() as koji_api:
+        basis_event = koji_api.getLastEvent(before=basis_event_ts)['id']
+
+    logger.info(f'The following image package_names were detected in the nightlies: {component_image_builds.keys()}')
+
+    # That said, things happen. Let's say image component X was built in build X1 and X2.
+    # Image component Y was build in Y1. Let's say that the ordering was X1, X2, Y1 and, for
+    # whatever reason, we find X1 and Y1 in the user specified nightly. This means the basis_event_ts
+    # we find for Y1 is going to find X2 instead of X1 if we used it as part of an assembly's basis event.
+
+    # To avoid that, we now evaluate whether any images or RPMs defy our assumption that the nightly
+    # corresponds to the basis_event_ts we have calculated. If we find something that will not be swept
+    # correctly by the estimated basis event, we collect up the outliers (hopefully few in number) into
+    # a list of packages which must be included in the assembly as 'is:'.
+    force_is: Set[str] = set()  # A set of package_names whose NVRs are not correctly sourced by the estimated basis_event
+    for image_meta in runtime.image_metas():
+
+        if image_meta.base_only or not image_meta.for_release:
+            continue
+
+        dgk = image_meta.distgit_key
+        package_name = image_meta.get_component_name()
+        basis_event_build = image_meta.get_latest_build(default=None, complete_before_event=basis_event)
+        if not basis_event_build:
+            exit_with_error(f'No image was found for assembly {runtime.assembly} for component {dgk} at estimated brew event {basis_event}. No normal reason for this to happen so exiting out of caution.')
+
+        basis_event_build_nvr = basis_event_build['nvr']
+
+        if not image_meta.is_payload:
+            # If this is not for the payload, the nightlies cannot have informed our NVR decision; just
+            # pick whatever the estimated basis will pull and let the user know. If they want to change
+            # it, they will need to pin it.
+            logger.info(f'{dgk} non-payload build {basis_event_build_nvr} will be swept by estimated assembly basis event')
+            component_image_builds[package_name] = basis_event_build
+            continue
+
+        # Otherwise, the image_meta is destined for the payload and analyzing the nightlies should
+        # have given us an NVR which is expected to be selected by the assembly.
+
+        if package_name not in component_image_builds:
+            logger.error(f'Unable to find {dgk} in nightlies despite it being marked as is_payload in ART metadata; this may mean the image does not have the proper labeling for being in the payload. Choosing what was in the estimated basis event sweep: {basis_event_build_nvr}')
+            component_image_builds[package_name] = basis_event_build
+            continue
+
+        nightlies_component_build = component_image_builds[package_name]
+        nightlies_component_build_nvr = nightlies_component_build['nvr']
+
+        if basis_event_build_nvr != nightlies_component_build_nvr:
+            logger.info(f'{dgk} build {basis_event_build_nvr} was selected by estimated basis event. That is not what is in the specified nightlies, so this image will be pinned.')
+            force_is.add(package_name)
+            continue
+
+        # Otherwise, the estimated basis event resolved the image nvr we found in the nightlies. The
+        # image NVR does not need to be pinned. Yeah!
+
+    # We should have found a machine-os-content for each architecture in the group
+    for arch in runtime.arches:
+        if arch not in mosc_by_arch:
+            exit_with_error(f'Did not find machine-os-content image for active group architecture: {arch}')
+
+    # We now have a list of image builds that should be selected by the assembly basis event
+    # and those that will need to be forced with 'is'. We now need to perform a similar step
+    # for RPMs. Look at the image contents, see which RPMs are in use. If we build them,
+    # then the NVRs in the image must be selected by the estimated basis event. If they are
+    # not, then we must pin the NVRs in the assembly definition.
+
+    with runtime.shared_koji_client_session() as koji_api:
+
+        archive_lists = brew.list_archives_by_builds([b["id"] for b in component_image_builds.values()], "image", koji_api)
+        rpm_build_ids = {rpm["build_id"] for archives in archive_lists for ar in archives for rpm in ar["rpms"]}
+        logger.info("Querying Brew build build information for %s RPM builds...", len(rpm_build_ids))
+        # We now have a list of all RPM builds which have been installed into the various images which
+        # ART builds. Specifically the ART builds which went into composing the nightlies.
+        nightly_rpm_builds: List[Dict] = brew.get_build_objects(rpm_build_ids, koji_api)
+
+        for nightly_rpm_build in nightly_rpm_builds:
+            package_name = nightly_rpm_build['package_name']
+            if package_name in package_rpm_meta:  # Does ART build this package?
+                rpm_meta = package_rpm_meta[package_name]
+                dgk = rpm_meta.distgit_key
+                rpm_build_nvr = nightly_rpm_build['nvr']
+                # If so, what RHEL version is this build for?
+                el_ver = util.isolate_el_version_in_release(nightly_rpm_build['release'])
+                if not el_ver:
+                    exit_with_error(f'Unable to isolate el? version in {rpm_build_nvr}')
+
+                if package_name not in component_rpm_builds:
+                    # If this is the first time we've seen this ART package, bootstrap a dict for its
+                    # potentially different builds for different RHEL versions.
+                    component_rpm_builds[package_name]: Dict[int, Dict] = dict()
+
+                if el_ver in component_rpm_builds[package_name]:
+                    # We've already captured the build in our results
+                    continue
+
+                # Now it is time to see whether a query for the RPM from the basis event
+                # estimate comes up with this RPM NVR.
+                basis_event_build = rpm_meta.get_latest_build(el_target=el_ver, complete_before_event=basis_event)
+                if not basis_event_build:
+                    exit_with_error(f'No RPM was found for assembly {runtime.assembly} for component {dgk} at estimated brew event {basis_event}. No normal reason for this to happen so exiting out of caution.')
+
+                if el_ver in component_rpm_builds[package_name]:
+                    # We've already logged a build for this el version before
+                    continue
+
+                component_rpm_builds[package_name][el_ver] = nightly_rpm_build
+                basis_event_build_nvr = basis_event_build['nvr']
+                logger.info(f'{dgk} build {basis_event_build_nvr} selected by scan against estimated basis event')
+                if basis_event_build_nvr != nightly_rpm_build['nvr']:
+                    # The basis event estimate did not find the RPM from the nightlies. We have to pin the package.
+                    logger.info(f'{dgk} build {basis_event_build_nvr} was selected by estimated basis event. That is not what is in the specified nightlies, so this RPM will be pinned.')
+                    force_is.add(package_name)
+
+    # component_image_builds now contains a mapping of package_name -> brew_build for all images that should be included
+    # in the assembly.
+    # component_rpm_builds now contains a mapping of package_name to different RHEL versions that should be included
+    # in the assembly.
+    # force_is is a set of package_names which were not successfully selected by the estimated basis event.
+
+    image_member_overrides: List[Dict] = []
+    rpm_member_overrides: List[Dict] = []
+    for package_name in force_is:
+        if package_name in component_image_builds:
+            dgk = package_image_meta[package_name].distgit_key
+            image_member_overrides.append({
+                'distgit_key': dgk,
+                'why': 'Query from assembly basis event failed to replicate reference nightly content exactly. Pinning to replicate.',
+                'metadata': {
+                    'is': {
+                        'nvr': component_image_builds[package_name]['nvr']
+                    }
+                }
+            })
+        elif package_name in component_rpm_builds:
+            dgk = package_rpm_meta[package_name].distgit_key
+            rpm_member_overrides.append({
+                'distgit_key': dgk,
+                'why': 'Query from assembly basis event failed to replicate reference nightly content exactly. Pinning to replicate.',
+                'metadata': {
+                    'is': {
+                        f'el{el_ver}': component_rpm_builds[package_name][el_ver]['nvr'] for el_ver in component_rpm_builds[package_name]
+                    }
+                }
+            })
+
+    assembly_def = {
+        'releases': {
+            gen_assembly_name: {
+                'type': 'standard',
+                'basis': {
+                    'brew_event': basis_event,
+                    'reference_releases': reference_releases_by_arch,
+                },
+                'rhcos': {
+                    'machine-os-content': mosc_by_arch
+                },
+                'members': {
+                    'rpms': rpm_member_overrides,
+                    'images': image_member_overrides,
+                }
+            }
+        }
+    }
+
+    print('Suggested assembly definition')
+    print('=====================================================')
+    print(yaml.dump(assembly_def))

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -307,7 +307,7 @@ class Metadata(object):
             check_f=lambda req: req.code == 200)
         return req.read()
 
-    def get_latest_build(self, default=-1, assembly=None, extra_pattern='*', build_state: BuildStates = BuildStates.COMPLETE, el_target=None, honor_is=True):
+    def get_latest_build(self, default=-1, assembly=None, extra_pattern='*', build_state: BuildStates = BuildStates.COMPLETE, el_target=None, honor_is=True, complete_before_event: int = None):
         """
         :param default: A value to return if no latest is found (if not specified, an exception will be thrown)
         :param assembly: A non-default assembly name to search relative to. If not specified, runtime.assembly
@@ -323,6 +323,8 @@ class Metadata(object):
                             contains '....-rhel-?..' and the number will be extracted. If you want the true
                             latest, leave as None.
         :param honor_is: If True, and an assembly component specifies 'is', that nvr will be returned.
+        :param complete_before_event: If specified, the search will be constrained to builds which completed before
+                the specified brew_event. If not specified, the search will be relative to the current assembly's basis event.
         :return: Returns the most recent build object from koji for this package & assembly.
                  Example https://gist.github.com/jupierce/57e99b80572336e8652df3c6be7bf664
         """
@@ -357,6 +359,15 @@ class Metadata(object):
             if assembly is None:
                 assembly = self.runtime.assembly
 
+            if not complete_before_event:
+                # If not specified, use the brew_event in runtime. If the current assembly has a basis
+                # event, this will also be the basis event for the assembly (unless overridden on the command
+                # line).
+                complete_before_event = self.runtime.brew_event
+
+            # listBuilds accepts timestamps, not brew events, so convert brew event into seconds since the epoch
+            complete_before_ts = koji_api.getEvent(complete_before_event)['ts']
+
             def default_return():
                 msg = f"No builds detected for using prefix: '{pattern_prefix}', extra_pattern: '{extra_pattern}', assembly: '{assembly}', build_state: '{build_state.name}', el_target: '{el_target}'"
                 if default != -1:
@@ -371,6 +382,7 @@ class Metadata(object):
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}',
+                                             completeBefore=complete_before_ts,
                                              queryOpts={'limit': 1, 'order': '-creation_event_id'})
 
                 # Ensure the suffix ends the string OR at least terminated by a '.' .
@@ -459,13 +471,13 @@ class Metadata(object):
                             # that they are no builds for this assembly.
                             builds = []
 
-        if not builds:
-            return default_return()
+            if not builds:
+                return default_return()
 
-        found_build = builds[0]
-        # Different brew apis return different keys here; normalize to make the rest of doozer not need to change.
-        found_build['id'] = found_build['build_id']
-        return found_build
+            found_build = builds[0]
+            # Different brew apis return different keys here; normalize to make the rest of doozer not need to change.
+            found_build['id'] = found_build['build_id']
+            return found_build
 
     def get_latest_build_info(self, default=-1, **kwargs):
         """

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -23,7 +23,7 @@ import urllib.parse
 import signal
 import io
 import pathlib
-from typing import Optional, List, Dict, Tuple
+from typing import Optional, List, Dict, Tuple, Union
 import time
 
 from doozerlib import gitdata
@@ -754,10 +754,10 @@ class Runtime(object):
         if self.freeze_automation == FREEZE_AUTOMATION_YES:
             raise DoozerFatalError('Automation (builds / mutations) for this group is currently frozen (freeze_automation set to {}). Coordinate with the group owner to change this if you believe it is incorrect.'.format(FREEZE_AUTOMATION_YES))
 
-    def image_metas(self):
+    def image_metas(self) -> List[ImageMetadata]:
         return list(self.image_map.values())
 
-    def ordered_image_metas(self):
+    def ordered_image_metas(self) -> List[ImageMetadata]:
         return [self.image_map[dg] for dg in self.image_order]
 
     def get_global_arches(self):
@@ -812,10 +812,10 @@ class Runtime(object):
         """Returns image meta by full name, short name, or distgit"""
         return self.image_name_map.get(name, None)
 
-    def rpm_metas(self):
+    def rpm_metas(self) -> List[RPMMetadata]:
         return list(self.rpm_map.values())
 
-    def all_metas(self):
+    def all_metas(self) -> List[Union[ImageMetadata, RPMMetadata]]:
         return self.image_metas() + self.rpm_metas()
 
     def register_source_alias(self, alias, path):

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -22,7 +22,6 @@ except ImportError:
 
 from doozerlib import constants, exectools
 
-
 def stringify(val):
     """
     Accepts either str or bytes and returns a str
@@ -387,6 +386,30 @@ def split_el_suffix_in_release(release: str) -> Tuple[str, Optional[str]]:
         return release, None
 
 
+def isolate_nightly_name_components(nightly_name: str) -> (str, str, bool):
+    """
+    Given a release name (e.g. 4.8.0-0.nightly-s390x-2021-07-02-143555, 4.1.0-0.nightly-priv-2019-11-08-213727),
+    return:
+     - The major.minor of the release (e.g. 4.8)
+     - The brew CPU architecture name associated with the nightly (e.g. s390x, x86_64)
+     - Whether the release is from a private release controller.
+    :param nightly_name: The name of the nightly to analyze
+    :return: (major_minor, brew_arch, is_private)
+    """
+    major_minor = '.'.join(nightly_name.split('.')[:2])
+    nightly_name = nightly_name[nightly_name.find('.nightly')+1:]  # strip off versioning info (e.g.  4.8.0-0.)
+    components = nightly_name.split('-')
+    is_private = ('priv' in components)
+    pos = components.index('nightly')
+    possible_arch = components[pos + 1]
+    if possible_arch not in go_arches:
+        go_arch = 'x86_64'  # for historical reasons, amd64 is not included in the release name
+    else:
+        go_arch = possible_arch
+    brew_arch = brew_arch_for_go_arch(go_arch)
+    return major_minor, brew_arch, is_private
+
+
 def isolate_assembly_in_release(release: str) -> str:
     """
     Given a release field, determines whether is contains
@@ -491,16 +514,28 @@ def brew_arch_for_go_arch(go_arch: str) -> str:
     raise Exception(f"no such golang arch '{go_arch}' - cannot translate to brew arch")
 
 
-# imagestreams and such often began without consideration for multi-arch and then
-# added a suffix everywhere to accommodate arches (but kept the legacy location for x86).
-def go_suffix_for_arch(arch: str) -> str:
+def go_suffix_for_arch(arch: str, is_private: bool = False) -> str:
+    """
+    Imagestreams and namespaces for the release controller indicate
+    a CPU architecture and whether the release is part of the private release controller.
+    using [-<arch>][-priv] as a suffix. This method calculates that suffix
+    based on what arch and privacy you are trying to reach.
+    :param arch: The CPU architecture
+    :param is_private: True if you are looking for a private release controller
+    :return: A suffix to use when address release controller imagestreams/namespaces.
+             x86 arch is never included in the suffix (i.e. '' is used).
+    """
     arch = go_arch_for_brew_arch(arch)  # translate either incoming arch style
-    return go_arch_suffixes[go_arches.index(arch)]
+    suffix = go_arch_suffixes[go_arches.index(arch)]
+    if is_private:
+        suffix += '-priv'
+    return suffix
 
 
 def brew_suffix_for_arch(arch: str) -> str:
     arch = brew_arch_for_go_arch(arch)  # translate either incoming arch style
     return brew_arch_suffixes[brew_arches.index(arch)]
+
 
 
 def find_latest_build(builds: List[Dict], assembly: Optional[str]) -> Optional[Dict]:

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -22,6 +22,7 @@ except ImportError:
 
 from doozerlib import constants, exectools
 
+
 def stringify(val):
     """
     Accepts either str or bytes and returns a str
@@ -356,7 +357,7 @@ def get_docker_config_json(config_dir):
         raise FileNotFoundError("Can not find the registry config file in {}".format(config_dir))
 
 
-def isolate_pflag_in_release(release: str) -> str:
+def isolate_pflag_in_release(release: str) -> Optional[str]:
     """
     Given a release field, determines whether is contains
     .p0/.p1 information. If it does, it returns the value
@@ -397,7 +398,7 @@ def isolate_nightly_name_components(nightly_name: str) -> (str, str, bool):
     :return: (major_minor, brew_arch, is_private)
     """
     major_minor = '.'.join(nightly_name.split('.')[:2])
-    nightly_name = nightly_name[nightly_name.find('.nightly')+1:]  # strip off versioning info (e.g.  4.8.0-0.)
+    nightly_name = nightly_name[nightly_name.find('.nightly') + 1:]  # strip off versioning info (e.g.  4.8.0-0.)
     components = nightly_name.split('-')
     is_private = ('priv' in components)
     pos = components.index('nightly')
@@ -410,7 +411,7 @@ def isolate_nightly_name_components(nightly_name: str) -> (str, str, bool):
     return major_minor, brew_arch, is_private
 
 
-def isolate_assembly_in_release(release: str) -> str:
+def isolate_assembly_in_release(release: str) -> Optional[str]:
     """
     Given a release field, determines whether is contains
     an assembly name. If it does, it returns the assembly
@@ -449,7 +450,7 @@ def isolate_el_version_in_brew_tag(tag: str) -> Optional[int]:
 
 
 # https://code.activestate.com/recipes/577504/
-def total_size(o, handlers={}, verbose=False):
+def total_size(o, handlers=None, verbose=False):
     """ Returns the approximate memory footprint an object and all of its contents.
 
     Automatically finds the contents of the following builtin containers and
@@ -460,6 +461,9 @@ def total_size(o, handlers={}, verbose=False):
                     OtherContainerClass: OtherContainerClass.get_elements}
 
     """
+    if handlers is None:
+        handlers = dict()
+
     dict_handler = lambda d: chain.from_iterable(d.items())
     all_handlers = {
         tuple: iter,
@@ -537,10 +541,9 @@ def brew_suffix_for_arch(arch: str) -> str:
     return brew_arch_suffixes[brew_arches.index(arch)]
 
 
-
 def find_latest_build(builds: List[Dict], assembly: Optional[str]) -> Optional[Dict]:
     """ Find the latest build specific to the assembly in a list of builds belonging to the same component and brew tag
-    :param brew_builds: a list of build dicts sorted by tagging event in descending order
+    :param builds: a list of build dicts sorted by tagging event in descending order
     :param assembly: the name of assembly; None if assemblies support is disabled
     :return: a brew build dict or None
     """

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -120,7 +120,7 @@ class TestMetadata(TestCase):
         koji_mock = self.koji_mock
         now = datetime.datetime.now(datetime.timezone.utc)
 
-        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
+        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None, **kwargs):
             return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
 
         koji_mock.listBuilds.side_effect = list_builds
@@ -216,13 +216,14 @@ class TestMetadata(TestCase):
         koji_mock = self.koji_mock
         now = datetime.datetime.now(datetime.timezone.utc)
 
-        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
+        builds = []
+
+        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None, **kwargs):
             return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
 
         koji_mock.listBuilds.side_effect = list_builds
 
         # If listBuilds returns nothing, no build should be returned
-        builds = []
         self.assertIsNone(meta.get_latest_build(default=None))
 
         meta.meta_type = 'rpm'
@@ -258,7 +259,7 @@ class TestMetadata(TestCase):
         now = datetime.datetime.now(datetime.timezone.utc)
         then = now - datetime.timedelta(hours=5)
 
-        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
+        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None, **kwargs):
             return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
 
         runtime.downstream_commitish_overrides = {}
@@ -322,7 +323,7 @@ class TestMetadata(TestCase):
         now = datetime.datetime.now(datetime.timezone.utc)
         then = now - datetime.timedelta(hours=5)
 
-        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
+        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None, **kwargs):
             return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
 
         runtime.downstream_commitish_overrides = {}
@@ -395,7 +396,7 @@ class TestMetadata(TestCase):
         now = datetime.datetime.now(datetime.timezone.utc)
         then = now - datetime.timedelta(hours=5)
 
-        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None):
+        def list_builds(packageID=None, state=None, pattern=None, queryOpts=None, **kwargs):
             return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
 
         runtime.downstream_commitish_overrides = {}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,6 +24,12 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.art12398'), None)
         self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.7.e.8'), None)
 
+    def test_isolate_nightly_name_components(self):
+        self.assertEqual(util.isolate_nightly_name_components('4.1.0-0.nightly-2019-11-08-213727'), ('4.1', 'x86_64', False))
+        self.assertEqual(util.isolate_nightly_name_components('4.1.0-0.nightly-priv-2019-11-08-213727'), ('4.1', 'x86_64', True))
+        self.assertEqual(util.isolate_nightly_name_components('4.1.0-0.nightly-s390x-2019-11-08-213727'), ('4.1', 's390x', False))
+        self.assertEqual(util.isolate_nightly_name_components('4.9.0-0.nightly-arm64-priv-2021-06-08-213727'), ('4.9', 'aarch64', True))
+
     def test_isolate_pflag(self):
         self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p1'), 'p1')
         self.assertEqual(util.isolate_pflag_in_release('1.2.3-y.p.p1.el7'), 'p1')


### PR DESCRIPTION
Example invocation to build a "standard" assembly:
`./doozer --group openshift-4.7 --user jupierce --assembly stream release:gen-assembly --name art123 from-releases --nightly 4.7.0-0.nightly-2021-07-15-180731 --nightly 4.7.0-0.nightly-s390x-2021-07-15-181430 --nightly 4.7.0-0.nightly-ppc64le-2021-07-15-181317` 

stdout:
```
Suggested assembly definition
=====================================================
releases:
  art123:
    basis:
      brew_event: 39987701
      reference_releases:
        ppc64le: 4.7.0-0.nightly-ppc64le-2021-07-15-181317
        s390x: 4.7.0-0.nightly-s390x-2021-07-15-181430
        x86_64: 4.7.0-0.nightly-2021-07-15-180731
    members:
      images: []
      rpms: []
    rhcos:
      machine-os-content:
        ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2202d05bd07168b2995cbba111b3576f324e5fb818e6bc443e782bb99f72abc2
        s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:44dc69c88b187007ccd12a2658af2746bc207c6021be8cab54ee23d78ec18117
        x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6f13f9164129c3cbb89bcba63459e88c178f0fb8aa1fe58106cb49e3e265a7af
    type: standard
```

300 lines of code that works very hard to do almost nothing during expected scenarios :) 

The main business logic here is to:
1. Estimate a basis brew event for a new assembly based on the nightlies specified
2. Carefully verify that the basis brew event reflects the content of those nightlies
3. If it does, a barebones assembly definition will be output.
4. If it does not, then `is` overrides will be included in the definition to ensure the assembly definition perfectly reflects the nightly contents