### PR TITLE
Include arch details in rhcos rpm inconsistency check

### DIFF
--- a/doozerlib/cli/inspect_stream.py
+++ b/doozerlib/cli/inspect_stream.py
@@ -1,4 +1,5 @@
 import click
+from pprint import pprint
 
 from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder
 from doozerlib.cli import cli
@@ -25,8 +26,9 @@ def inspect_stream(runtime, code, strict):
     if code == AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS:
         rhcos_builds, rhcos_inconsistencies = _check_inconsistent_rhcos_rpms(runtime, assembly_inspector)
         if rhcos_inconsistencies:
-            msg = f'Found RHCOS inconsistencies in builds {rhcos_builds}: {rhcos_inconsistencies}'
+            msg = f'Found RHCOS inconsistencies in builds {rhcos_builds}'
             print(msg)
+            pprint(rhcos_inconsistencies)
             assembly_issue = AssemblyIssue(msg, component='rhcos', code=code)
             if assembly_inspector.does_permit(assembly_issue):
                 print(f'Assembly permits code {code}.')

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -875,11 +875,13 @@ class PayloadGenerator:
             for nvr in rhcos_build.get_rpm_nvrs():
                 rpm_name = parse_nvr(nvr)['name']
                 if rpm_name not in rpm_uses:
-                    rpm_uses[rpm_name] = set()
-                rpm_uses[rpm_name].add(nvr)
+                    rpm_uses[rpm_name] = dict()
+                if nvr not in rpm_uses[rpm_name]:
+                    rpm_uses[rpm_name][nvr] = []
+                rpm_uses[rpm_name][nvr].append(rhcos_build.brew_arch)
 
         # Report back rpm name keys which were associated with more than one NVR in the set of RHCOS builds.
-        return {rpm_name: nvr_list for rpm_name, nvr_list in rpm_uses.items() if len(nvr_list) > 1}
+        return {rpm_name: nvr_dict for rpm_name, nvr_dict in rpm_uses.items() if len(nvr_dict) > 1}
 
     @staticmethod
     def get_mirroring_destination(sha256: str, dest_repo: str) -> str:


### PR DESCRIPTION
To know which arches are outdated for rhcos builds, we need to know the nvr -> arch mapping.
This gets us that.

```
doozer --quiet -g openshift-4.10 inspect:stream inconsistent_rhcos_rpms
Disregarding non-stream assembly: test. This command is only intended for stream
Found RHCOS inconsistencies in builds [RHCOSBuild:x86_64:410.84.202206131532-0, RHCOSBuild:ppc64le:410.84.202206211600-0, RHCOSBuild:s390x:410.84.202206171658-0, RHCOSBuild:aarch64:410.84.202206171555-0]
{'conmon': {'conmon-2.0.29-4.rhaos4.10.el8': ['x86_64', 'aarch64'],
            'conmon-2.0.29-5.rhaos4.10.el8': ['ppc64le', 's390x']},
 'cri-o': {'cri-o-1.23.3-3.rhaos4.10.git5fe1720.el8': ['x86_64', 'aarch64'],
           'cri-o-1.23.3-6.rhaos4.10.git74543e3.el8': ['ppc64le', 's390x']},
 'cups-libs': {'cups-libs-2.2.6-38.el8': ['x86_64'],
               'cups-libs-2.2.6-38.el8_4.1': ['ppc64le', 's390x', 'aarch64']},
 'grub2-common': {'grub2-common-2.02-99.el8_4.2': ['x86_64'],
                  'grub2-common-2.02-99.el8_4.9': ['ppc64le', 'aarch64']},
 'grub2-tools': {'grub2-tools-2.02-99.el8_4.2': ['x86_64'],
                 'grub2-tools-2.02-99.el8_4.9': ['ppc64le', 'aarch64']},
 'grub2-tools-extra': {'grub2-tools-extra-2.02-99.el8_4.2': ['x86_64'],
                       'grub2-tools-extra-2.02-99.el8_4.9': ['ppc64le',
                                                             'aarch64']},
 'grub2-tools-minimal': {'grub2-tools-minimal-2.02-99.el8_4.2': ['x86_64'],
                         'grub2-tools-minimal-2.02-99.el8_4.9': ['ppc64le',
                                                                 'aarch64']},
 'mokutil': {'mokutil-0.3.0-11.el8': ['x86_64'],
             'mokutil-0.3.0-11.el8_4.1': ['aarch64']},
 'openshift-clients': {'openshift-clients-4.10.0-202205190747.p0.g878f5a8.assembly.stream.el8': ['x86_64'],
                       'openshift-clients-4.10.0-202206151927.p0.g5a36fd4.assembly.stream.el8': ['ppc64le',
                                                                                                 's390x',
                                                                                                 'aarch64']}}
```