### PR TITLE
Fix image build error when assembly has a basis event

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1580,7 +1580,7 @@ class ImageDistGitRepo(DistGitRepo):
                             parent_build_info = build_model.extra.image.parent_image_builds[tag_pullspec]
                             if parent_build_info is Missing:
                                 raise IOError(f'Unable to resolve parent {target_parent_name} in {latest_build} for {assembly_msg}; tried {tag_pullspec}')
-                            parent_build_nvr = parse_nvr(parent_build_info._nvr)
+                            parent_build_nvr = parse_nvr(parent_build_info.nvr)
                             # Hang in there.. this is a long dance. Now that we know the NVR, we can construct
                             # a truly unique pullspec.
                             if '@' in tag_pullspec:


### PR DESCRIPTION
Fixes

```
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Fcustom/art-tools/doozer/doozerlib/cli/__main__.py", line 557, in dgr_rebase
    (real_version, real_release) = dgr.rebase_dir(version, release, terminate_event, force_yum_updates)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Fcustom/art-tools/doozer/doozerlib/distgit.py", line 2402, in rebase_dir
    real_version, real_release = self.update_distgit_dir(version, release, prev_release, force_yum_updates)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Fcustom/art-tools/doozer/doozerlib/distgit.py", line 1582, in update_distgit_dir
    parent_build_nvr = parse_nvr(parent_build_info._nvr)
  File "/home/jenkins/.local/lib/python3.6/site-packages/kobo/rpmlib.py", line 194, in parse_nvr
    nvr_parts = nvr.rsplit("-", 2)
TypeError: 'MissingModel' object is not callable
2021-08-24 04:13:43,922 ERROR [containers/openshift-kubernetes-nmstate-operator] 'MissingModel' object is not callable
```

The field name is `nvr` instead of `_nvr`.