### PR TITLE
ART-3107 Change operator channel names to stable (4.10)

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -560,13 +560,14 @@ class OLMBundle(object):
 
     @property
     def operator_framework_tags(self):
-        version = '{MAJOR}.{MINOR}'.format(**self.runtime.group_config.vars)
         override_channel = self.channel
         override_default = self.channel
-        # wip see: issues.redhat.com/browse/ART-3107
-        if version == '4.10':
-            override_channel = f'{self.channel},stable'
-            override_default = 'stable'
+        stable_channel = 'stable'
+
+        # see: issues.redhat.com/browse/ART-3107
+        if self.runtime.group_config.operator_channel_stable:
+            override_channel = ','.join([self.channel, stable_channel])
+            override_default = stable_channel
 
         return {
             'operators.operatorframework.io.bundle.channel.default.v1': override_default,

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -566,7 +566,7 @@ class OLMBundle(object):
 
         # see: issues.redhat.com/browse/ART-3107
         if self.runtime.group_config.operator_channel_stable:
-            override_channel = ','.join([self.channel, stable_channel])
+            override_channel = ','.join({self.channel, stable_channel})
             override_default = stable_channel
 
         return {

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -561,8 +561,8 @@ class OLMBundle(object):
     @property
     def operator_framework_tags(self):
         return {
-            'operators.operatorframework.io.bundle.channel.default.v1': self.channel,
-            'operators.operatorframework.io.bundle.channels.v1': self.channel,
+            'operators.operatorframework.io.bundle.channel.default.v1': 'stable',
+            'operators.operatorframework.io.bundle.channels.v1': f'{self.channel},stable',
             'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
             'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
             'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -560,9 +560,17 @@ class OLMBundle(object):
 
     @property
     def operator_framework_tags(self):
+        version = '{MAJOR}.{MINOR}'.format(**self.runtime.group_config.vars)
+        override_channel = self.channel
+        override_default = self.channel
+        # wip see: issues.redhat.com/browse/ART-3107
+        if version == '4.10':
+            override_channel = f'{self.channel},stable'
+            override_default = 'stable'
+
         return {
-            'operators.operatorframework.io.bundle.channel.default.v1': 'stable',
-            'operators.operatorframework.io.bundle.channels.v1': f'{self.channel},stable',
+            'operators.operatorframework.io.bundle.channel.default.v1': override_default,
+            'operators.operatorframework.io.bundle.channels.v1': override_channel,
             'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
             'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
             'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-3107

Test run:
./doozer --assembly=test -g openshift-4.10 olm-bundle:rebase-and-build --force sriov-network-operator-container-v4.10.0-202109150958.p0.git.5e1261d.assembly.stream

Changes visible at
- https://pkgs.devel.redhat.com/cgit/containers/sriov-network-operator-bundle/tree/metadata/annotations.yaml?h=rhaos-4.10-rhel-8
- https://pkgs.devel.redhat.com/cgit/containers/sriov-network-operator-bundle/tree/Dockerfile?h=rhaos-4.10-rhel-8
