### PR TITLE
gen-assembly: fix rhcos config

### DIFF
--- a/doozerlib/cli/release_gen_assembly.py
+++ b/doozerlib/cli/release_gen_assembly.py
@@ -314,7 +314,9 @@ def gen_assembly_from_nightlies(ctx, runtime, nightlies, custom):
                     },
                     'group': group_info,
                     'rhcos': {
-                        'machine-os-content': mosc_by_arch
+                        'machine-os-content': {
+                            "images": mosc_by_arch,
+                        }
                     },
                     'members': {
                         'rpms': rpm_member_overrides,


### PR DESCRIPTION
Arch-specific pullspecs should be under the `images` key.