### PR TITLE
Allow an RPM is an image dependency to not appear in the final image

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -20,6 +20,7 @@ class AssemblyIssueCode(Enum):
     MISMATCHED_SIBLINGS = 3
     OUTDATED_RPMS_IN_STREAM_BUILD = 4
     INCONSISTENT_RHCOS_RPMS = 5
+    MISSING_INHERITED_DEPENDENCY = 6
 
 
 class AssemblyIssue:

--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -204,9 +204,10 @@ class AssemblyInspector:
             for package_name, required_nvr in all_package_overrides.items():
                 if package_name in member_package_overrides and package_name not in installed_packages:
                     # A dependency was defined explicitly in an assembly member, but it is not installed.
-                    # i.e. the artists expected something to be installed, but it wasn't. Raise an issue.
-                    # Tis is impermissible because the assembly definition can easily be changed to remove the explicit dep.
-                    issues.append(AssemblyIssue(f'Expected image to contain assembly member override dependencies NVR {required_nvr} but it was not installed', component=dgk))
+                    # i.e. the artists expected something to be installed, but it wasn't found in the final image.
+                    # Raise an issue. In rare circumstances the RPM may be used by early stage of the Dockerfile
+                    # and not in the final. In this case, it should be permitted in the assembly definition.
+                    issues.append(AssemblyIssue(f'Expected image to contain assembly member override dependencies NVR {required_nvr} but it was not installed', component=dgk, code=AssemblyIssueCode.MISSING_INHERITED_DEPENDENCY))
 
                 if package_name in installed_packages:
                     installed_build_dict: Dict = installed_packages[package_name]


### PR DESCRIPTION
This actually ocurred during [ART-3875](https://issues.redhat.com/browse/ART-3875) where the ironic image
installed grub2 in a stage, but it was not included in the final
stage.