### PR TITLE
inspect:stream: Add strict mode

### DIFF
--- a/doozerlib/cli/inspect_stream.py
+++ b/doozerlib/cli/inspect_stream.py
@@ -12,8 +12,9 @@ from doozerlib.assembly_inspector import AssemblyInspector
 @cli.command("inspect:stream", short_help="Inspect stream assembly for assembly issues")
 @click.argument("code", type=click.Choice([code.name for code in AssemblyIssueCode], case_sensitive=False),
                 required=True)
+@click.option("--strict", default=False, type=bool, is_flag=True, help='Fail even if permitted')
 @click.pass_obj
-def inspect_stream(runtime, code):
+def inspect_stream(runtime, code, strict):
     code = AssemblyIssueCode[code]
     if runtime.assembly != 'stream':
         print(f'Disregarding non-stream assembly: {runtime.assembly}. This command is only intended for stream')
@@ -29,7 +30,9 @@ def inspect_stream(runtime, code):
             assembly_issue = AssemblyIssue(msg, component='rhcos', code=code)
             if assembly_inspector.does_permit(assembly_issue):
                 print(f'Assembly permits code {code}.')
-                exit(0)
+                if not strict:
+                    exit(0)
+                print('Running in strict mode')
             exit(1)
         print(f'RHCOS builds consistent {rhcos_builds}')
         exit(0)


### PR DESCRIPTION
Currently, ocp4_scan relies on the exit code of inspect:stream to
determine if an rhcos build needs to be kicked off. As rhcos has been
failing, we have temporarily allowed build-sync to ignore inconsistent
rpms in rhcos to produce nightlies. This circumstance currently leads to
not triggering nightly builds.

This commit adds a `--strict` command line option, defaulting to
`False`. The current behavior is kept, but with invoking it with this
new flag, ocp4_scan will trigger new rhcos builds regardless of whether
the inconsistency is allowed.