### PR TITLE
Permit errors from start-build

### DIFF
--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -183,8 +183,8 @@ def images_streams_start_buildconfigs(runtime, as_user, live_test_mode):
             cmd = f'oc -n ci start-build {name}'
             if as_user:
                 cmd += f' --as {as_user}'
-            stdout, stderr = exectools.cmd_assert(cmd, retries=3)
-            print('   ' + stdout or stderr)
+            rc, stdout, stderr = exectools.cmd_gather(cmd)
+            print(f'start-build (rc: {rc}):\nstdout>>\n{stdout}\nstderr>>\n{stderr}\n')
     else:
         print(f'No buildconfigs associated with this group: {group_label}')
 


### PR DESCRIPTION
In some situations, start-build returns an error immediately
if images don't exist. The intention of this flow was to
try the build and eventually things will reconcile. It is ok
for images to be missing on the first runs of reconciliation.