### PR TITLE
get_latest_build: permit unbounded brew event

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -749,7 +749,7 @@ class ImageDistGitRepo(DistGitRepo):
                 # If the version & release information was not specified,
                 # try to detect latest build from brew.
                 # Read in version information from the Distgit dockerfile
-                _, version, release = self.metadata.get_latest_build_info()
+                _, version, release = self.metadata.get_latest_build_info(complete_before_event=-1)
 
             image_name_and_version = "%s:%s-%s" % (self.config.name, version, release)
             brew_image_url = self.runtime.resolve_brew_image_url(image_name_and_version)

--- a/doozerlib/exectools.py
+++ b/doozerlib/exectools.py
@@ -5,7 +5,6 @@ ordinary subprocess behaviors.
 """
 
 import asyncio
-from asyncio import events
 import contextvars
 import functools
 

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -117,7 +117,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             runtime=self.mock_runtime(),
                             distgit_key="my-distgit-key",
                             name="my-name",
-                            get_latest_build_info=lambda *_: ("_", "my-version", "my-release"),
+                            get_latest_build_info=lambda *_, **_2: ("_", "my-version", "my-release"),
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
                             logger=flexmock(info=lambda *_: None),


### PR DESCRIPTION
Based on https://github.com/openshift/doozer/pull/526.

If `complete_before_event < 0`, `get_latest_build` will return the latest
build with no constraint on brew event. This should fix the tag push issue
in 3.11.

This PR also consolidates the implementation in `doozerlib` and
`elliottlib`: Include tag names of the build in `_tags` field.