### PR TITLE
Targeted RHCOS builds are not being checked for consistency

### DIFF
--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -279,6 +279,9 @@ read and propagate/expose this annotation in its display of the release image.
                 # We already stored inconsistencies for each image_meta; look them up if there are any.
                 payload_entry.issues.extend(filter(lambda ai: ai.component == payload_entry.image_meta.distgit_key, assembly_issues))
             elif payload_entry.rhcos_build:
+                # Record the build so that we can later evaluate consistency between all RHCOS builds. There are presently
+                # no private RHCOS builds, so add only to private_mode=False.
+                targeted_rhcos_builds[False].append(payload_entry.rhcos_build)
                 assembly_issues.extend(assembly_inspector.check_rhcos_issues(payload_entry.rhcos_build))
                 payload_entry.issues.extend(filter(lambda ai: ai.component == 'rhcos', assembly_issues))
                 if runtime.assembly == 'stream':


### PR DESCRIPTION
Selected RHCOS builds were not being added to the list of scanned builds. This made the rpm inconsistency a no-op. 

```python
    for private_mode in privacy_modes:
        rhcos_builds = targeted_rhcos_builds[private_mode]
        rhcos_inconsistencies: Dict[str, List[str]] = PayloadGenerator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
        if rhcos_inconsistencies:
            assembly_issues.append(AssemblyIssue(f'Found RHCOS inconsistencies in builds {targeted_rhcos_builds}: {rhcos_inconsistencies}', component='rhcos', code=AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS))

```