### PR TITLE
Add options to config Cachito flags

### DIFF
--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -554,7 +554,7 @@ COPY --from=builder /some/path/a /some/path/b
                 "content": {
                     "source": {"git": {"url": "git@example.com:openshift-priv/foo.git", "branch": {"target": "release-4.10"}}}
                 },
-                "cachito": {"enabled": True}
+                "cachito": {"enabled": True, "flags": ["gomod-vendor-check"]}
             },
         }))
         dg = distgit.ImageDistGitRepo(meta, autoclone=False)


### PR DESCRIPTION
Use the following options in image metadata config or group config to
control which Cachito flags should be used:

```yaml
cachito:
  enabled: true
  flags:
  - gomod-vendor-check
```

For all valid flags, see https://github.com/containerbuildsystem/cachito#flags