### PR TITLE
Pin pygit2 to 1.6

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,7 @@ coverage
 flake8
 flexmock
 mock
-pygit2 ~= 0.28 ; python_version <= '3.4'
-pygit2 ; python_version >= '3.5'
+pygit2 == 1.6.*
 pylint
 pytest
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py36
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
pygit2 1.7 requires libgit 1.3, which is not in the repos yet. Also,
python3.6 support is dropped, which we require on buildvm.

Also, use python3.6 to run the tests in tox to ensure parity in test
environments and production environment.