### PR TITLE
ART-3107 Differentiate between default and extra channel stable mode

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -565,8 +565,9 @@ class OLMBundle(object):
         stable_channel = 'stable'
 
         # see: issues.redhat.com/browse/ART-3107
-        if self.runtime.group_config.operator_channel_stable:
+        if self.runtime.group_config.operator_channel_stable in ['default', 'extra']:
             override_channel = ','.join({self.channel, stable_channel})
+        if self.runtime.group_config.operator_channel_stable == 'default':
             override_default = stable_channel
 
         return {


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-3107
Follow up from https://github.com/openshift/doozer/pull/521

We need 3 modes for group.yml key `operator_channel_stable` as per OCP version:
- for ocp versions we want no change in, the key will simply be absent
- for ocp versions we want to have "stable" as only a regular publish channel - "extra"
- for ocp versions we want to have "stable" as a default publish channel - "default"