### PR TITLE
config:read-group does not do unecessary assembly calculations

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1467,7 +1467,9 @@ CONFIG_RUNTIME_OPTS = {
     'mode': 'both',           # config wants it all
     'clone_distgits': False,  # no need, just doing config
     'clone_source': False,    # no need, just doing config
-    'disabled': True          # show all, including disabled/wip
+    'disabled': True,         # show all, including disabled/wip
+    'prevent_cloning': True,  # raise exception is somehow we try to clone
+    'config_only': True       # only initialize config and nothing else
 }
 
 
@@ -1563,7 +1565,7 @@ def config_read_group(runtime, key, as_len, as_yaml, permit_missing_group, defau
     """
     _fix_runtime_mode(runtime)
     try:
-        runtime.initialize(no_group=False, **CONFIG_RUNTIME_OPTS)
+        runtime.initialize(**CONFIG_RUNTIME_OPTS)
     except gitdata.GitDataException:
         # This may happen if someone if trying to get data for a branch that does not exist.
         # This may be perfectly OK if they are just trying to check the next minor's branch,

--- a/doozerlib/dblib.py
+++ b/doozerlib/dblib.py
@@ -478,17 +478,20 @@ class Record(object):
         return self
 
     def __exit__(self, *args):
-        with self.db.runtime.get_named_semaphore('dblib::mysql'):
+        try:
+            with self.db.runtime.get_named_semaphore('dblib::mysql'):
 
-            attr_payload = {}
+                attr_payload = {}
 
-            for k, v in self.attrs.items():
+                for k, v in self.attrs.items():
 
-                if v is None or v is Missing or v == '':
-                    continue
-                else:
-                    attr_payload[self.db.rename_to_valid_column(k)] = v
-            self.db.create_payload_entry(attr_payload, self.table, self.dry_run)
+                    if v is None or v is Missing or v == '':
+                        continue
+                    else:
+                        attr_payload[self.db.rename_to_valid_column(k)] = v
+                self.db.create_payload_entry(attr_payload, self.table, self.dry_run)
+        except:
+            self.logger.warning("Cannot connect to the DB")
 
         self._tl.record = self.previous_record
 

--- a/doozerlib/dblib.py
+++ b/doozerlib/dblib.py
@@ -491,7 +491,7 @@ class Record(object):
                         attr_payload[self.db.rename_to_valid_column(k)] = v
                 self.db.create_payload_entry(attr_payload, self.table, self.dry_run)
         except:
-            self.logger.warning("Cannot connect to the DB")
+            pass
 
         self._tl.record = self.previous_record
 

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -317,7 +317,7 @@ class Runtime(object):
     def initialize(self, mode='images', clone_distgits=True,
                    validate_content_sets=False,
                    no_group=False, clone_source=None, disabled=None,
-                   prevent_cloning: bool = False):
+                   prevent_cloning: bool = False, config_only: bool = False):
 
         if self.initialized:
             return
@@ -450,6 +450,10 @@ class Runtime(object):
             replace_vars = self.group_config.vars.primitive()
         if self.assembly:
             replace_vars['runtime_assembly'] = self.assembly
+
+        # only initialize group and assembly configs and nothing else
+        if config_only:
+            return
 
         # Read in the streams definition for this group if one exists
         streams_data = self.gitdata.load_data(key='streams', replace_vars=replace_vars)

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -384,7 +384,11 @@ class Runtime(object):
 
         self.init_state()
 
-        self.db = dblib.DB(self, self.datastore)
+        try:
+            self.db = dblib.DB(self, self.datastore)
+        except:
+            self.logger.warning('Cannot connect to the DB')
+
         self.logger.info(f'Initial execution (cwd) directory: {os.getcwd()}')
 
         if no_group:


### PR DESCRIPTION
When running a config command, we don't need assembly initialization for all components. This helps speed up the command when we run as part of our jobs, as well as reduce flaky failures (mysql connection errors).

Edit: also add try/catch calls to DB, so we don't fail when DB is unreacheable for any reason.

Test run:
`./doozer --assembly=4.7.33 --group openshift-4.7 config:read-group advisories --yaml`