### PR TITLE
Prevent private check on git commit target branch

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1681,7 +1681,9 @@ def config_print(runtime, key, name_only, as_yaml):
         $ doozer --group=openshift-4.0 config:print --name-only
     """
     _fix_runtime_mode(runtime)
-    runtime.initialize(**CONFIG_RUNTIME_OPTS)
+    opts = dict(CONFIG_RUNTIME_OPTS)
+    opts['config_only'] = False  # This verb must load image & rpm data
+    runtime.initialize(**opts)
     config = mdc(runtime)
     config.config_print(key, name_only, as_yaml)
 

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -2139,8 +2139,11 @@ class ImageDistGitRepo(DistGitRepo):
             self.public_facing_source_url, _ = self.runtime.get_public_upstream(out)  # Point to public upstream if there are private components to the URL
 
             # If private_fix has not already been set (e.g. by --embargoed), determine if the source contains private fixes by checking if the private org branch commit exists in the public org
-            if self.private_fix is None and self.metadata.public_upstream_branch:
-                self.private_fix = not util.is_commit_in_public_upstream(self.source_full_sha, self.metadata.public_upstream_branch, source_dir)
+            if self.private_fix is None:
+                if self.metadata.public_upstream_branch:
+                    self.private_fix = not util.is_commit_in_public_upstream(self.source_full_sha, self.metadata.public_upstream_branch, source_dir)
+                else:
+                    self.private_fix = False
 
             self.env_vars_from_source.update(self.metadata.extract_kube_env_vars())
 

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -71,8 +71,11 @@ class RPMMetadata(Metadata):
             self.pre_init_sha = source_full_sha = out.strip()
 
             # Determine if the source contains private fixes by checking if the private org branch commit exists in the public org
-            if self.private_fix is None and self.public_upstream_branch:
-                self.private_fix = not util.is_commit_in_public_upstream(source_full_sha, self.public_upstream_branch, self.source_path)
+            if self.private_fix is None:
+                if self.public_upstream_branch:
+                    self.private_fix = not util.is_commit_in_public_upstream(source_full_sha, self.public_upstream_branch, self.source_path)
+                else:
+                    self.private_fix = False
 
             self.extra_os_git_vars.update(self.extract_kube_env_vars())
 

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -939,7 +939,14 @@ class Runtime(object):
                 if not (url and branch):
                     raise DoozerFatalError(f"Couldn't detect source URL or branch for local source {path}. Is it a valid Git repo?")
                 public_upstream_url, public_upstream_branch = self.get_public_upstream(url)
-                self.source_resolutions[alias] = SourceResolution(path, url, branch, public_upstream_url, public_upstream_branch or branch)
+                if branch == 'HEAD':
+                    # If branch == HEAD, our source is a detached HEAD.
+                    public_upstream_url = None
+                    public_upstream_branch = None
+                else:
+                    if not public_upstream_branch:
+                        public_upstream_branch = branch
+                self.source_resolutions[alias] = SourceResolution(path, url, branch, public_upstream_url, public_upstream_branch)
             else:
                 self.source_resolutions[alias] = SourceResolution(path, url, branch, None, None)
 


### PR DESCRIPTION
When setting a commit hash for the `target` branch of a release component, the private check for the component was failing with: 
```
2022-01-10 16:44:28,962 INFO $19: ['git', 'merge-base', '--is-ancestor', '--', '7bb0ec5e3b0b01ecdcaf608c05bfbc2dce476540', 'public_upstream/HEAD'] - [cwd=/mnt/workspace/jenkins/working/aos-cd-builds_build_rebuild/artcd_working/doozer-working/sources/rpms_openshift_kubernetes]: Executing:cmd_gather
2022-01-10 16:44:28,966 INFO Time elapsed (hh:mm:ss.ms) 0:00:00.004188 in exectools.py:165 from util.py:196:rc, out, err = exectools.cmd_gather(cmd) : $19: ['git', 'merge-base', '--is-ancestor', '--', '7bb0ec5e3b0b01ecdcaf608c05bfbc2dce476540', 'public_upstream/HEAD'] - [cwd=/mnt/workspace/jenkins/working/aos-cd-builds_build_rebuild/artcd_working/doozer-working/sources/rpms_openshift_kubernetes]: Executed:cmd_gather
2022-01-10 16:44:28,978 ERROR [rpms/openshift] Exception occurred when rebasing openshift:
Traceback (most recent call last):
  File "/mnt/workspace/jenkins/working/aos-cd-builds_build_rebuild/art-tools/doozer/doozerlib/cli/rpms_build.py", line 148, in _rebase_rpm
    await builder.rebase(rpm, version, release)
  File "/mnt/workspace/jenkins/working/aos-cd-builds_build_rebuild/art-tools/doozer/doozerlib/rpm_builder.py", line 52, in rebase
    exectools.to_thread(rpm.distgit_repo, autoclone=True),
  File "/mnt/workspace/jenkins/working/aos-cd-builds_build_rebuild/art-tools/doozer/doozerlib/exectools.py", line 399, in to_thread
    return await loop.run_in_executor(None, func_call)
  File "/usr/lib64/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/jenkins/.local/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/mnt/workspace/jenkins/working/aos-cd-builds_build_rebuild/art-tools/doozer/doozerlib/rpmcfg.py", line 75, in clone_source
    self.private_fix = not util.is_commit_in_public_upstream(source_full_sha, self.public_upstream_branch, self.source_path)
  File "/mnt/workspace/jenkins/working/aos-cd-builds_build_rebuild/art-tools/doozer/doozerlib/util.py", line 202, in is_commit_in_public_upstream
    f"Couldn't determine if the commit {revision} is in the public upstream source repo. `git merge-base` exited with {rc}, stdout={out}, stderr={err}")
OSError: Couldn't determine if the commit 7bb0ec5e3b0b01ecdcaf608c05bfbc2dce476540 is in the public upstream source repo. `git merge-base` exited with 128, stdout=, stderr=fatal: Not a valid object name public_upstream/HEAD
```

The check for `public_upstream/HEAD` was made because, in runtime.py, this rev-parse line was returning `HEAD` because the head is detached.
```
rc2, out_branch, err_branch = exectools.cmd_gather(
                ["git", "rev-parse", "--abbrev-ref", "HEAD"])
```
