### PR TITLE
[wip] Gen-assembly don't fail early on inconsistent nightlies

### DIFF
--- a/doozerlib/cli/release_gen_assembly.py
+++ b/doozerlib/cli/release_gen_assembly.py
@@ -11,6 +11,7 @@ from doozerlib.model import Model
 from doozerlib import brew
 from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.image import BrewBuildImageInspector
+from doozerlib.util import red_print
 
 
 @cli.group("release:gen-assembly", short_help="Output assembly metadata based on inputs")
@@ -78,6 +79,7 @@ def gen_assembly_from_releases(ctx, runtime, nightlies, standards, custom):
             raise ValueError(f'Cannot process {standard_release_name} since {release_pullspecs[brew_cpu_arch]} is already included')
         release_pullspecs[brew_cpu_arch] = standard_pullspec
 
+    different_nvrs = False
     for brew_cpu_arch, pullspec in release_pullspecs.items():
         runtime.logger.info(f'Processing release: {pullspec}')
 
@@ -106,7 +108,9 @@ def gen_assembly_from_releases(ctx, runtime, nightlies, standards, custom):
                 # We want the releases to be populated with identical builds.
                 existing_nvr = component_image_builds[package_name].get_nvr()
                 if build_nvr != existing_nvr:
-                    exit_with_error(f'Found disparate nvrs between releases; {existing_nvr} in processed and {build_nvr} in {pullspec}')
+                    different_nvrs = True
+                    red_print(f'Found disparate nvrs between releases; {existing_nvr} in processed and {build_nvr} in'
+                      f' {pullspec}')
             else:
                 # Otherwise, record the build as the first time we've seen an NVR for this
                 # package.
@@ -130,6 +134,9 @@ def gen_assembly_from_releases(ctx, runtime, nightlies, standards, custom):
             # If the basis event for this image is > the basis_event capable of
             # sweeping images we've already analyzed, increase the basis_event_ts.
             basis_event_ts = max(basis_event_ts, completion_ts + (60.0 * 5))
+
+    if different_nvrs:
+        red_print("Found different nvrs! Make sure to pin those builds in assembly definition")
 
     # basis_event_ts should now be greater than the build completion / target tagging operation
     # for any (non machine-os-content) image in the nightlies. Because images are built after RPMs,

--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -491,7 +491,10 @@ class Metadata(object):
                 if self.meta_type == 'rpm':
                     if el_ver is None:
                         raise ValueError(f'Expected el_target to be set when querying a pinned RPM component {self.distgit_key}')
-                    is_nvr = isd[f'el{el_ver}']
+                    el_str = f'el{el_ver}'
+                    if not isinstance(isd, dict):
+                        raise ValueError(f'Expected "is" to be a dict {isd}')
+                    is_nvr = isd[el_str]
                     if not is_nvr:
                         return default_return()
                 else:


### PR DESCRIPTION
- Gen-assembly should list out nvrs that are found different between nightlies. So artists can still prepare payload with the right brew_event
- complain when "is" is not a list when expected

Rationale for gen-assembly change

Gen-assembly right now errors out if nightlies are nvr-inconsistent (i.e. have different sets of nvrs - not talking about rhcos). Usually I as a release artist just pick a set of similarly timed nightlies - aka `doozer get-nightlies` - not knowing if they are consistent. The significant one being the x86 one - since we pick the one that is accepted on RC. 

This change, in case of inconsistencies between reference_nightlies - would let gen-assembly regard the x86 as the "basis nightly", upon which the basis_event is decided. The conflicting nightlies are then removed from reference_nightlies section. Their rhcos would still be picked up.

This will make it smoother for release-artist with fewer runs of gen-assembly to get the assembly definition - without this change if a release artist picks up an inconsistent set - it would take them atleast 2 tries - maybe more now that we have 4 arches. This is essentially like running gen-assembly only with x86 nightly - but still notifying the artist that nightlies have different nvrs.