### PR TITLE
Fix doozer --version

### DIFF
--- a/doozerlib/__init__.py
+++ b/doozerlib/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 if sys.version_info < (3, 6):
     sys.exit('Sorry, Python < 3.6 is not supported.')
@@ -9,4 +10,8 @@ from .pushd import Dir
 
 
 def version():
-    return get_version()
+    return get_version(
+        root=os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..')
+        )
+    )


### PR DESCRIPTION
Command was failing when executed from outside Doozer folder. Setting **root** param for setuptools_scm.get_version() fixed it.