### PR TITLE
container.yml: Add PATCH to tags

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -523,6 +523,8 @@ class ImageDistGitRepo(DistGitRepo):
         vsplit = version.split(".")  # Split the version number: v4.3.4 => [ 'v4', '3, '4' ]
         if len(vsplit) > 1:
             floating_tags.add(f"{vsplit[0]}.{vsplit[1]}")
+        if len(vsplit) > 2:
+            floating_tags.add(f"{vsplit[0]}.{vsplit[1]}.{vsplit[2]}")
         if self.metadata.config.additional_tags:
             floating_tags |= set(self.metadata.config.additional_tags)
         if floating_tags:

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -493,12 +493,12 @@ COPY --from=builder /some/path/a /some/path/b
         # assembly is not enabled
         runtime.assembly = None
         container_yaml = dg._generate_osbs_image_config("v4.10.0")
-        self.assertEqual(sorted(container_yaml["tags"]), sorted(['v4.10.0.123456', 'v4.10', 'tag_a', 'tag_b']))
+        self.assertEqual(sorted(container_yaml["tags"]), sorted(['v4.10.0.123456', 'v4.10', 'v4.10.0', 'tag_a', 'tag_b']))
 
         # assembly is enabled
         runtime.assembly = "art3109"
         container_yaml = dg._generate_osbs_image_config("v4.10.0")
-        self.assertEqual(sorted(container_yaml["tags"]), sorted(['assembly.art3109', 'v4.10.0.123456', 'v4.10', 'tag_a', 'tag_b']))
+        self.assertEqual(sorted(container_yaml["tags"]), sorted(['assembly.art3109', 'v4.10.0.123456', 'v4.10', 'v4.10.0', 'tag_a', 'tag_b']))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
v3.11 relies on images being pullable through with a tag like
`:v3.11.345`. This change ensures the patch version is included in
`container.yml`.