### PR TITLE
Minor improvements to get-nightlies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: venv tox lint test
+
+venv:
+	python3 -m venv venv
+	./venv/bin/pip install -r requirements-dev.txt
+	# source venv/bin/activate
+
+lint:
+	./venv/bin/python -m flake8
+
+test: lint
+	./venv/bin/python -m pytest --verbose --color=yes tests/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-rrequirements.txt
 autopep8
 coverage
 flake8
@@ -10,4 +11,3 @@ tox
 typing
 typing-extensions
 setuptools~=49.6.0
-python-dateutil~=2.8.1


### PR DESCRIPTION
$ doozer --quiet -g openshift-4.9 get-nightlies --latest --rhcos
```
4.9.0-0.nightly-2022-03-09-205109 Ready 49.84.202203081945-0
4.9.0-0.nightly-s390x-2022-03-09-213958 Accepted 49.84.202203082102-0
4.9.0-0.nightly-ppc64le-2022-03-09-211420 Accepted 49.84.202203091929-0
4.9.0-0.nightly-arm64-2022-03-09-215559 Ready 49.84.202203090103-0
4.9.0-0.nightly-2022-03-09-205109,4.9.0-0.nightly-s390x-2022-03-09-213958,4.9.0-0.nightly-ppc64le-2022-03-09-211420,4.9.0-0.nightly-arm64-2022-03-09-215559
```