### PR TITLE
[ART-3069] olm-bundle assembly awareness

### DIFF
--- a/doozerlib/brew.py
+++ b/doozerlib/brew.py
@@ -441,6 +441,7 @@ class KojiWrapper(koji.ClientSession):
         'listArchives',
         'listRPMs',
         'getPackage',
+        'getPackageID',
         'listTags',
         'gssapi_login',
         'sslLogin',

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -873,6 +873,7 @@ class ImageDistGitRepo(DistGitRepo):
             "task_url": "n/a",
             "status": -1,
             "push_status": -1,
+            "has_olm_bundle": 1 if self.config['update-csv'] is not Missing else 0,
             # Status defaults to failure until explicitly set by success. This handles raised exceptions.
         }
 

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, unicode_literals
+from multiprocessing.pool import MapResult
 from future import standard_library
 standard_library.install_aliases()
 from future.utils import as_native_str
@@ -1475,14 +1476,14 @@ class Runtime(object):
             self.all_metas(),
             n_threads=n_threads)
 
-    def parallel_exec(self, f, args, n_threads=None):
+    def parallel_exec(self, f, args, n_threads=None) -> MapResult:
         """
         :param f: A function to invoke for all arguments
         :param args: A list of argument tuples. Each tuple will be used to invoke the function once.
         :param n_threads: preferred number of threads to use during the work
         :return:
         """
-        n_threads = n_threads if n_threads is not None else len(args)
+        n_threads = n_threads if n_threads is not None else max(len(args), 1)
         terminate_event = threading.Event()
         pool = ThreadPool(n_threads)
         # Python 3 doesn't allow to unpack tuple argument in a lambdas or functions (PEP-3113).

--- a/tests/test_olm_bundle.py
+++ b/tests/test_olm_bundle.py
@@ -1,14 +1,17 @@
 import unittest
+
 import flexmock
+from mock import MagicMock
+
 from doozerlib.olm.bundle import OLMBundle
 
 
 class TestOLMBundle(unittest.TestCase):
 
     def test_get_bundle_image_name_no_ose_prefix(self):
-        obj = flexmock(OLMBundle(None), bundle_name='foo')
+        obj = flexmock(OLMBundle(None, dry_run=False, brew_session=MagicMock()), bundle_name='foo')
         self.assertEqual(obj.get_bundle_image_name(), 'openshift/ose-foo')
 
     def test_get_bundle_image_name_with_ose_prefix(self):
-        obj = flexmock(OLMBundle(None), bundle_name='ose-foo')
+        obj = flexmock(OLMBundle(None, dry_run=False, brew_session=MagicMock()), bundle_name='ose-foo')
         self.assertEqual(obj.get_bundle_image_name(), 'openshift/ose-foo')


### PR DESCRIPTION
1. Currently `olm-bundle:rebase` and `olm-bundle:rebase-and-build` verbs
   require explicitly passing operator NVRs via command line arguments.
This PR keeps this behavior but also allows to run those verbs without
operator NVRs. In this case, operator NVRs selected by the runtime
assembly will be used for bundle builds.

2. Improve debug and troubleshoot capability by adding more logs and writing build related info to `record.log`.

3. Patch `images:build` to write `has_olm_bundle` field to `record.log`. This makes it easier to run `olm-bundle` verbs from Jenkins jobs by filtering image builds with OLM bundles.

4. Honor `--upcycle` and `--dry-run` options for better testing.