### PR TITLE
Mitigate GSSAPIAuthError

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -953,6 +953,9 @@ def images_build_image(runtime, repo_type, repo, push_to_defaults, push_to, scra
 
     if not runtime.local:
         threads = None
+        with runtime.shared_koji_client_session() as koji_api:
+            if not koji_api.logged_in:
+                koji_api.gssapi_login()
 
     # load active build profile
     profiles = runtime.group_config.build_profiles

--- a/doozerlib/cli/rpms_build.py
+++ b/doozerlib/cli/rpms_build.py
@@ -54,6 +54,10 @@ async def _rpms_rebase_and_build(runtime: Runtime, version: str, release: str, e
         for rpm in rpms:
             rpm.private_fix = True
 
+    with runtime.shared_koji_client_session() as koji_api:
+        if not koji_api.logged_in:
+            koji_api.gssapi_login()
+
     builder = RPMBuilder(runtime, dry_run=dry_run, scratch=scratch)
 
     async def _rebase_and_build(rpm: RPMMetadata):
@@ -187,6 +191,10 @@ async def _rpms_build(runtime: Runtime, scratch: bool, dry_run: bool):
     if not rpms:
         runtime.logger.error("No RPMs found. Check the arguments.")
         exit(0)
+
+    with runtime.shared_koji_client_session() as koji_api:
+        if not koji_api.logged_in:
+            koji_api.gssapi_login()
 
     builder = RPMBuilder(runtime, dry_run=dry_run, scratch=scratch)
     tasks = [asyncio.ensure_future(_build_rpm(runtime, builder, rpm)) for rpm in rpms]

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1757,7 +1757,7 @@ class ImageDistGitRepo(DistGitRepo):
             # For rebuild logic, we need to be able to prioritize repos; RHEL7 requires a plugin to be installed.
             yum_update_line = "RUN yum install -y yum-plugin-priorities && yum update -y && yum clean all"
         else:
-            yum_update_line = f"RUN yum update -y && yum clean all"
+            yum_update_line = "RUN yum update -y && yum clean all"
         output = io.StringIO()
         build_stage = 0
         for line in df_lines_iter:

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1210,17 +1210,18 @@ class ImageDistGitRepo(DistGitRepo):
                 self.logger.info("Error building image: {}, {}".format(task_url, error))
                 return False
 
-            koji_api = self.runtime.build_retrying_koji_client()
-            koji_api.gssapi_login()
-            # Unlike rpm build, koji_api.listBuilds(taskID=...) doesn't support image build. For now, let's use a different approach.
-            taskResult = koji_api.getTaskResult(task_id)
-            build_id = int(taskResult["koji_builds"][0])
-            build_info = koji_api.getBuild(build_id)
-            record["nvrs"] = build_info["nvr"]
-            if self.runtime.hotfix:
-                # Tag the image so they don't get garbage collected.
-                self.runtime.logger.info(f'Tagging {self.metadata.get_component_name()} build {build_info["nvr"]} with {self.metadata.hotfix_brew_tag()} to prevent garbage collection')
-                koji_api.tagBuild(self.metadata.hotfix_brew_tag(), build_info["nvr"])
+            with self.runtime.shared_koji_client_session() as koji_api:
+                if not koji_api.logged_in:
+                    koji_api.gssapi_login()
+                # Unlike rpm build, koji_api.listBuilds(taskID=...) doesn't support image build. For now, let's use a different approach.
+                taskResult = koji_api.getTaskResult(task_id)
+                build_id = int(taskResult["koji_builds"][0])
+                build_info = koji_api.getBuild(build_id)
+                record["nvrs"] = build_info["nvr"]
+                if self.runtime.hotfix:
+                    # Tag the image so they don't get garbage collected.
+                    self.runtime.logger.info(f'Tagging {self.metadata.get_component_name()} build {build_info["nvr"]} with {self.metadata.hotfix_brew_tag()} to prevent garbage collection')
+                    koji_api.tagBuild(self.metadata.hotfix_brew_tag(), build_info["nvr"])
 
             self.update_build_db(True, task_id=task_id, scratch=scratch)
             self.logger.info("Successfully built image: {} ; {}".format(target_image, task_url))

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -142,7 +142,7 @@ class TestRPMBuilder(unittest.TestCase):
             task_id: None for task_id in task_ids})
         mocked_cmd_gather_async.return_value = (0, "some stdout", "some stderr")
         dg.resolve_specfile_async = mock.AsyncMock(return_value=(dg.dg_path / "foo.spec", ("foo", "1.2.3", "1"), source_sha))
-        koji_api = runtime.build_retrying_koji_client.return_value
+        koji_api = runtime.shared_koji_client_session.return_value.__enter__.return_value
         koji_api.multicall.return_value.__enter__.return_value.listBuilds.side_effect = lambda taskID, completeBefore: {
             10001: mock.MagicMock(result=[{"nvr": "foo-1.2.3-1.el8"}]),
             10002: mock.MagicMock(result=[{"nvr": "foo-1.2.3-1.el7"}]),


### PR DESCRIPTION
`koji.GSSAPIAuthError: unable to obtain a session` still occurs very frequently
after applying https://github.com/openshift/doozer/commit/0436b546a2bfabf2ab3bcba9916ea13f3e9a9b99.

This PR proposes a workaround by calling `gssapi_login` on `runtime.shared_koji_client_session`
before we build any image or rpm. This would significantly reduce the number of `gssapi_login` calls
in one doozer invocation. Even if `gssapi_login` fails in the first call, it fails earlier.