### PR TITLE
[ART-4070] Add valid-subscription annotation to bundle

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -577,8 +577,13 @@ class OLMBundle(object):
             'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
             'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
             'operators.operatorframework.io.bundle.package.v1': self.package,
+            'operators.openshift.io/valid-subscription': self.valid_subscription_label,
         }
 
     @property
     def target(self):
         return self.runtime.get_default_candidate_brew_tag() or '{}-candidate'.format(self.branch)
+
+    @property
+    def valid_subscription_label(self):
+        return self.operator_csv_config['valid-subscription-label']

--- a/tests/test_olm_bundle.py
+++ b/tests/test_olm_bundle.py
@@ -15,3 +15,21 @@ class TestOLMBundle(unittest.TestCase):
     def test_get_bundle_image_name_with_ose_prefix(self):
         obj = flexmock(OLMBundle(None, dry_run=False, brew_session=MagicMock()), bundle_name='ose-foo')
         self.assertEqual(obj.get_bundle_image_name(), 'openshift/ose-foo')
+
+    def test_valid_subscription_label_is_present(self):
+        expected_key = 'operators.openshift.io/valid-subscription'
+        expected_val = '["My", "Subscription", "Label"]'
+
+        # mocking
+        config = {'update-csv': {'valid-subscription-label': expected_val}}
+        runtime = flexmock(
+            group_config=flexmock(operator_channel_stable='default'),
+            image_map={'myimage': flexmock(config=config)}
+        )
+        obj = flexmock(OLMBundle(runtime, dry_run=False, brew_session=MagicMock()), operator_name='myimage')
+        obj.channel = '...'
+        obj.package = '...'
+
+        self.assertIn(expected_key, obj.operator_framework_tags.keys())
+        actual_val = obj.operator_framework_tags[expected_key]
+        self.assertEqual(expected_val, actual_val)


### PR DESCRIPTION
`operators.openshift.io/valid-subscription` is now present in `annotations.yml`
and in the bundle's Dockerfile (as a `LABEL`)