### PR TITLE
Log ocp-build-data commit

### DIFF
--- a/doozerlib/dblib.py
+++ b/doozerlib/dblib.py
@@ -107,7 +107,7 @@ class DB(object):
 
         if not (constants.DB_USER in os.environ and constants.DB_PWD in os.environ):
             self.runtime.logger.info("Environment variables required for db operation missing. Doozer will be running"
-                                        "in no DB use mode.")
+                                     "in no DB use mode.")
             return False
 
         import mysql.connector as mysql_connector

--- a/doozerlib/gitdata.py
+++ b/doozerlib/gitdata.py
@@ -172,6 +172,8 @@ class GitData(object):
         self.origin_url, _ = exectools.cmd_assert(f'git -C {self.data_path} remote get-url origin', strip=True)
         self.commit_hash, _ = exectools.cmd_assert(f'git -C {self.data_path} rev-parse HEAD', strip=True)
 
+        self.logger.info(f'On commit: {self.commit_hash}')
+
         if not os.path.isdir(self.data_dir):
             raise GitDataPathException('{} is not a valid sub-directory in the data'.format(self.sub_dir))
 


### PR DESCRIPTION
While checking build-sync logs for failure, 
I want to know the exact assembly definition being used 
By logging the commit for the ocp-build-data release branch
we'll be able to navigate to, for example
https://github.com/thegreyd/ocp-build-data/blob/6f1900208f89d64bd441115c6943a561ab38f7ba/releases.yml

