### PR TITLE
lock click version at 8.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles
 bashlex
-click >= 6.7
+click == 8.1.2
 contextvars ; python_version<"3.7"
 dockerfile-parse >= 0.0.13
 future


### PR DESCRIPTION
Multi-value flags broken in version 8.1.3 (which is the current latest).

```python
File "/home/ashwindas/.local/lib/python3.9/site-packages/click/core.py", line 2584, in __init__
    raise TypeError("'multiple' is not valid with 'is_flag', use 'count'.")
TypeError: 'multiple' is not valid with 'is_flag', use 'count'.
```

Issue PR: https://github.com/pallets/click/issues/2292