### PR TITLE
assembly.py: permits should be a list

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -283,7 +283,7 @@ def assembly_permits(releases_config: Model, assembly: typing.Optional[str]) -> 
     permits are defined ListModel([]) is returned.
     """
 
-    defined_permits = _assembly_config_struct(releases_config, assembly, 'permits', {})
+    defined_permits = _assembly_config_struct(releases_config, assembly, 'permits', [])
 
     if not defined_permits and (assembly == 'stream' or not assembly):  # If assembly is None, this a group without assemblies enabled
         # TODO: Address this formally with https://issues.redhat.com/browse/ART-3162 .


### PR DESCRIPTION
```
ERROR: failed shell command: doozer --assembly=fc.1 --working-dir... 'openshift-4.9' release:gen-payload
with rc=1 and output:
[...see full archive #8...]
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Fbuild-sync/art-tools/doozer/doozerlib/assembly.py", line 234, in _assembly_config_struct
    return Model(dict_to_model=key_struct)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Fbuild-sync/art-tools/doozer/doozerlib/model.py", line 127, in __init__
    for k, v in dict_to_model.items():
AttributeError: 'list' object has no attribute 'items'

Finished: FAILURE
```