### PR TITLE
Fix Cachito request failure when image has an empty subpath.

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -534,7 +534,7 @@ class ImageDistGitRepo(DistGitRepo):
             }
             if flags:
                 remote_source['flags'] = flags
-            if self.config.content.source.path is not Missing:  # source is in subdirectory
+            if self.config.content.source.path:  # source is in subdirectory
                 remote_source['packages'] = {pkg_manager: [{"path": self.config.content.source.path}] for pkg_manager in pkg_managers}
             config_overrides.update({
                 'remote_sources': [


### PR DESCRIPTION
Image config `config.content.source.path` could be empty string. Cachito
doesn't like it. Example failure: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=43630013