### PR TITLE
[ART-3241] Build basis locked assemblies artifacts from their lastet build's upstream commit

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -17,7 +17,6 @@ from typing import Tuple
 
 import aiofiles
 import bashlex
-from kobo.rpmlib import parse_nvr
 import requests
 import yaml
 from dockerfile_parse import DockerfileParser
@@ -2260,7 +2259,7 @@ class ImageDistGitRepo(DistGitRepo):
 
     def _run_modifications(self):
         """
-        Interprets and applies content.source.modify steps in the image metadata.
+        Interprets and applies content.source.modifications steps in the image metadata.
         """
         dg_path = self.dg_path
         df_path = dg_path.joinpath('Dockerfile')

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -1,20 +1,16 @@
 import glob
 import io
 import os
-import re
-import shutil
 import threading
-import traceback
-from typing import List, Optional
+from typing import List, Dict, Optional, Union
 
 import rpm
 
-from doozerlib import brew, constants, util
+from doozerlib import brew, util
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.source_modifications import SourceModifierFactory
 
 from . import exectools
-from .brew import watch_tasks
 from .metadata import Metadata
 from .model import Missing
 from .pushd import Dir

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -2,6 +2,7 @@ import copy
 import os
 import pathlib
 import re
+import urllib.parse
 from collections import deque
 from contextlib import contextmanager
 from datetime import datetime
@@ -355,6 +356,20 @@ def get_docker_config_json(config_dir):
         return abspath(os.path.join(config_dir, 'config.json'))
     else:
         raise FileNotFoundError("Can not find the registry config file in {}".format(config_dir))
+
+
+def isolate_git_commit_in_release(release: str) -> Optional[str]:
+    """
+    Given a release field, determines whether is contains
+    .git.<commit> information. If it does, it returns the value
+    of <commit>. If it is not found, None is returned.
+    """
+    match = re.match(r'.*\.git\.([a-f0-9]+)(?:\.+|$)', release)
+
+    if match:
+        return match.group(1)
+
+    return None
 
 
 def isolate_pflag_in_release(release: str) -> Optional[str]:

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import unittest
+import io
 from pathlib import Path
 
 import mock
@@ -17,9 +18,12 @@ class TestRPMBuilder(unittest.TestCase):
 
     def _make_runtime(self, assembly=None):
         runtime = mock.MagicMock()
-        runtime.group_config.public_upstreams = [{"private": "https://github.com/openshift-priv", "puiblic": "https://github.com/openshift"}]
+        runtime.group_config.public_upstreams = [{"private": "https://github.com/openshift-priv", "public": "https://github.com/openshift"}]
         runtime.brew_logs_dir = "/path/to/brew-logs"
         runtime.assembly = assembly
+        stream = io.StringIO()
+        logging.basicConfig(level=logging.INFO, stream=stream)
+        runtime.logger = logging.getLogger()
         return runtime
 
     def _make_rpm_meta(self, runtime, source_sha, distgit_sha):


### PR DESCRIPTION
When you define an assembly with a basis event and you rebuild an image for it, during the rebase, it will use the upstream commit for the latest image in the assembly according to the basis event.

In other words, if you define a release 4.7.22 with a basis event, then when you run the rebuild job for ose-etcd, it will rebase using the upstream commit used by the latest build for the assembly/basis event. 

Similarly, if you create a derivative assembly `art1999` which uses 4.7.22 as its basis, rebuilding ose-etcd will rebase using the upstream commit for the latest build of the 4.7.22 assembly.

If this is not what you want, you will need to pin the exact committish you want in the assembly definition for the component. 