### PR TITLE
ART-3589 Command to check for rhcos build inconsistency

### DIFF
--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -6,7 +6,8 @@ from kobo.rpmlib import parse_nvr
 from doozerlib import util, Runtime
 from doozerlib.image import BrewBuildImageInspector
 from doozerlib.rpmcfg import RPMMetadata
-from doozerlib.assembly import assembly_rhcos_config, AssemblyTypes, Assembly_permits, AssemblyIssue, AssemblyIssueCode, assembly_type
+from doozerlib.assembly import assembly_rhcos_config, AssemblyTypes, assembly_permits, AssemblyIssue, \
+    AssemblyIssueCode, assembly_type
 from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder
 
 

--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -12,8 +12,14 @@ from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder
 
 
 class AssemblyInspector:
-
+    """ It inspects an assembly """
     def __init__(self, runtime: Runtime, brew_session: ClientSession = None, lite: bool = False):
+        """
+        :param runtime: Doozer runtime
+        :param brew_session: Brew session object to use for communicating with Brew
+        :param lite: Create a lite version without the ability to inspect Images; can be used to check AssemblyIssues,
+        fetch rhcos_builds and other defined methods
+        """
         self.runtime = runtime
         self.brew_session = brew_session
         if not lite and runtime.mode != 'both':

--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -6,16 +6,16 @@ from kobo.rpmlib import parse_nvr
 from doozerlib import util, Runtime
 from doozerlib.image import BrewBuildImageInspector
 from doozerlib.rpmcfg import RPMMetadata
-from doozerlib.assembly import assembly_rhcos_config, AssemblyTypes, assembly_permits, AssemblyIssue, AssemblyIssueCode, assembly_type
+from doozerlib.assembly import assembly_rhcos_config, AssemblyTypes, Assembly_permits, AssemblyIssue, AssemblyIssueCode, assembly_type
 from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder
 
 
 class AssemblyInspector:
 
-    def __init__(self, runtime: Runtime, brew_session: ClientSession):
+    def __init__(self, runtime: Runtime, brew_session: ClientSession = None, lite: bool = False):
         self.runtime = runtime
         self.brew_session = brew_session
-        if runtime.mode != 'both':
+        if not lite and runtime.mode != 'both':
             raise ValueError('Runtime must be initialized with "both"')
 
         self.assembly_rhcos_config = assembly_rhcos_config(self.runtime.releases_config, self.runtime.assembly)
@@ -23,6 +23,8 @@ class AssemblyInspector:
         self._rpm_build_cache: Dict[int, Dict[str, Optional[Dict]]] = {}  # Dict[rhel_ver] -> Dict[distgit_key] -> Optional[BuildDict]
         self._permits = assembly_permits(self.runtime.releases_config, self.runtime.assembly)
 
+        if lite:
+            return
         # If an image component has a latest build, an ImageInspector associated with the image.
         self._release_image_inspectors: Dict[str, Optional[BrewBuildImageInspector]] = dict()
         for image_meta in runtime.get_for_release_image_metas():

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -34,6 +34,7 @@ from doozerlib.cli.scan_sources import config_scan_source_changes
 from doozerlib.cli.rpms_build import rpms_build
 from doozerlib.cli.config_plashet import config_plashet
 from doozerlib.cli.release_calc_upgrade_tests import release_calc_upgrade_tests
+from doozerlib.cli.inspect_rhcos import inspect_rhcos
 
 from doozerlib import coverity
 from doozerlib.exceptions import DoozerFatalError

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -34,7 +34,7 @@ from doozerlib.cli.scan_sources import config_scan_source_changes
 from doozerlib.cli.rpms_build import rpms_build
 from doozerlib.cli.config_plashet import config_plashet
 from doozerlib.cli.release_calc_upgrade_tests import release_calc_upgrade_tests
-from doozerlib.cli.inspect_rhcos import inspect_rhcos
+from doozerlib.cli.inspect_stream import inspect_stream
 
 from doozerlib import coverity
 from doozerlib.exceptions import DoozerFatalError

--- a/doozerlib/cli/inspect_rhcos.py
+++ b/doozerlib/cli/inspect_rhcos.py
@@ -1,0 +1,31 @@
+import click
+
+from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder
+from doozerlib.cli import cli
+from doozerlib.util import brew_arches
+from doozerlib.cli.release_gen_payload import PayloadGenerator
+
+@cli.command("inspect:rhcos", short_help="Inspect latest rhcos builds for consistency")
+@click.pass_obj
+def inspect_rhcos(runtime):
+    runtime.initialize(clone_distgits=False)
+    logger = runtime.logger
+    rhcos_builds = []
+    major = runtime.group_config.vars.MAJOR
+    minor = runtime.group_config.vars.MINOR
+    version = f'{major}.{minor}'
+    not_arm = major == 4 and minor < 9
+    for arch in brew_arches:
+        if not_arm and arch == 'aarch64':
+            continue
+        build_id, pullspec = RHCOSBuildFinder(runtime, version, arch, False).latest_machine_os_content()
+        if not pullspec:
+            raise IOError(f"No RHCOS latest found for {version} / {arch}")
+        rhcos_builds.append(RHCOSBuildInspector(runtime, pullspec, arch))
+    logger.info(f"Checking following builds for inconsistency: {rhcos_builds}")
+    rhcos_inconsistencies: Dict[str, List[str]] = PayloadGenerator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
+    if rhcos_inconsistencies:
+        print(f'Found RHCOS inconsistencies in builds {rhcos_builds}: {rhcos_inconsistencies}')
+        exit(1)
+    print(f'RHCOS builds consistent {rhcos_builds}')
+    exit(0)

--- a/doozerlib/cli/inspect_rhcos.py
+++ b/doozerlib/cli/inspect_rhcos.py
@@ -4,18 +4,33 @@ from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder
 from doozerlib.cli import cli
 from doozerlib.util import brew_arches
 from doozerlib.cli.release_gen_payload import PayloadGenerator
+from doozerlib.assembly import AssemblyIssueCode
 
 
-@cli.command("inspect:rhcos", short_help="Inspect latest rhcos builds for consistency")
+@cli.command("inspect:stream", short_help="Inspect stream assembly for assembly issues")
+@click.argument("code", type=click.Choice([code.name for code in AssemblyIssueCode], required=True))
 @click.pass_obj
-def inspect_rhcos(runtime):
+def inspect_stream(runtime, code):
     runtime.initialize(clone_distgits=False)
+    if runtime.assembly != 'stream':
+        print('Cannot inspect non-stream assembly.')
+        exit(1)
     logger = runtime.logger
-    rhcos_builds = []
     major = runtime.group_config.vars.MAJOR
     minor = runtime.group_config.vars.MINOR
     version = f'{major}.{minor}'
     not_arm = major == 4 and minor < 9
+
+    if code == AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS.name:
+        rhcos_inconsistencies = _check_inconsistent_rhcos_rpms()
+        if rhcos_inconsistencies:
+            print(f'Found RHCOS inconsistencies in builds {rhcos_builds}: {rhcos_inconsistencies}')
+            exit(1)
+        print(f'RHCOS builds consistent {rhcos_builds}')
+        exit(0)
+
+def _check_inconsistent_rhcos_rpms(assembly):
+    rhcos_builds = []
     for arch in brew_arches:
         if not_arm and arch == 'aarch64':
             continue
@@ -25,8 +40,3 @@ def inspect_rhcos(runtime):
         rhcos_builds.append(RHCOSBuildInspector(runtime, pullspec, arch))
     logger.info(f"Checking following builds for inconsistency: {rhcos_builds}")
     rhcos_inconsistencies = PayloadGenerator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
-    if rhcos_inconsistencies:
-        print(f'Found RHCOS inconsistencies in builds {rhcos_builds}: {rhcos_inconsistencies}')
-        exit(1)
-    print(f'RHCOS builds consistent {rhcos_builds}')
-    exit(0)

--- a/doozerlib/cli/inspect_rhcos.py
+++ b/doozerlib/cli/inspect_rhcos.py
@@ -5,6 +5,7 @@ from doozerlib.cli import cli
 from doozerlib.util import brew_arches
 from doozerlib.cli.release_gen_payload import PayloadGenerator
 
+
 @cli.command("inspect:rhcos", short_help="Inspect latest rhcos builds for consistency")
 @click.pass_obj
 def inspect_rhcos(runtime):
@@ -23,7 +24,7 @@ def inspect_rhcos(runtime):
             raise IOError(f"No RHCOS latest found for {version} / {arch}")
         rhcos_builds.append(RHCOSBuildInspector(runtime, pullspec, arch))
     logger.info(f"Checking following builds for inconsistency: {rhcos_builds}")
-    rhcos_inconsistencies: Dict[str, List[str]] = PayloadGenerator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
+    rhcos_inconsistencies = PayloadGenerator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
     if rhcos_inconsistencies:
         print(f'Found RHCOS inconsistencies in builds {rhcos_builds}: {rhcos_inconsistencies}')
         exit(1)

--- a/doozerlib/cli/inspect_stream.py
+++ b/doozerlib/cli/inspect_stream.py
@@ -10,13 +10,13 @@ from doozerlib.assembly_inspector import AssemblyInspector
 
 
 @cli.command("inspect:stream", short_help="Inspect stream assembly for assembly issues")
-@click.argument("code", type=click.Choice([code.name for code in AssemblyIssueCode]), required=True)
+@click.argument("code", type=click.Choice([code.name for code in AssemblyIssueCode], case_sensitive=False),
+                required=True)
 @click.pass_obj
 def inspect_stream(runtime, code):
     code = AssemblyIssueCode[code]
     if runtime.assembly != 'stream':
-        print(f'Disregarding non-stream assembly: {runtime.assembly}. This command is only intended for '
-                       f'stream')
+        print(f'Disregarding non-stream assembly: {runtime.assembly}. This command is only intended for stream')
     runtime.assembly = 'stream'
     runtime.initialize(clone_distgits=False)
     assembly_inspector = AssemblyInspector(runtime, lite=True)
@@ -30,13 +30,13 @@ def inspect_stream(runtime, code):
             if assembly_inspector.does_permit(assembly_issue):
                 print(f'Assembly permits code {code}.')
                 exit(0)
-            print(f'Assembly does not permit code {code}. Failed')
             exit(1)
         print(f'RHCOS builds consistent {rhcos_builds}')
         exit(0)
     else:
         print(f'AssemblyIssueCode {code} not supported at this time :(')
         exit(1)
+
 
 def _check_inconsistent_rhcos_rpms(runtime, assembly_inspector):
     logger = runtime.logger

--- a/doozerlib/cli/inspect_stream.py
+++ b/doozerlib/cli/inspect_stream.py
@@ -5,23 +5,32 @@ from doozerlib.cli import cli
 from doozerlib.util import brew_arches
 from doozerlib.cli.release_gen_payload import PayloadGenerator
 from doozerlib.assembly import AssemblyIssueCode
+from doozerlib.assembly import AssemblyIssue
+from doozerlib.assembly_inspector import AssemblyInspector
 
 
 @cli.command("inspect:stream", short_help="Inspect stream assembly for assembly issues")
 @click.argument("code", type=click.Choice([code.name for code in AssemblyIssueCode]), required=True)
 @click.pass_obj
 def inspect_stream(runtime, code):
-    runtime.initialize(clone_distgits=False)
-    logger = runtime.logger
+    code = AssemblyIssueCode[code]
     if runtime.assembly != 'stream':
-        logger.warning(f'Disregarding non-stream assembly: {runtime.assembly}. This command is only intended for '
+        print(f'Disregarding non-stream assembly: {runtime.assembly}. This command is only intended for '
                        f'stream')
+    runtime.assembly = 'stream'
+    runtime.initialize(clone_distgits=False)
+    assembly_inspector = AssemblyInspector(runtime, lite=True)
 
-
-    if code == AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS.name:
-        rhcos_builds, rhcos_inconsistencies = _check_inconsistent_rhcos_rpms(runtime)
+    if code == AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS:
+        rhcos_builds, rhcos_inconsistencies = _check_inconsistent_rhcos_rpms(runtime, assembly_inspector)
         if rhcos_inconsistencies:
-            print(f'Found RHCOS inconsistencies in builds {rhcos_builds}: {rhcos_inconsistencies}')
+            msg = f'Found RHCOS inconsistencies in builds {rhcos_builds}: {rhcos_inconsistencies}'
+            print(msg)
+            assembly_issue = AssemblyIssue(msg, component='rhcos', code=code)
+            if assembly_inspector.does_permit(assembly_issue):
+                print(f'Assembly permits code {code}.')
+                exit(0)
+            print(f'Assembly does not permit code {code}. Failed')
             exit(1)
         print(f'RHCOS builds consistent {rhcos_builds}')
         exit(0)
@@ -29,20 +38,17 @@ def inspect_stream(runtime, code):
         print(f'AssemblyIssueCode {code} not supported at this time :(')
         exit(1)
 
-def _check_inconsistent_rhcos_rpms(runtime):
+def _check_inconsistent_rhcos_rpms(runtime, assembly_inspector):
     logger = runtime.logger
     major = runtime.group_config.vars.MAJOR
     minor = runtime.group_config.vars.MINOR
-    version = f'{major}.{minor}'
     not_arm = major == 4 and minor < 9
     rhcos_builds = []
     for arch in brew_arches:
         if not_arm and arch == 'aarch64':
             continue
-        build_id, pullspec = RHCOSBuildFinder(runtime, version, arch, False).latest_machine_os_content()
-        if not pullspec:
-            raise IOError(f"No RHCOS latest found for {version} / {arch}")
-        rhcos_builds.append(RHCOSBuildInspector(runtime, pullspec, arch))
+        build_inspector = assembly_inspector.get_rhcos_build(arch)
+        rhcos_builds.append(build_inspector)
     logger.info(f"Checking following builds for inconsistency: {rhcos_builds}")
     rhcos_inconsistencies = PayloadGenerator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
     return rhcos_builds, rhcos_inconsistencies

--- a/doozerlib/cli/inspect_stream.py
+++ b/doozerlib/cli/inspect_stream.py
@@ -40,13 +40,8 @@ def inspect_stream(runtime, code):
 
 def _check_inconsistent_rhcos_rpms(runtime, assembly_inspector):
     logger = runtime.logger
-    major = runtime.group_config.vars.MAJOR
-    minor = runtime.group_config.vars.MINOR
-    not_arm = major == 4 and minor < 9
     rhcos_builds = []
-    for arch in brew_arches:
-        if not_arm and arch == 'aarch64':
-            continue
+    for arch in runtime.group_config.arches:
         build_inspector = assembly_inspector.get_rhcos_build(arch)
         rhcos_builds.append(build_inspector)
     logger.info(f"Checking following builds for inconsistency: {rhcos_builds}")

--- a/doozerlib/rhcos.py
+++ b/doozerlib/rhcos.py
@@ -168,7 +168,7 @@ class RHCOSBuildInspector:
             self._build_meta = finder.rhcos_build_meta(self.build_id, meta_type='meta')
             self._os_commitmeta = finder.rhcos_build_meta(self.build_id, meta_type='commitmeta')
 
-    def __str__(self):
+    def __repr__(self):
         return f'RHCOSBuild:{self.brew_arch}:{self.build_id}'
 
     def get_os_metadata(self) -> Dict:


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-3589

Summary:
The usecase for this command is described in the ticket. 
Basically we want to perform an early check for rhcos builds consistency,
on stream, since if that fails we don't want to get to the end of build-sync and fail.
It won't fail if the code is permitted in assembly definition.

The command is only intended for stream use, and with the idea that we can
support more assembly issue codes in the future.

```
doozer -g openshift-4.10 inspect:stream INCONSISTENT_RHCOS_RPMS
...
2021-12-15 18:59:32,526 INFO Checking following builds for inconsistency: [RHCOSBuild:x86_64:410.84.202112151002-0, RHCOSBuild:s390x:410.84.202112152002-0, RHCOSBuild:ppc64le:410.84.202112152015-0, RHCOSBuild:aarch64:410.84.202112152003-0]
Found RHCOS inconsistencies in builds [RHCOSBuild:x86_64:410.84.202112151002-0, RHCOSBuild:s390x:410.84.202112152002-0, RHCOSBuild:ppc64le:410.84.202112152015-0, RHCOSBuild:aarch64:410.84.202112152003-0]: {'libibverbs': {'libibverbs-32.0-5.el8_4', 'libibverbs-32.0-4.el8'}, 'openshift-clients': {'openshift-clients-4.10.0-202112151834.p0.gc86d58d.assembly.stream.el8', 'openshift-clients-4.10.0-202112150826.p0.gc86d58d.assembly.stream.el8'}, 'openshift-hyperkube': {'openshift-hyperkube-4.10.0-202112150826.p0.g6859754.assembly.stream.el8', 'openshift-hyperkube-4.10.0-202112151834.p0.g6859754.assembly.stream.el8'}, 'rdma-core': {'rdma-core-32.0-4.el8', 'rdma-core-32.0-5.el8_4'}}
```