### PR TITLE
images:rebase: Sort tags and content sets

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -568,7 +568,7 @@ class ImageDistGitRepo(DistGitRepo):
         if self.metadata.config.additional_tags:
             floating_tags |= set(self.metadata.config.additional_tags)
         if floating_tags:
-            config_overrides["tags"] = list(floating_tags)
+            config_overrides["tags"] = sorted(floating_tags)
 
         if not self.runtime.group_config.doozer_feature_gates.odcs_enabled and not self.runtime.odcs_mode:
             # ODCS mode is not enabled

--- a/doozerlib/repos.py
+++ b/doozerlib/repos.py
@@ -286,14 +286,14 @@ class Repos(object):
         result = {}
         globally_enabled_repos = {r.name for r in self._repos.values() if r.enabled}
         shipping_repos = (set(globally_enabled_repos) | set(enabled_repos)) - set(non_shipping_repos)
-        for a in self._arches:
+        for a in sorted(self._arches):
             content_sets = []
             for r in shipping_repos:
                 cs = self._repos[r].content_set(a)
                 if cs:  # possible to be forced off by setting to null
                     content_sets.append(cs)
             if content_sets:
-                result[a] = content_sets
+                result[a] = sorted(content_sets)
         return CONTENT_SETS + yaml.dump(result, default_flow_style=False)
 
     def _validate_content_sets(self, arch, names):


### PR DESCRIPTION
It's often not very obvious to see diffs on distgit. Sorting tags and content sets will create a smaller diff in distgit.