### PR TITLE
[ART-3109] Use container.yaml to apply floating tags

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
-		"ms-python.vscode-pylance",
+		"ms-python.python",
 		"eamodio.gitlens"
 	]
 }

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -54,7 +54,7 @@ CONTAINER_YAML_HEADER = """
 
 # Always ignore these files/folders when rebasing into distgit
 # May be added to based on group/image config
-BASE_IGNORE = [".git", ".oit", "additional-tags"]
+BASE_IGNORE = [".git", ".oit"]
 
 logger = logutil.getLogger(__name__)
 
@@ -446,12 +446,12 @@ class ImageDistGitRepo(DistGitRepo):
 
         return build_method
 
-    def _write_osbs_image_config(self):
+    def _write_osbs_image_config(self, version: str):
         # Writes OSBS image config (container.yaml).
         # For more info about the format, see https://osbs.readthedocs.io/en/latest/users.html#image-configuration.
 
         self.logger.info('Generating container.yaml')
-        container_config = self._generate_osbs_image_config()
+        container_config = self._generate_osbs_image_config(version)
 
         if 'compose' in container_config:
             self.logger.info("Rebasing with ODCS support")
@@ -463,7 +463,7 @@ class ImageDistGitRepo(DistGitRepo):
         with self.dg_path.joinpath('container.yaml').open('w', encoding="utf-8") as rc:
             rc.write(CONTAINER_YAML_HEADER + content_yml)
 
-    def _generate_osbs_image_config(self):
+    def _generate_osbs_image_config(self, version: str) -> Dict:
         """
         Generates OSBS image config (container.yaml).
         Returns a dict for the config.
@@ -514,6 +514,23 @@ class ImageDistGitRepo(DistGitRepo):
 
         if arches:
             config_overrides.setdefault('platforms', {})['only'] = arches
+
+        # Request OSBS to apply specified tags to the newly-built image as floating tags.
+        # See https://osbs.readthedocs.io/en/latest/users.html?highlight=tags#image-tags
+        #
+        # Include the UUID in the tags. This will allow other images being rebased
+        # to have a known tag to refer to this image if they depend on it - even
+        # before it is built.
+        floating_tags = {"latest", f"{version}.{self.runtime.uuid}"}
+        if self.runtime.assembly:
+            floating_tags.add(f"assembly.{self.runtime.assembly}")
+        vsplit = version.split(".")  # Split the version number: v4.3.4 => [ 'v4', '3, '4' ]
+        if len(vsplit) > 1:
+            floating_tags.add(f"{vsplit[0]}.{vsplit[1]}")
+        if self.metadata.config.additional_tags:
+            floating_tags |= set(self.metadata.config.additional_tags)
+        if floating_tags:
+            config_overrides["tags"] = list(floating_tags)
 
         if not self.runtime.group_config.doozer_feature_gates.odcs_enabled and not self.runtime.odcs_mode:
             # ODCS mode is not enabled
@@ -1423,8 +1440,6 @@ class ImageDistGitRepo(DistGitRepo):
 
             self._generate_config_digest()
 
-            self._write_osbs_image_config()
-
             self._write_cvp_owners()
 
             dfp = DockerfileParser(path=str(dg_path.joinpath('Dockerfile')))
@@ -1443,6 +1458,8 @@ class ImageDistGitRepo(DistGitRepo):
                     else:
                         DoozerFatalError("No version found in Dockerfile for %s" % self.metadata.qualified_name)
 
+            self._write_osbs_image_config(version)
+
             uuid_tag = "%s.%s" % (version, self.runtime.uuid)
 
             # Split the version number v4.3.4 => [ 'v4', '3, '4' ]
@@ -1452,20 +1469,6 @@ class ImageDistGitRepo(DistGitRepo):
             # Click validation should have ensured user specified semver, but double check because of version=None flow.
             minor_version = '0' if len(vsplit) < 2 else vsplit[1]
             patch_version = '0' if len(vsplit) < 3 else vsplit[2]
-
-            if not self.runtime.local:
-                with dg_path.joinpath('additional-tags').open('w', encoding="utf-8") as at:
-                    # Include the UUID in the tags. This will allow other images being rebased
-                    # to have a known tag to refer to this image if they depend on it - even
-                    # before it is built.
-                    at.write("%s\n" % uuid_tag)
-                    if self.runtime.assembly:
-                        at.write("assembly.%s\n" % self.runtime.assembly)
-                    if len(vsplit) > 1:
-                        at.write("%s.%s\n" % (vsplit[0], vsplit[1]))  # e.g. "v3.7.0" -> "v3.7"
-                    if self.metadata.config.additional_tags is not Missing:
-                        for tag in self.metadata.config.additional_tags:
-                            at.write("{}\n".format(tag))
 
             self.logger.debug("Dockerfile contains the following labels:")
             for k, v in dfp.labels.items():

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -521,7 +521,7 @@ class ImageDistGitRepo(DistGitRepo):
         # Include the UUID in the tags. This will allow other images being rebased
         # to have a known tag to refer to this image if they depend on it - even
         # before it is built.
-        floating_tags = {"latest", f"{version}.{self.runtime.uuid}"}
+        floating_tags = {f"{version}.{self.runtime.uuid}"}
         if self.runtime.assembly:
             floating_tags.add(f"assembly.{self.runtime.assembly}")
         vsplit = version.split(".")  # Split the version number: v4.3.4 => [ 'v4', '3, '4' ]

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -11,6 +11,7 @@ import flexmock
 from mock import MagicMock
 
 from doozerlib import distgit, model
+from doozerlib import assembly
 from doozerlib.image import ImageMetadata
 from doozerlib.assembly import AssemblyTypes
 
@@ -476,6 +477,29 @@ FROM another-base-image:some-tag
 COPY --from=builder /some/path/a /some/path/b
         """.strip().splitlines()
         self.assertListEqual(actual, expected)
+
+    def test_generate_osbs_image_config_with_addtional_tags(self):
+        runtime = MagicMock(uuid="123456")
+        meta = ImageMetadata(runtime, model.Model({
+            "key": "foo",
+            'data': {
+                'name': 'openshift/foo',
+                'distgit': {'branch': 'fake-branch-rhel-8'},
+                "additional_tags": ["tag_a", "tag_b"]
+            },
+        }))
+        dg = distgit.ImageDistGitRepo(meta, autoclone=False)
+        dg.logger = logging.getLogger()
+
+        # assembly is not enabled
+        runtime.assembly = None
+        container_yaml = dg._generate_osbs_image_config("v4.10.0")
+        self.assertEqual(sorted(container_yaml["tags"]), sorted(['v4.10.0.123456', 'v4.10', 'latest', 'tag_a', 'tag_b']))
+
+        # assembly is enabled
+        runtime.assembly = "art3109"
+        container_yaml = dg._generate_osbs_image_config("v4.10.0")
+        self.assertEqual(sorted(container_yaml["tags"]), sorted(['assembly.art3109', 'v4.10.0.123456', 'v4.10', 'latest', 'tag_a', 'tag_b']))
 
 
 if __name__ == "__main__":

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -494,12 +494,12 @@ COPY --from=builder /some/path/a /some/path/b
         # assembly is not enabled
         runtime.assembly = None
         container_yaml = dg._generate_osbs_image_config("v4.10.0")
-        self.assertEqual(sorted(container_yaml["tags"]), sorted(['v4.10.0.123456', 'v4.10', 'latest', 'tag_a', 'tag_b']))
+        self.assertEqual(sorted(container_yaml["tags"]), sorted(['v4.10.0.123456', 'v4.10', 'tag_a', 'tag_b']))
 
         # assembly is enabled
         runtime.assembly = "art3109"
         container_yaml = dg._generate_osbs_image_config("v4.10.0")
-        self.assertEqual(sorted(container_yaml["tags"]), sorted(['assembly.art3109', 'v4.10.0.123456', 'v4.10', 'latest', 'tag_a', 'tag_b']))
+        self.assertEqual(sorted(container_yaml["tags"]), sorted(['assembly.art3109', 'v4.10.0.123456', 'v4.10', 'tag_a', 'tag_b']))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Existing `additional-tags` files in distgit repos will be automatically
removed during rebase.

Test build: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=40266870
Distgit diff: https://pkgs.devel.redhat.com/cgit/containers/openshift-enterprise-cli/commit/?h=rhaos-4.10-rhel-8&id=524587ed73acddaf4e62ffe380c3c968b9f85038