### PR TITLE
release_gen_payload: fix default_imagestream_base_name usage

### DIFF
--- a/tests/test_rhcos.py
+++ b/tests/test_rhcos.py
@@ -95,6 +95,7 @@ class TestRhcos(unittest.TestCase):
         # Data source: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/?stream=releases/rhcos-4.7-s390x&release=47.83.202107261211-0#47.83.202107261211-0
         rhcos_meta = json.loads(self.respath.joinpath('rhcos1', '47.83.202107261211-0.meta.json').read_text())
         rhcos_commitmeta = json.loads(self.respath.joinpath('rhcos1', '47.83.202107261211-0.commitmeta.json').read_text())
+        # NOTE: loading and parsing these fixtures can take a few seconds, no cause for concern
         rpm_defs = yaml.safe_load(self.respath.joinpath('rhcos1', '47.83.202107261211-0.rpm_defs.yaml').read_text())
         pkg_build_dicts = yaml.safe_load(self.respath.joinpath('rhcos1', '47.83.202107261211-0.pkg_builds.yaml').read_text())
 

--- a/tests/test_rhcos.py
+++ b/tests/test_rhcos.py
@@ -9,6 +9,7 @@ import os
 import yaml
 from pathlib import Path
 from unittest.mock import patch, MagicMock, Mock
+from urllib.error import URLError
 
 from doozerlib import rhcos
 from doozerlib.model import Model
@@ -68,6 +69,12 @@ class TestRhcos(unittest.TestCase):
         _urlopen_json_cm(mock_urlopen, dict(builds=[]))
         self.assertIsNone(rhcos.RHCOSBuildFinder(self.runtime, "4.2", "ppc64le")._latest_rhcos_build_id())
         self.assertIn('/rhcos-4.2-ppc64le/', mock_urlopen.call_args_list[1][0][0])
+
+    @patch('urllib.request.urlopen')
+    def test_build_find_failure(self, mock_urlopen):
+        mock_urlopen.side_effect = URLError("test")
+        with self.assertRaises(rhcos.RHCOSNotFound):
+            rhcos.RHCOSBuildFinder(self.runtime, "4.9")._latest_rhcos_build_id()
 
     @patch('doozerlib.rhcos.RHCOSBuildFinder.latest_rhcos_build_id')
     @patch('doozerlib.rhcos.RHCOSBuildFinder.rhcos_build_meta')


### PR DESCRIPTION
this method changed signature. scan_sources was using the previous
signature and began silently failing, causing it not to detect that
rhcos has an update.

the usage of rhcos.latest_rhcos_build_id also changed out from under
scan_sources - fixed.