### PR TITLE
[ART-4052] Allow override of `csv_namespace` per image

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1952,6 +1952,9 @@ class ImageDistGitRepo(DistGitRepo):
         csv_file, image_refs = self._get_csv_file_and_refs(csv_config)
         registry = csv_config['registry'].rstrip("/")
         image_map = csv_config.get('image-map', {})
+        namespace = csv_config.get('csv_namespace', self.runtime.group_config.get('csv_namespace', None))
+        if not namespace:
+            raise DoozerFatalError('csv_namespace is required in group.yaml when any image defines update-csv')
 
         for ref in image_refs:
             try:
@@ -1975,9 +1978,6 @@ class ImageDistGitRepo(DistGitRepo):
                     _, v, r = meta.get_latest_build_info()
                     image_tag = '{}:{}-{}'.format(meta.image_name_short, v, r)
 
-                namespace = self.runtime.group_config.get('csv_namespace', None)
-                if not namespace:
-                    raise DoozerFatalError('csv_namespace is required in group.yaml when any image defines update-csv')
                 replace = '{}/{}/{}'.format(registry, namespace, image_tag)
 
                 with io.open(csv_file, 'r+', encoding="utf-8") as f:


### PR DESCRIPTION
**WHY?**
We need to onboard some TELCO images that have references to images in non-openshift namespaces.

---

This change starts considering a new `csv_namespace` config present on the image, and uses its value when declared.
If not explicitly declared on the image config, it falls back to `group.yml`'s `csv_namespace` value.

Example:

Given the following image config snippet:
```yaml
update-csv:
  registry: foo.svc:5000
  namespace: bar
```

The image replacement in the CSV will become:
```
foo.svc:5000/bar/<image>
```

Relevant links:
* Related PR (adding this new option to ocp-build-data-validator): https://github.com/openshift/ocp-build-data-validator/pull/72
* Test run:
  * Image declaration: https://github.com/thiagoalessio/ocp-build-data/commit/f70fc08cd4dd11f08676f559cf6d48c94a02b90a
  * Custom build: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcustom/2542/parameters
    * Generated the following result in distgit: http://pkgs.devel.redhat.com/cgit/containers/topology-aware-lifecycle-operator/commit/manifests/stable/cluster-group-upgrades-operator.clusterserviceversion.yaml?h=rhaos-4.10-rhel-8&id=4eb1c05a261b4fdfaf85103db492d2333c6d9c28
    * operator test build: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=45972584
    * bundle distgit rebase (fetched correct SHAs for CSV images): http://pkgs.devel.redhat.com/cgit/containers/topology-aware-lifecycle-operator-bundle/commit/?h=rhaos-4.10-rhel-8&id=628e5d687e065980034bbc25d0221bf24d73dbd7
    * bundle test build: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=45977611