### PR TITLE
Prevent leading zero in nvr semver

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -9,7 +9,7 @@ from doozerlib.model import Missing, Model, ListModel
 class AssemblyTypes(Enum):
     STREAM = "stream"  # Default assembly type - indicates continuous build and no basis event
     STANDARD = "standard"  # All constraints / checks enforced (e.g. consistent RPMs / siblings)
-    CANDIDATE = "candidate"  # Indicates releaes or feature candidate
+    CANDIDATE = "candidate"  # Indicates release candidate or feature candidate
     CUSTOM = "custom"  # No constraints enforced
 
 

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1660,7 +1660,7 @@ class ImageDistGitRepo(DistGitRepo):
                     release += pval
 
                 if self.source_full_sha:
-                    release += ".git." + self.source_full_sha[:7]
+                    release += ".g" + self.source_full_sha[:7]
 
                 if self.runtime.assembly:
                     release += f'.assembly.{self.runtime.assembly}'

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -377,7 +377,7 @@ class Metadata(object):
         :param extra_pattern: An extra glob pattern that must be matched in the middle of the
                          build's release field. Pattern must match release timestamp and components
                          like p? and git commit (up to, but not including ".assembly.<name>" release
-                         component). e.g. "*.git.<commit>.*   or '*.p1.*'
+                         component). e.g. "*.g<commit>.*   or '*.p1.*'
         :param build_state: 0=BUILDING, 1=COMPLETE, 2=DELETED, 3=FAILED, 4=CANCELED
         :param el_target: In the case of an RPM, which can build for multiple targets, you can specify
                             '7' for el7, '8' for el8, etc. You can also pass in a brew target that
@@ -710,7 +710,7 @@ class Metadata(object):
                 upstream_commit_hash, _ = exectools.cmd_assert('git rev-parse HEAD', strip=True)
 
         self.logger.debug(f'scan-sources coordinate: upstream_commit_hash: {upstream_commit_hash}')
-        git_component = f'.git.{upstream_commit_hash[:7]}'
+        git_component = f'.g*{upstream_commit_hash[:7]}'  # use .g*<commit> so it matches new form ".g0123456" and old ".git.0123456"
 
         # Scan for any build in this assembly which also includes the git commit.
         upstream_commit_build = self.get_latest_build(default=None,

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -76,7 +76,7 @@ class RPMBuilder:
             release = release[:-3] + pval
 
         # include commit hash in release field
-        release += ".git." + rpm.pre_init_sha[:7]
+        release += ".g" + rpm.pre_init_sha[:7]
 
         if self._runtime.assembly:
             release += f'.assembly.{self._runtime.assembly}'

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -366,11 +366,14 @@ def get_docker_config_json(config_dir):
 def isolate_git_commit_in_release(release: str) -> Optional[str]:
     """
     Given a release field, determines whether is contains
-    .git.<commit> information. If it does, it returns the value
+    .git.<commit> information or .g<commit> (new style). If it does, it returns the value
     of <commit>. If it is not found, None is returned.
     """
     match = re.match(r'.*\.git\.([a-f0-9]+)(?:\.+|$)', release)
+    if match:
+        return match.group(1)
 
+    match = re.match(r'.*\.g([a-f0-9]+)(?:\.+|$)', release)
     if match:
         return match.group(1)
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -68,7 +68,7 @@ class TestMetadata(TestCase):
             release += f'.{p}'
 
         if git_commit:
-            release += f'.git.{git_commit[:7]}'
+            release += f'.g{git_commit[:7]}'
 
         if assembly is not None:
             release += f'.assembly.{assembly}{release_suffix}'
@@ -204,12 +204,12 @@ class TestMetadata(TestCase):
         # Check whether extra pattern matching works
         builds = [
             self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
-            self.build_record(now - datetime.timedelta(hours=25), assembly='stream', release_prefix='99999.git.1234567', release_suffix='.el8'),
+            self.build_record(now - datetime.timedelta(hours=25), assembly='stream', release_prefix='99999.g1234567', release_suffix='.el8'),
             self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
             self.build_record(now, assembly='not_ours'),
             self.build_record(now - datetime.timedelta(hours=8), assembly=f'{runtime.assembly}')
         ]
-        self.assertEqual(meta.get_latest_build(default=None, extra_pattern='*.git.1234567.*'), builds[1])
+        self.assertEqual(meta.get_latest_build(default=None, extra_pattern='*.g1234567.*'), builds[1])
 
     def test_get_latest_build_multi_target(self):
         meta = self.meta

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -81,7 +81,7 @@ class TestRPMBuilder(unittest.TestCase):
         actual = asyncio.get_event_loop().run_until_complete(builder.rebase(rpm, "1.2.3", "202104070000.test.p?"))
 
         self.assertEqual(actual, distgit_sha)
-        self.assertEqual(rpm.release, "202104070000.test.p0.git." + source_sha[:7])
+        self.assertEqual(rpm.release, "202104070000.test.p0.g" + source_sha[:7])
         mocked_open.assert_called_once_with(dg.dg_path / "foo.spec", "w")
         mocked_open.return_value.__aenter__.return_value.writelines.assert_called_once_with(["fake spec content"])
         mocked_cmd_assert_async.assert_any_call(["tar", "-czf", dg.dg_path / f"{rpm.config.name}-{rpm.version}-{rpm.release}.tar.gz", "--exclude=.git", fr"--transform=s,^\./,{rpm.config.name}-{rpm.version}/,", "."], cwd=rpm.source_path)
@@ -93,7 +93,7 @@ class TestRPMBuilder(unittest.TestCase):
         dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].",
                                           commit_attributes={
                                               'version': '1.2.3',
-                                              'release': '202104070000.test.p0.git.3f17b42',
+                                              'release': '202104070000.test.p0.g3f17b42',
                                               'io.openshift.build.commit.id': '3f17b42b8aa7d294c0d2b6f946af5fe488f3a722',
                                               'io.openshift.build.source-location': None}
                                           )
@@ -121,7 +121,7 @@ class TestRPMBuilder(unittest.TestCase):
         actual = asyncio.get_event_loop().run_until_complete(builder.rebase(rpm, "1.2.3", "202104070000.test.p?"))
 
         self.assertEqual(actual, distgit_sha)
-        self.assertEqual(rpm.release, "202104070000.test.p0.git." + source_sha[:7] + '.assembly.tester')
+        self.assertEqual(rpm.release, "202104070000.test.p0.g" + source_sha[:7] + '.assembly.tester')
         mocked_open.assert_called_once_with(dg.dg_path / "foo.spec", "w")
         mocked_open.return_value.__aenter__.return_value.writelines.assert_called_once_with(["fake spec content"])
         mocked_cmd_assert_async.assert_any_call(["tar", "-czf", dg.dg_path / f"{rpm.config.name}-{rpm.version}-{rpm.release}.tar.gz", "--exclude=.git", fr"--transform=s,^\./,{rpm.config.name}-{rpm.version}/,", "."], cwd=rpm.source_path)
@@ -133,7 +133,7 @@ class TestRPMBuilder(unittest.TestCase):
         dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].",
                                           commit_attributes={
                                               'version': '1.2.3',
-                                              'release': '202104070000.test.p0.git.3f17b42.assembly.tester',
+                                              'release': '202104070000.test.p0.g3f17b42.assembly.tester',
                                               'io.openshift.build.commit.id': '3f17b42b8aa7d294c0d2b6f946af5fe488f3a722',
                                               'io.openshift.build.source-location': None})
         dg.push_async.assert_called_once()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -136,27 +136,27 @@ class TestUtil(unittest.TestCase):
         self.assertEqual([13, 23, 33], [b["id"] for b in actual])
 
     def test_isolate_timestamp_in_release(self):
-        actual = util.isolate_timestamp_in_release("foo-4.7.0-202107021813.p0.git.01c9f3f.el8")
+        actual = util.isolate_timestamp_in_release("foo-4.7.0-202107021813.p0.g01c9f3f.el8")
         expected = "202107021813"
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.git.8b4b094")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.g8b4b094")
         expected = "202107021907"
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.git.8b4b094")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.g8b4b094")
         expected = "202107021907"
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.8.0-202106152230.p0.git.25122f5.assembly.stream")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.8.0-202106152230.p0.g25122f5.assembly.stream")
         expected = "202106152230"
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-1.p0.git.8b4b094")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-1.p0.g8b4b094")
         expected = None
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202199999999.p0.git.8b4b094")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202199999999.p0.g8b4b094")
         expected = None
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
The semver standard prevents numeric elements of the pre-release portion of a version from starting with `0`. This means that doozer could rarely create invalid semvers like `.git.0123456`. We will change to be `.g0123456` so these fields are always non-numeric.