### PR TITLE
Pin click to 8.0.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles
 bashlex
-click == 8.1.2
+click~=8.0
 contextvars ; python_version<"3.7"
 dockerfile-parse >= 0.0.13
 future


### PR DESCRIPTION
Click 8.1 does not support python3.6, which is what we have in
production environment.