### PR TITLE
Assembly inheritance: Fix key removal

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -1,9 +1,8 @@
-import typing
 import copy
-
+import typing
 from enum import Enum
 
-from doozerlib.model import Missing, Model, ListModel
+from doozerlib.model import ListModel, Missing, Model
 
 
 class AssemblyTypes(Enum):
@@ -89,6 +88,7 @@ def merger(a, b):
                 if k not in c:
                     c[k] = v
             elif k.endswith('-'):  # remove key entirely
+                k = k[:-1]
                 c.pop(k, None)
             else:
                 if k in c:

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -227,6 +227,12 @@ releases:
             {'r': [1, 2]}
         )
 
+        # - key removes itself entirely
+        self.assertEqual(
+            merger({'r-': [1, 2]}, {'r': [3, 4]}),
+            {}
+        )
+
     def test_assembly_basis_event(self):
         self.assertEqual(assembly_basis_event(self.releases_config, 'ART_1'), None)
         self.assertEqual(assembly_basis_event(self.releases_config, 'ART_6'), 5)


### PR DESCRIPTION
Fix an issue that removing a key (using `key-`) doesn't work in a child
assembly.