### PR TITLE
Enable gen_payload to apply directly and update multi release controller

### DIFF
--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -63,7 +63,7 @@ class AssemblyInspector:
         """
         Analyzes an RHCOS build to check whether the installed packages are consistent with:
         1. package NVRs defined at the group dependency level
-        2. package NVRs defiend at the rhcos dependency level
+        2. package NVRs defined at the rhcos dependency level
         3. package NVRs of any RPMs built in this assembly/group
         :param rhcos_build: The RHCOS build to analyze.
         :return: Returns a (potentially empty) list of inconsistencies in the build.

--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -97,7 +97,7 @@ def print_version(ctx, param, value):
 @click.option("--datastore", metavar="ENV", required=False, default=None,
               help="Whether to store & retrieve data in int / stage / prod database environment")
 @click.option("--profile", metavar="NAME", default="", help="Name of build profile")
-@click.option("--brew-event", metavar='EVENT', default=None,
+@click.option("--brew-event", metavar='EVENT', default=None, type=int,
               help="Lock koji clients from runtime to this brew event.")
 @click.pass_context
 def cli(ctx, **kwargs):

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -528,10 +528,10 @@ def total_size(o, handlers=None, verbose=False):
 
 
 # some of our systems refer to golang's architecture nomenclature; translate between that and brew arches
-brew_arches = ["x86_64", "s390x", "ppc64le", "aarch64"]
-brew_arch_suffixes = ["", "-s390x", "-ppc64le", "-aarch64"]
-go_arches = ["amd64", "s390x", "ppc64le", "arm64"]
-go_arch_suffixes = ["", "-s390x", "-ppc64le", "-arm64"]
+brew_arches = ["x86_64", "s390x", "ppc64le", "aarch64", "multi"]
+brew_arch_suffixes = ["", "-s390x", "-ppc64le", "-aarch64", "-multi"]
+go_arches = ["amd64", "s390x", "ppc64le", "arm64", "multi"]
+go_arch_suffixes = ["", "-s390x", "-ppc64le", "-arm64", "-multi"]
 
 
 def go_arch_for_brew_arch(brew_arch: str) -> str:
@@ -777,3 +777,12 @@ def get_release_calc_previous(version, arch,
                 upgrade_from.add(hotfix_version)
 
     return sort_semver(list(upgrade_from))
+
+
+def find_manifest_list_sha(pull_spec):
+    cmd = 'oc image info --filter-by-os=linux/amd64 -o json {}'.format(pull_spec)
+    out, err = exectools.cmd_assert(cmd, retries=3)
+    image_data = json.loads(out)
+    if 'listDigest' not in image_data:
+        raise ValueError('Specified image is not a manifest-list.')
+    return image_data['listDigest']

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ tenacity
 wrapt
 mysql-connector-python~=8.0.21
 python-dateutil~=2.8.1
+openshift-client~=1.0.12


### PR DESCRIPTION
This change enables gen_payload to generate heterogeneous release payloads
and update the `multi` release controller instance. It also transitions to make
gen_payload directly apply changes to the CI cluster imagestreams. 
The build_sync job should no longer try to run a mirroring operation or update the imagestreams itself.