### PR TITLE
ART-3278: Request a rebuild if its dependency is newer

### DIFF
--- a/doozerlib/cli/scan_sources.py
+++ b/doozerlib/cli/scan_sources.py
@@ -1,12 +1,13 @@
-from pathlib import Path
+from datetime import datetime, timezone
 
 import click
 import yaml
 
-from doozerlib import brew, exectools, rhcos
+from doozerlib import brew, exectools, rhcos, util
 from doozerlib.cli import cli, pass_runtime
 from doozerlib.cli import release_gen_payload as rgp
 from doozerlib.metadata import RebuildHint, RebuildHintCode
+from doozerlib.runtime import Runtime
 
 
 @cli.command("config:scan-sources", short_help="Determine if any rpms / images need to be rebuilt.")
@@ -14,7 +15,7 @@ from doozerlib.metadata import RebuildHint, RebuildHintCode
               help="File containing kubeconfig for looking at release-controller imagestreams")
 @click.option("--yaml", "as_yaml", default=False, is_flag=True, help='Print results in a yaml block')
 @pass_runtime
-def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
+def config_scan_source_changes(runtime: Runtime, ci_kubeconfig, as_yaml):
     """
     Determine if any rpms / images need to be rebuilt.
 
@@ -109,30 +110,50 @@ def config_scan_source_changes(runtime, ci_kubeconfig, as_yaml):
         newest_image_event_ts = 0
         for image_meta in runtime.image_metas():
             info = image_meta.get_latest_build(default=None)
-            if info is not None:
+            if info is None:
+                continue
+            create_event_ts = koji_api.getEvent(info['creation_event_id'])['ts']
+            if oldest_image_event_ts is None or create_event_ts < oldest_image_event_ts:
+                oldest_image_event_ts = create_event_ts
+            if create_event_ts > newest_image_event_ts:
+                newest_image_event_ts = create_event_ts
 
-                # If no upstream change has been detected, check configurations
-                # like image meta, repos, and streams to see if they have changed
-                # We detect config changes by comparing their digest changes.
-                # The config digest of the previous build is stored at .oit/config_digest on distgit repo.
-                try:
-                    source_url = info['source']  # git://pkgs.devel.redhat.com/containers/atomic-openshift-descheduler#6fc9c31e5d9437ac19e3c4b45231be8392cdacac
-                    source_commit = source_url.split('#')[1]  # isolate the commit hash
-                    # Look at the digest that created THIS build. What is in head does not matter.
-                    prev_digest = image_meta.fetch_cgit_file('.oit/config_digest', commit_hash=source_commit).decode('utf-8')
-                    current_digest = image_meta.calculate_config_digest(runtime.group_config, runtime.streams)
-                    if current_digest.strip() != prev_digest.strip():
-                        runtime.logger.info('%s config_digest %s is differing from %s', dgk, prev_digest, current_digest)
-                        add_image_meta_change(image_meta, RebuildHint(RebuildHintCode.CONFIG_CHANGE, 'Metadata configuration change'))
-                except exectools.RetryException:
-                    runtime.logger.info('%s config_digest cannot be retrieved; request a build', dgk)
-                    add_image_meta_change(image_meta, RebuildHint(RebuildHintCode.CONFIG_CHANGE, 'Unable to retrieve config_digest'))
+            if image_meta in changing_image_metas:
+                continue  # A rebuild is already requested.
 
-                create_event_ts = koji_api.getEvent(info['creation_event_id'])['ts']
-                if oldest_image_event_ts is None or create_event_ts < oldest_image_event_ts:
-                    oldest_image_event_ts = create_event_ts
-                if create_event_ts > newest_image_event_ts:
-                    newest_image_event_ts = create_event_ts
+            # Request a rebuild if A is a dependent of B but the latest build of A is older than B.
+            rebase_time = datetime.strptime(util.isolate_timestamp_in_release(info["release"]), "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+            for dep_key in image_meta.dependencies:
+                dep = runtime.image_map.get(dep_key)
+                if not dep:
+                    runtime.logger.warning("Image %s has unknown dependency %s. Is it excluded?", image_meta.distgit_key, dep_key)
+                    continue
+                dep_info = dep.get_latest_build(default=None)
+                if not dep_info:
+                    continue
+                dep_rebase_time = datetime.strptime(util.isolate_timestamp_in_release(dep_info["release"]), "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+                if dep_rebase_time > rebase_time:
+                    add_image_meta_change(image_meta, RebuildHint(RebuildHintCode.DEPENDENCY_NEWER, 'Dependency has a newer build'))
+
+            if image_meta in changing_image_metas:
+                continue  # A rebuild is already requested.
+
+            # If no upstream change has been detected, check configurations
+            # like image meta, repos, and streams to see if they have changed
+            # We detect config changes by comparing their digest changes.
+            # The config digest of the previous build is stored at .oit/config_digest on distgit repo.
+            try:
+                source_url = info['source']  # git://pkgs.devel.redhat.com/containers/atomic-openshift-descheduler#6fc9c31e5d9437ac19e3c4b45231be8392cdacac
+                source_commit = source_url.split('#')[1]  # isolate the commit hash
+                # Look at the digest that created THIS build. What is in head does not matter.
+                prev_digest = image_meta.fetch_cgit_file('.oit/config_digest', commit_hash=source_commit).decode('utf-8')
+                current_digest = image_meta.calculate_config_digest(runtime.group_config, runtime.streams)
+                if current_digest.strip() != prev_digest.strip():
+                    runtime.logger.info('%s config_digest %s is differing from %s', dgk, prev_digest, current_digest)
+                    add_image_meta_change(image_meta, RebuildHint(RebuildHintCode.CONFIG_CHANGE, 'Metadata configuration change'))
+            except exectools.RetryException:
+                runtime.logger.info('%s config_digest cannot be retrieved; request a build', dgk)
+                add_image_meta_change(image_meta, RebuildHint(RebuildHintCode.CONFIG_CHANGE, 'Unable to retrieve config_digest'))
 
     runtime.logger.debug(f'Will be assessing tagging changes between newest_image_event_ts:{newest_image_event_ts} and oldest_image_event_ts:{oldest_image_event_ts}')
     change_results = runtime.parallel_exec(

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -66,6 +66,7 @@ class RebuildHintCode(Enum):
     BUILD_ROOT_CHANGING = (True, 12)
     PACKAGE_CHANGE = (True, 13)
     ARCHES_CHANGE = (True, 14)
+    DEPENDENCY_NEWER = (True, 15)
 
 
 class RebuildHint(NamedTuple):

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -606,9 +606,10 @@ class Runtime(object):
 
             if mode in ['images', 'both']:
                 for i in image_data.values():
-                    metadata = ImageMetadata(self, i, self.upstream_commitish_overrides.get(i.key), clone_source=clone_source, prevent_cloning=prevent_cloning)
-                    self.image_map[metadata.distgit_key] = metadata
-                    self.component_map[metadata.get_component_name()] = metadata
+                    if i.key not in self.image_map:
+                        metadata = ImageMetadata(self, i, self.upstream_commitish_overrides.get(i.key), clone_source=clone_source, prevent_cloning=prevent_cloning)
+                        self.image_map[metadata.distgit_key] = metadata
+                        self.component_map[metadata.get_component_name()] = metadata
                 if not self.image_map:
                     self.logger.warning("No image metadata directories found for given options within: {}".format(self.group_dir))
 
@@ -1021,6 +1022,7 @@ class Runtime(object):
         meta = ImageMetadata(self, data_obj, self.upstream_commitish_overrides.get(data_obj.key))
         if add:
             self.image_map[distgit_name] = meta
+        self.component_map[meta.get_component_name()] = meta
         return meta
 
     def resolve_brew_image_url(self, image_name_and_version):

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -620,3 +620,21 @@ def strip_epoch(nvr: str):
     returns NVR exactly as-is.
     """
     return nvr.split(':')[0]
+
+
+def isolate_timestamp_in_release(release: str) -> Optional[str]:
+    """
+    Given a release field, determines whether is contains
+    a timestamp. If it does, it returns the timestamp.
+    If it is not found, None is returned.
+    """
+    match = re.search(r"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})", release)  # yyyyMMddHHmm
+    if match:
+        year = int(match.group(1))
+        month = int(match.group(2))
+        day = int(match.group(3))
+        hour = int(match.group(4))
+        minute = int(match.group(5))
+        if year >= 2000 and month >= 1 and month <= 12 and day >= 1 and day <= 31 and hour <= 23 and minute <= 59:
+            return match.group(0)
+    return None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -135,6 +135,35 @@ class TestUtil(unittest.TestCase):
         actual = util.find_latest_builds(builds, None)
         self.assertEqual([13, 23, 33], [b["id"] for b in actual])
 
+    def test_isolate_timestamp_in_release(self):
+        actual = util.isolate_timestamp_in_release("foo-4.7.0-202107021813.p0.git.01c9f3f.el8")
+        expected = "202107021813"
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.git.8b4b094")
+        expected = "202107021907"
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.git.8b4b094")
+        expected = "202107021907"
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.8.0-202106152230.p0.git.25122f5.assembly.stream")
+        expected = "202106152230"
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-1.p0.git.8b4b094")
+        expected = None
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202199999999.p0.git.8b4b094")
+        expected = None
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("")
+        expected = None
+        self.assertEqual(actual, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Currently if image A is a dependent of B and B is changing, a rebuild of A will be requested as well. However, if the rebuild of B is successful but rebuild of A is failed, Doozer will not request a rebuild of A again.