### PR TITLE
[ART-3665] flatten out settings file extensions iteration to avoid redundant cycles

### DIFF
--- a/doozerlib/dotconfig.py
+++ b/doozerlib/dotconfig.py
@@ -58,14 +58,13 @@ class Config(object):
             if not os.path.isdir(self.base_dir):
                 os.makedirs(self.base_dir)
 
-            for ext in VALID_EXT:
-                for _ext in [ext, ext.upper()]:
-                    filename = '{}.{}'.format(name, _ext)
-                    cfg = os.path.join(self.base_dir, filename)
-                    if os.path.isfile(cfg):
-                        self.full_path = cfg
-                        self.filename = filename
-                        break
+            for ext in [ext for t in zip(VALID_EXT, [item.upper() for item in VALID_EXT]) for ext in t]:
+                filename = '{}.{}'.format(name, ext)
+                cfg = os.path.join(self.base_dir, filename)
+                if os.path.isfile(cfg):
+                    self.full_path = cfg
+                    self.filename = filename
+                    break
 
             if self.filename is None:
                 self.filename = name + '.' + VALID_EXT[0]

--- a/doozerlib/dotconfig.py
+++ b/doozerlib/dotconfig.py
@@ -59,7 +59,7 @@ class Config(object):
                 os.makedirs(self.base_dir)
 
             for ext in [ext for t in zip(VALID_EXT, [item.upper() for item in VALID_EXT]) for ext in t]:
-                filename = '{}.{}'.format(name, ext)
+                filename = f'{name}.{ext}'
                 cfg = os.path.join(self.base_dir, filename)
                 if os.path.isfile(cfg):
                     self.full_path = cfg
@@ -67,7 +67,7 @@ class Config(object):
                     break
 
             if self.filename is None:
-                self.filename = name + '.' + VALID_EXT[0]
+                self.filename = f'{name}.{VALID_EXT[0]}'
                 self.full_path = os.path.join(self.base_dir, self.filename)
                 if template_file:
                     shutil.copyfile(template_file, self.full_path)


### PR DESCRIPTION
I've used a list comprehension to derive this list: `['yaml', 'YAML', 'yml', 'YML', 'json', 'JSON']` from the original [VALID_EXT](https://github.com/openshift/doozer/blob/master/doozerlib/dotconfig.py#L11) list. The nested loop can be then flattened out.