### PR TITLE
Allow INCONSISTENT_RHCOS_RPMS in stream

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -297,6 +297,10 @@ def assembly_permits(releases_config: Model, assembly: typing.Optional[str]) -> 
             {
                 'code': 'CONFLICTING_GROUP_RPM_INSTALLED',
                 'component': 'rhcos'
+            },
+            {
+                'code': 'INCONSISTENT_RHCOS_RPMS',
+                'component': 'rhcos'
             }
         ]
         return ListModel(list_to_model=default_stream_permits)

--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -312,7 +312,7 @@ class AssemblyInspector:
         assembly_rhcos_arch_pullspec = self.assembly_rhcos_config['machine-os-content'].images[brew_arch]
 
         if self.runtime.assembly_type != AssemblyTypes.STREAM and not assembly_rhcos_arch_pullspec:
-            raise Exception(f'Assembly {runtime.assembly} has is not a STREAM but no assembly.rhcos MOSC image data for {brew_arch}; all MOSC image data must be populated for this assembly to be valid')
+            raise Exception(f'Assembly {runtime.assembly} is not STREAM but no assembly.rhcos MOSC image data for {brew_arch}; all MOSC image data must be populated for this assembly to be valid')
 
         version = self.runtime.get_minor_version()
         if assembly_rhcos_arch_pullspec:


### PR DESCRIPTION
In e.g. [this build-sync job](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/21416/console),
there was no attempt to produce a nightly, because RHCOS had different
rpm contents between the different arches:

```yaml
- code: INCONSISTENT_RHCOS_RPMS
  msg: 'Found RHCOS inconsistencies in builds {False: [RHCOSBuild:x86_64:410.84.202201210604-0, RHCOSBuild:ppc64le:410.84.202201201604-0, RHCOSBuild:s390x:410.84.202201201602-0, RHCOSBuild:aarch64:410.84.202201210203-0], True: []}: {''ignition'': {''ignition-2.13.0-2.rhaos4.10.el8'', ''ignition-2.12.0-3.rhaos4.10.el8''}}'
  permitted: false
```

This is a situation that should be allowed as a stream assembly, as
rhcos can be produced with some delay, while it obviously should be
flagged down when creating a named assembly.