### PR TITLE
Always use Cachito remote source name cachito-gomod-with-deps

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -539,7 +539,7 @@ class ImageDistGitRepo(DistGitRepo):
             config_overrides.update({
                 'remote_sources': [
                     {
-                        'name': 'cachito-with-deps',
+                        'name': 'cachito-gomod-with-deps',  # The remote source name is always `cachito-gomod-with-deps` for backward compatibility even if gomod is not used.
                         'remote_source': remote_source,
                     }
                 ]


### PR DESCRIPTION
Existing repos has hardcoded this name (e.g.https://github.com/openshift/etcd/blob/f99cada055fe83dc3cefb546dea95547d7da727d/Dockerfile.art#L4).

For backward compatibility, let's always use `cachito-gomod-with-deps` even if gomod is not used.