### PR TITLE
[ART-3145] Allow git "branch" in image metadata to be hash

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -33,6 +33,7 @@ from doozerlib.model import ListModel, Missing, Model
 from doozerlib.pushd import Dir
 from doozerlib.source_modifications import SourceModifierFactory
 from doozerlib.util import convert_remote_git_to_https, yellow_print
+from doozerlib.assembly import AssemblyTypes
 
 # doozer used to be part of OIT
 OIT_COMMENT_PREFIX = '#oit##'
@@ -113,8 +114,13 @@ class DistGitRepo(object):
         self.source_date_epoch = None
         self.actual_source_url = None
         self.public_facing_source_url = None
-        # This will be set to True if the source contains embargoed (private) CVE fixes. Defaulting to None which means the value should be determined while rebasing.
+
+        # If this is a standard release, private_fix will be set to True if the source contains
+        # embargoed (private) CVE fixes. Defaulting to None which means the value should be determined while rebasing.
         self.private_fix = None
+        if self.runtime.assembly_type != AssemblyTypes.STANDARD:
+            # Only standard releases can have embargoed workflows.
+            self.private_fix = False
 
         # If we are rebasing, this map can be populated with
         # variables acquired from the source path.

--- a/tests/test_distgit/support.py
+++ b/tests/test_distgit/support.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from future import standard_library
+
+from doozerlib.assembly import AssemblyTypes
+
 standard_library.install_aliases()
 import unittest
 try:
@@ -52,6 +55,7 @@ class MockRuntime(object):
         self.mutex = SimpleMockLock()
         self.missing_pkgs = set()
         self.cache_dir = None
+        self.assembly_type = AssemblyTypes.STANDARD
 
     def detect_remote_source_branch(self, _):
         pass

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -8,6 +8,7 @@ import unittest
 import flexmock
 
 from doozerlib import distgit
+from doozerlib.assembly import AssemblyTypes
 
 
 class TestImageDistGitRepoPushImage(unittest.TestCase):
@@ -24,6 +25,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
             branch="some-branch",
             command="some-command",
             add_record=lambda *_, **__: None,
+            assembly_type=AssemblyTypes.STANDARD,
         )
 
     def test_push_image_is_late_push(self):


### PR DESCRIPTION
During custom assembly rebuilds, it is important to be able to specify specific git commit hashes instead of just branch names. This allows doozer to work with commit hashes instead of just branch names.