### PR TITLE
Allow PRs to be opened even if upstream_image is defined

### DIFF
--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -632,10 +632,6 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
             logger.info('The image has alignment PRs disabled; ignoring')
             continue
 
-        if image_meta.config.content.source.ci_alignment.upstream_image:
-            logger.info(f'Skipping PR check since image has alternative upstream representation: {image_meta.config.content.source.ci_alignment.upstream_image}')
-            continue
-
         from_config = image_meta.config['from']
         if not from_config:
             logger.info('Skipping PR check since there is no configured .from')


### PR DESCRIPTION
This was preventing PRs from being opened against
github.com/openshift/images for openshift-enterprise-base.
We need this image kept in sync for CI to promote appropriate
base images.
ART publishes the base images normally, but when a PR merges
in openshift/images, the image produced by CI can't be
widly off.