### PR TITLE
Remove rpm-py-installer

### DIFF
--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -1,7 +1,7 @@
 from typing import List, Dict, Optional
 
 from koji import ClientSession
-from kobo.rpmlib import parse_nvr
+from doozerlib.rpm_utils import parse_nvr
 
 from doozerlib import util, Runtime
 from doozerlib.image import BrewBuildImageInspector

--- a/doozerlib/cli/config_plashet.py
+++ b/doozerlib/cli/config_plashet.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Tuple
 import click
 import requests
 import yaml
-from kobo.rpmlib import compare_nvr, parse_nvr
+from doozerlib.rpm_utils import compare_nvr, parse_nvr
 from requests_kerberos import HTTPKerberosAuth
 
 from doozerlib.cli import cli

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple, Dict, NamedTuple, Iterable, Set, Any, 
 import click
 import yaml
 import openshift as oc
-from kobo.rpmlib import parse_nvr
+from doozerlib.rpm_utils import parse_nvr
 
 from doozerlib.brew import KojiWrapper
 from doozerlib.rhcos import RHCOSBuildInspector

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -21,7 +21,7 @@ import bashlex
 import requests
 import yaml
 from dockerfile_parse import DockerfileParser
-from kobo.rpmlib import parse_nvr
+from doozerlib.rpm_utils import parse_nvr
 from tenacity import (before_sleep_log, retry, retry_if_not_result,
                       stop_after_attempt, wait_fixed)
 

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -4,7 +4,7 @@ import json
 import random
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from kobo.rpmlib import parse_nvr, compare_nvr
+from doozerlib.rpm_utils import parse_nvr, compare_nvr
 
 from doozerlib import brew, coverity, exectools
 from doozerlib.distgit import pull_image

--- a/doozerlib/plashet.py
+++ b/doozerlib/plashet.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from logging import Logger
 from typing import Dict, Iterable, List, Optional, Union
 
-from kobo.rpmlib import parse_nvr
+from doozerlib.rpm_utils import parse_nvr
 from koji import ClientSession
 
 from doozerlib.assembly import assembly_metadata_config, assembly_rhcos_config

--- a/doozerlib/rhcos.py
+++ b/doozerlib/rhcos.py
@@ -2,7 +2,7 @@
 import json
 from typing import Dict, List, Tuple, Optional
 
-from kobo.rpmlib import parse_nvr
+from doozerlib.rpm_utils import parse_nvr
 
 from tenacity import retry, stop_after_attempt, wait_fixed
 from urllib import request

--- a/doozerlib/rpm_utils.py
+++ b/doozerlib/rpm_utils.py
@@ -1,0 +1,249 @@
+from typing import Dict, Optional, Tuple
+
+
+NVR = Dict[str, Optional[str]]
+
+
+def split_nvr_epoch(nvre: str):
+    """Split nvre to N-V-R and E.
+
+    This function is backported from `kobo.rpmlib.split_nvr_epoch`.
+
+    @param nvre: E:N-V-R or N-V-R:E string
+    @type nvre: str
+    @return: (N-V-R, E)
+    @rtype: (str, str)
+    """
+
+    if ":" in nvre:
+        if nvre.count(":") != 1:
+            raise ValueError("Invalid NVRE: %s" % nvre)
+
+        nvr, epoch = nvre.rsplit(":", 1)
+        if "-" in epoch:
+            if "-" not in nvr:
+                # switch nvr with epoch
+                nvr, epoch = epoch, nvr
+            else:
+                # it's probably N-E:V-R format, handle it after the split
+                nvr, epoch = nvre, ""
+    else:
+        nvr, epoch = nvre, ""
+
+    return (nvr, epoch)
+
+
+def parse_nvr(nvre: str):
+    """Split N-V-R into a dictionary.
+
+    This function is backported from `kobo.rpmlib.parse_nvr`.
+
+    @param nvre: N-V-R:E, E:N-V-R or N-E:V-R string
+    @type nvre: str
+    @return: {name, version, release, epoch}
+    @rtype: dict
+    """
+
+    if "/" in nvre:
+        nvre = nvre.split("/")[-1]
+
+    nvr, epoch = split_nvr_epoch(nvre)
+
+    nvr_parts = nvr.rsplit("-", 2)
+    if len(nvr_parts) != 3:
+        raise ValueError("Invalid NVR: %s" % nvr)
+
+    # parse E:V
+    if epoch == "" and ":" in nvr_parts[1]:
+        epoch, nvr_parts[1] = nvr_parts[1].split(":", 1)
+
+    # check if epoch is empty or numeric
+    if epoch != "":
+        try:
+            int(epoch)
+        except ValueError:
+            raise ValueError("Invalid epoch '%s' in '%s'" % (epoch, nvr))
+
+    result = dict(zip(["name", "version", "release"], nvr_parts))
+    result["epoch"] = epoch
+    return result
+
+
+def compare_nvr(nvr_dict1: NVR, nvr_dict2: NVR, ignore_epoch: bool = False):
+    """Compare two N-V-R dictionaries.
+
+    This function is backported from `kobo.rpmlib.compare_nvr`.
+
+    @param nvr_dict1: {name, version, release, epoch}
+    @type nvr_dict1: dict
+    @param nvr_dict2: {name, version, release, epoch}
+    @type nvr_dict2: dict
+    @param ignore_epoch: ignore epoch during the comparison
+    @type ignore_epoch: bool
+    @return: nvr1 newer than nvr2: 1, same nvrs: 0, nvr1 older: -1, different names: ValueError
+    @rtype: int
+    """
+
+    nvr1 = nvr_dict1.copy()
+    nvr2 = nvr_dict2.copy()
+
+    nvr1["epoch"] = nvr1.get("epoch", None)
+    nvr2["epoch"] = nvr2.get("epoch", None)
+
+    if nvr1["name"] != nvr2["name"]:
+        raise ValueError("Package names doesn't match: %s, %s" % (nvr1["name"], nvr2["name"]))
+
+    if ignore_epoch:
+        nvr1["epoch"] = 0
+        nvr2["epoch"] = 0
+
+    if nvr1["epoch"] is None:
+        nvr1["epoch"] = ""
+
+    if nvr2["epoch"] is None:
+        nvr2["epoch"] = ""
+
+    return labelCompare((str(nvr1["epoch"]), str(nvr1["version"]), str(nvr1["release"])), (str(nvr2["epoch"]), str(nvr2["version"]), str(nvr2["release"])))
+
+
+EVR = Tuple[Optional[str], str, str]
+
+
+def labelCompare(a: EVR, b: EVR):
+    """ This function is backported from C function `rpmverCmp`.
+    https://github.com/rpm-software-management/rpm/blob/9e4caf0fc536d1244b298abd9dc4c535b6560d69/rpmio/rpmver.c#L115
+
+    :return: 1: a is newer than b; 0: a and b are the same version; -1: b is newer than a
+    """
+    e1 = "0" if a[0] is None else a[0]
+    e2 = "0" if b[0] is None else b[0]
+    rc = _compare_values(e1, e2)
+    if rc == 0:  # a.epoch == b.epoch
+        rc = _compare_values(a[1], b[1])
+        if rc == 0:  # a.version == b.version
+            rc = _compare_values(a[2], b[2])
+    return rc
+
+
+def _compare_values(a: Optional[str], b: Optional[str]):
+    """ This function is backported from C function `compare_values`.
+    https://github.com/rpm-software-management/rpm/blob/9e4caf0fc536d1244b298abd9dc4c535b6560d69/rpmio/rpmver.c#L104
+    """
+    if a is None and b is None:
+        return 0
+    if a is not None and b is None:
+        return 1
+    if a is None and b is not None:
+        return -1
+    return _rpmvercmp(a, b)
+
+
+def _rpmvercmp(a: str, b: str):
+    """ This function is backported from C function `rpmvercmp`.
+    https://github.com/rpm-software-management/rpm/blob/9e4caf0fc536d1244b298abd9dc4c535b6560d69/rpmio/rpmvercmp.c#L16
+    """
+    if a == b:
+        return 0
+    str1 = a + "\0"
+    str2 = b + "\0"
+    one = 0
+    two = 0
+    while str1[one] != "\0" or str2[two] != "\0":
+        while str1[one] != "\0" and not str1[one].isalnum() and str1[one] not in ["~", "^"]:
+            one += 1
+        while str2[two] != "\0" and not str2[two].isalnum() and str2[two] not in ["~", "^"]:
+            two += 1
+        # handle the tilde separator, it sorts before everything else
+        if str1[one] == "~" or str2[two] == "~":
+            if str1[one] != "~":
+                return 1
+            if str2[two] != "~":
+                return -1
+            one += 1
+            two += 1
+            continue
+        # Handle caret separator. Concept is the same as tilde,
+        # except that if one of the strings ends (base version),
+        # the other is considered as higher version.
+        if str1[one] == "^" or str2[two] == "^":
+            if str1[one] == "\0":
+                return -1
+            if str2[two] == "\0":
+                return 1
+            if str1[one] != "^":
+                return 1
+            if str2[two] != "^":
+                return -1
+            one += 1
+            two += 1
+            continue
+        # If we ran to the end of either, we are finished with the loop
+        if not (str1[one] != "\0" and str2[two] != "\0"):
+            break
+
+        p = one
+        q = two
+
+        # grab first completely alpha or completely numeric segment
+        # leave one and two pointing to the start of the alpha or numeric
+        # segment and walk str1 and str2 to end of segment
+        if str1[p].isdigit():
+            while(str1[p] != "\0" and str1[p].isdigit()):
+                p += 1
+            while(str2[q] != "\0" and str2[q].isdigit()):
+                q += 1
+            isnum = 1
+        else:
+            while(str1[p] != "\0" and str1[p].isalpha()):
+                p += 1
+            while(str2[q] != "\0" and str2[q].isalpha()):
+                q += 1
+            isnum = 0
+
+        # this cannot happen, as we previously tested to make sure that
+        # the first string has a non-null segment
+        if one == p:
+            return -1  # arbitrary
+
+        # take care of the case where the two version segments are
+        # different types: one numeric, the other alpha (i.e. empty)
+        # numeric segments are always newer than alpha segments
+        if two == q:
+            return 1 if isnum else -1
+
+        if isnum:
+            # throw away any leading zeros - it's a number, right?
+            while str1[one] == "0":
+                one += 1
+            while str2[two] == "0":
+                two += 1
+            # whichever number has more digits wins
+            onelen = p - one
+            twolen = q - two
+            if onelen > twolen:
+                return 1
+            if onelen < twolen:
+                return -1
+
+        # strcmp will return which one is greater - even if the two
+        # segments are alpha or if they are numeric.  don't return
+        # if they are equal because there might be more segments to
+        # compare
+
+        if str1[one:p] < str2[two:q]:
+            return -1
+        if str1[one:p] > str2[two:q]:
+            return 1
+
+        one = p
+        two = q
+
+    # this catches the case where all numeric and alpha segments have
+    # compared identically but the segment sepparating characters were
+    # different
+
+    if str1[one] == "\0" and str2[two] == "\0":
+        return 0
+
+    # whichever version still has characters left over wins
+    return -1 if str1[one] == "\0" else 1

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -2,9 +2,9 @@ import glob
 import io
 import os
 import threading
-from typing import List, Dict, Optional, Union
+from typing import Optional
 
-import rpm
+from doozerlib.rpm_utils import labelCompare
 
 from doozerlib import brew, util
 from doozerlib.exceptions import DoozerFatalError
@@ -180,7 +180,7 @@ class RPMMetadata(Metadata):
                 max_golang_nevr = None
                 for build in latest_builds:
                     nevr = (build["name"], build["epoch"], build["version"], build["release"])
-                    if max_golang_nevr is None or rpm.labelCompare(nevr[1:], max_golang_nevr[1:]) > 0:
+                    if max_golang_nevr is None or labelCompare(nevr[1:], max_golang_nevr[1:]) > 0:
                         max_golang_nevr = nevr
                 if max_golang_nevr is None:
                     raise DoozerFatalError(f"Buildroot {buildroot} doesn't contain any golang compiler packages.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,11 @@ click >= 6.7
 contextvars ; python_version<"3.7"
 dockerfile-parse >= 0.0.13
 future
-kobo ~= 0.19.0
 koji
 PyGitHub >= 1.46
 pyyaml >= 5.1
 requests
 requests_kerberos
-rpm-py-installer
 semver
 tenacity
 wrapt

--- a/tests/test_rpm_utils.py
+++ b/tests/test_rpm_utils.py
@@ -1,0 +1,117 @@
+import imp
+from unittest import TestCase
+from doozerlib import rpm_utils
+
+
+class TestRPMUtils(TestCase):
+    def test_rpmverCmp(self):
+        # Tests are extracted from
+        # https://github.com/rpm-software-management/rpm/blob/9e4caf0fc536d1244b298abd9dc4c535b6560d69/tests/rpmvercmp.at#L1
+        self.assertEqual(rpm_utils._rpmvercmp("1.0", "1.0"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0", "2.0"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("2.0", "1.0"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("2.0.1", "2.0.1"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("2.0", "2.0.1"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("2.0.1", "2.0"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("2.0.1a", "2.0.1a"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("2.0.1a", "2.0.1"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("2.0.1", "2.0.1a"), -1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("5.5p1", "5.5p1"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("5.5p1", "5.5p2"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("5.5p2", "5.5p1"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("5.5p10", "5.5p10"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("5.5p1", "5.5p10"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("5.5p10", "5.5p1"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("xyz10", "xyz10"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("xyz10", "xyz10.1"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("xyz10.1", "xyz10"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("xyz.4", "xyz.4"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("xyz.4", "8"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("8", "xyz.4"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("xyz.4", "2"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("2", "xyz.4"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("5.5p2", "5.6p1"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("5.6p1", "5.5p2"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("5.6p1", "6.5p1"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("6.5p1", "5.6p1"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("6.0.rc1", "6.0"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("6.0", "6.0.rc1"), -1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("10b2", "10a1"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("10a2", "10b2"), -1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("1.0aa", "1.0aa"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0a", "1.0aa"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0aa", "1.0a"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("10.0001", "10.0001"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("10.0001", "10.1"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("10.1", "10.0001"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("10.10.0001", "10.0039"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("10.10.0039", "10.0001"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("4.999.9", "5.0"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("5.0", "4.999.9"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("20101121", "20101121"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("20101121", "20101122"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("20101122", "20101121"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("2_0", "2_0"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("2.0", "2_0"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("2_0", "2.0"), 0)
+
+        self.assertEqual(rpm_utils._rpmvercmp("a", "a"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("a+", "a+"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("a+", "a_"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("a_", "a+"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("+a", "+a"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("+a", "_a"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("_a", "+a"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("+_", "+_"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("_+", "+_"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("_+", "_+"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("+", "_"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("_", "+"), 0)
+
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1", "1.0~rc1"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1", "1.0"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0", "1.0~rc1"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1", "1.0~rc2"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc2", "1.0~rc1"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1~git123", "1.0~rc1~git123"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1~git123", "1.0~rc1"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1", "1.0~rc1~git123"), 1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^", "1.0^"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^", "1.0"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0", "1.0^"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^git1", "1.0^git1"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^git1", "1.0"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0", "1.0^git1"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^git1", "1.0^git2"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^git2", "1.0^git1"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^git1", "1.01"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.01", "1.0^git1"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^20160101", "1.0^20160101"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^20160101", "1.0.1"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0.1", "1.0^20160101"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^20160101^git1", "1.0^20160101^git1"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^20160102", "1.0^20160101^git1"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^20160101^git1", "1.0^20160102"), -1)
+
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1^git1", "1.0~rc1^git1"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1^git1", "1.0~rc1"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0~rc1", "1.0~rc1^git1"), -1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^git1~pre", "1.0^git1~pre"), 0)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^git1", "1.0^git1~pre"), 1)
+        self.assertEqual(rpm_utils._rpmvercmp("1.0^git1~pre", "1.0^git1"), -1)


### PR DESCRIPTION
This package is RHEL-only, which also caused a lot of build failures in the past.
It is used to compare rpm versions. I would like to port it into pure C
implementation.