### PR TITLE
Turn git commit into a parsable yaml document

### DIFF
--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -136,7 +136,11 @@ class AssemblyInspector:
                     # Make sure things are in https form so we can compare
                     # content_git_url = util.convert_remote_git_to_https(content_git_url)
 
-                    # TODO: Download spec file associated with the build and verify SOURCE_GIT_URL
+                    # TODO: The commit in which this comment is introduced also introduces
+                    # machine parsable yaml documents into distgit commits. Once this code
+                    # has been running for our active 4.x releases for some time,
+                    # we should check the distgit commit info against the git.url
+                    # in our metadata.
 
                     try:
                         target_branch = rpm_meta.config.content.source.git.branch.target

--- a/doozerlib/exectools.py
+++ b/doozerlib/exectools.py
@@ -123,7 +123,7 @@ cmd_counter_lock = threading.Lock()
 cmd_counter = 0  # Increments atomically to help search logs for command start/stop
 
 
-def cmd_gather(cmd, set_env=None, realtime=False, strip=False, log_stdout=False, log_stderr=True) -> Tuple[int, str, str]:
+def cmd_gather(cmd: Union[str, List], set_env: Optional[Dict[str, str]] = None, realtime=False, strip=False, log_stdout=False, log_stderr=True) -> Tuple[int, str, str]:
     """
     Runs a command and returns rc,stdout,stderr as a tuple.
 

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -166,7 +166,13 @@ class RPMBuilder:
         logging.info("Committing distgit changes...")
         await aiofiles.os.remove(tarball_path)
         commit_hash = await exectools.to_thread(dg.commit,
-                                                f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}]."
+                                                f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].",
+                                                commit_attributes={
+                                                    'version': rpm.version,
+                                                    'release': rpm.release,
+                                                    'io.openshift.build.commit.id': rpm.pre_init_sha,
+                                                    'io.openshift.build.source-location': rpm.public_upstream_url,
+                                                }
                                                 )
 
         if self._push:

--- a/tests/test_distgit/test_generic_distgit.py
+++ b/tests/test_distgit/test_generic_distgit.py
@@ -491,7 +491,7 @@ class TestGenericDistGit(TestDistgit):
 
         expected_2nd_cmd = [
             "git", "commit", "--allow-empty", "-m",
-            "commit msg - my-source-sha\n- MaxFileSize: 100000000"]
+            "# commit msg\nMaxFileSize: 104857600\njenkins.url: null\n"]
 
         (flexmock(distgit.exectools)
          .should_receive("cmd_assert")
@@ -533,7 +533,7 @@ class TestGenericDistGit(TestDistgit):
 
         expected_2nd_cmd = [
             "git", "commit", "--allow-empty", "-m",
-            "commit msg\n- MaxFileSize: 100000000"]
+            "# commit msg\nMaxFileSize: 104857600\njenkins.url: null\n"]
 
         (flexmock(distgit.exectools)
          .should_receive("cmd_assert")

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -90,7 +90,13 @@ class TestRPMBuilder(unittest.TestCase):
         mocked_copy.assert_any_call(Path(rpm.source_path) / "a.diff", dg.dg_path / "a.diff", follow_symlinks=False)
         mocked_copy.assert_any_call(Path(rpm.source_path) / "b/c.diff", dg.dg_path / "b/c.diff", follow_symlinks=False)
         rpm._run_modifications.assert_called_once_with(dg.dg_path / "foo.spec", dg.dg_path)
-        dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].")
+        dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].",
+                                          commit_attributes={
+                                              'version': '1.2.3',
+                                              'release': '202104070000.test.p0.git.3f17b42',
+                                              'io.openshift.build.commit.id': '3f17b42b8aa7d294c0d2b6f946af5fe488f3a722',
+                                              'io.openshift.build.source-location': None}
+                                          )
         dg.push_async.assert_called_once()
 
     @mock.patch("doozerlib.rpm_builder.Path.mkdir")
@@ -124,7 +130,12 @@ class TestRPMBuilder(unittest.TestCase):
         mocked_copy.assert_any_call(Path(rpm.source_path) / "a.diff", dg.dg_path / "a.diff", follow_symlinks=False)
         mocked_copy.assert_any_call(Path(rpm.source_path) / "b/c.diff", dg.dg_path / "b/c.diff", follow_symlinks=False)
         rpm._run_modifications.assert_called_once_with(dg.dg_path / "foo.spec", dg.dg_path)
-        dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].")
+        dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].",
+                                          commit_attributes={
+                                              'version': '1.2.3',
+                                              'release': '202104070000.test.p0.git.3f17b42.assembly.tester',
+                                              'io.openshift.build.commit.id': '3f17b42b8aa7d294c0d2b6f946af5fe488f3a722',
+                                              'io.openshift.build.source-location': None})
         dg.push_async.assert_called_once()
 
     @mock.patch("doozerlib.rpm_builder.exectools.cmd_gather_async")


### PR DESCRIPTION
This will allow our automation to be able to detect source and commit
information without having to parse RPM spec files.