### PR TITLE
[ART-3883] multiple rhcos containers

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -21,6 +21,7 @@ class AssemblyIssueCode(Enum):
     OUTDATED_RPMS_IN_STREAM_BUILD = 4
     INCONSISTENT_RHCOS_RPMS = 5
     MISSING_INHERITED_DEPENDENCY = 6
+    MISSING_RHCOS_CONTAINER = 7
 
 
 class AssemblyIssue:

--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -8,7 +8,7 @@ from doozerlib.image import BrewBuildImageInspector
 from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.assembly import assembly_rhcos_config, AssemblyTypes, assembly_permits, AssemblyIssue, \
     AssemblyIssueCode, assembly_type
-from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder, get_primary_container_name
+from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder, get_container_configs
 
 
 class AssemblyInspector:
@@ -309,17 +309,28 @@ class AssemblyInspector:
         brew_arch = util.brew_arch_for_go_arch(arch)
         runtime.logger.info(f"Getting latest RHCOS source for {brew_arch}...")
 
-        # See if this assembly has assembly.rhcos.machine-os-content.images populated for this architecture.
-        assembly_rhcos_arch_pullspec = self.assembly_rhcos_config[get_primary_container_name(runtime)].images[brew_arch]
+        # See if this assembly has assembly.rhcos.*.images populated for this architecture.
+        pullspec_for_tag = dict()
+        for container_conf in get_container_configs(runtime):
+            # first we look at the assembly definition as the source of truth for RHCOS containers
+            assembly_rhcos_arch_pullspec = self.assembly_rhcos_config[container_conf.name].images[brew_arch]
+            if assembly_rhcos_arch_pullspec:
+                pullspec_for_tag[container_conf.name] = assembly_rhcos_arch_pullspec
+                continue
 
-        if self.runtime.assembly_type != AssemblyTypes.STREAM and not assembly_rhcos_arch_pullspec:
-            raise Exception(f'Assembly {runtime.assembly} has is not a STREAM but no assembly.rhcos MOSC image data for {brew_arch}; all MOSC image data must be populated for this assembly to be valid')
+            # for non-stream assemblies we expect explicit config for RHCOS
+            if self.runtime.assembly_type != AssemblyTypes.STREAM:
+                if container_conf.primary:
+                    raise Exception(f'Assembly {runtime.assembly} is not type STREAM but no assembly.rhcos.{container_conf.name} image data for {brew_arch}; all RHCOS image data must be populated for this assembly to be valid')
+                # require the primary container at least to be specified, but
+                # allow the edge case where we add an RHCOS container type and
+                # previous assemblies don't specify it - can just look it up from the build
+                continue
 
-        version = self.runtime.get_minor_version()
-        if assembly_rhcos_arch_pullspec:
-            return RHCOSBuildInspector(runtime, assembly_rhcos_arch_pullspec, brew_arch)
-        else:
-            _, pullspec = RHCOSBuildFinder(runtime, version, brew_arch, private, custom=custom).latest_container()
+            version = self.runtime.get_minor_version()
+            _, pullspec = RHCOSBuildFinder(runtime, version, brew_arch, private, custom=custom).latest_container(container_conf)
             if not pullspec:
                 raise IOError(f"No RHCOS latest found for {version} / {brew_arch}")
-            return RHCOSBuildInspector(runtime, pullspec, brew_arch)
+            pullspec_for_tag[container_conf.name] = pullspec
+
+        return RHCOSBuildInspector(runtime, pullspec_for_tag, brew_arch)

--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -8,7 +8,7 @@ from doozerlib.image import BrewBuildImageInspector
 from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.assembly import assembly_rhcos_config, AssemblyTypes, assembly_permits, AssemblyIssue, \
     AssemblyIssueCode, assembly_type
-from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder
+from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder, get_primary_container_name
 
 
 class AssemblyInspector:
@@ -310,7 +310,7 @@ class AssemblyInspector:
         runtime.logger.info(f"Getting latest RHCOS source for {brew_arch}...")
 
         # See if this assembly has assembly.rhcos.machine-os-content.images populated for this architecture.
-        assembly_rhcos_arch_pullspec = self.assembly_rhcos_config['machine-os-content'].images[brew_arch]
+        assembly_rhcos_arch_pullspec = self.assembly_rhcos_config[get_primary_container_name(runtime)].images[brew_arch]
 
         if self.runtime.assembly_type != AssemblyTypes.STREAM and not assembly_rhcos_arch_pullspec:
             raise Exception(f'Assembly {runtime.assembly} has is not a STREAM but no assembly.rhcos MOSC image data for {brew_arch}; all MOSC image data must be populated for this assembly to be valid')

--- a/doozerlib/assembly_inspector.py
+++ b/doozerlib/assembly_inspector.py
@@ -319,7 +319,7 @@ class AssemblyInspector:
         if assembly_rhcos_arch_pullspec:
             return RHCOSBuildInspector(runtime, assembly_rhcos_arch_pullspec, brew_arch)
         else:
-            _, pullspec = RHCOSBuildFinder(runtime, version, brew_arch, private, custom=custom).latest_machine_os_content()
+            _, pullspec = RHCOSBuildFinder(runtime, version, brew_arch, private, custom=custom).latest_container()
             if not pullspec:
                 raise IOError(f"No RHCOS latest found for {version} / {brew_arch}")
             return RHCOSBuildInspector(runtime, pullspec, brew_arch)

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -943,11 +943,12 @@ class PayloadGenerator:
                 final_members[tag_name] = pod_entry
 
         rhcos_build: RHCOSBuildInspector = assembly_inspector.get_rhcos_build(arch)
-        final_members['machine-os-content'] = PayloadGenerator.PayloadEntry(
-            dest_pullspec=rhcos_build.get_image_pullspec(),
-            rhcos_build=rhcos_build,
-            issues=list(),
-        )
+        for container_config in rhcos_build.get_container_configs():
+            final_members[container_config.name] = PayloadGenerator.PayloadEntry(
+                dest_pullspec=rhcos_build.get_container_pullspec(container_config),
+                rhcos_build=rhcos_build,
+                issues=list(),
+            )
 
         # Final members should have all tags populated.
         return final_members

--- a/doozerlib/rhcos.py
+++ b/doozerlib/rhcos.py
@@ -13,7 +13,11 @@ from doozerlib.model import ListModel, Model
 from doozerlib import brew
 
 RHCOS_BASE_URL = "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases"
-default_primary_container = dict(  # historically the only RHCOS container
+# Historically the only RHCOS container was 'machine-os-content'; see
+# https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
+# But in the future this will change, see
+# https://github.com/coreos/enhancements/blob/main/os/coreos-layering.md
+default_primary_container = dict(
     name="machine-os-content",
     build_metadata_key="oscontainer",
     primary=True)
@@ -44,6 +48,14 @@ def get_primary_container_conf(runtime):
         if tag.primary:
             return tag
     raise Exception("Need to provide a group.yml rhcos.payload_tags entry with primary=true")
+
+
+def get_primary_container_name(runtime):
+    """
+    convenience method to retrieve configured primary RHCOS container name
+    @return primary container name (used in payload tag)
+    """
+    return get_primary_container_conf(runtime).name
 
 
 class RHCOSNotFound(Exception):

--- a/tests/cli/test_gen_payload.py
+++ b/tests/cli/test_gen_payload.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from doozerlib.assembly import AssemblyIssueCode
+from doozerlib.cli import release_gen_payload as rgp_cli
+from doozerlib.model import Model
+from doozerlib import rhcos
+
+
+class TestGenPayloadCli(TestCase):
+
+    def test_find_rhcos_payload_entries(self):
+        rhcos_build = MagicMock()
+        assembly_inspector = MagicMock()
+        assembly_inspector.get_rhcos_build.return_value = rhcos_build
+        rhcos_build.get_container_configs.return_value = [
+            Model(dict(name="spam", build_metadata_tag="eggs", primary=True)),
+            Model(dict(name="foo", build_metadata_tag="bar")),
+        ]
+
+        # test when a primary container is missing from rhcos build
+        rhcos_build.get_container_pullspec.side_effect = [
+            rhcos.RhcosMissingContainerException("primary missing"),
+            "somereg/somerepo@sha256:somesum",
+        ]
+        rhcos_entries, issues = rgp_cli.PayloadGenerator._find_rhcos_payload_entries(assembly_inspector, "arch")
+        self.assertNotIn("spam", rhcos_entries)
+        self.assertIn("foo", rhcos_entries)
+        self.assertEqual(issues[0].code, AssemblyIssueCode.IMPERMISSIBLE)
+
+        # test when a non-primary container is missing from rhcos build
+        rhcos_build.get_container_pullspec.side_effect = [
+            "somereg/somerepo@sha256:somesum",
+            rhcos.RhcosMissingContainerException("non-primary missing"),
+        ]
+        rhcos_entries, issues = rgp_cli.PayloadGenerator._find_rhcos_payload_entries(assembly_inspector, "arch")
+        self.assertIn("spam", rhcos_entries)
+        self.assertNotIn("foo", rhcos_entries)
+        self.assertEqual(issues[0].code, AssemblyIssueCode.MISSING_RHCOS_CONTAINER)
+
+        # test when no container is missing from rhcos build
+        rhcos_build.get_container_pullspec.side_effect = [
+            "somereg/somerepo@sha256:somesum",
+            "somereg/somerepo@sha256:someothersum",
+        ]
+        rhcos_entries, issues = rgp_cli.PayloadGenerator._find_rhcos_payload_entries(assembly_inspector, "arch")
+        self.assertEqual([], issues)
+        self.assertEqual(2, len(rhcos_entries))

--- a/tests/cli/test_scan_sources.py
+++ b/tests/cli/test_scan_sources.py
@@ -4,25 +4,26 @@ from unittest.mock import MagicMock, patch
 import yaml
 
 from doozerlib.cli import scan_sources
+from doozerlib.model import Model
 from doozerlib import rhcos
 
 
 class TestScanSourcesCli(TestCase):
 
     @patch("doozerlib.exectools.cmd_assert")
-    def test_tagged_mosc_id(self, mock_cmd):
+    def test_tagged_rhcos_id(self, mock_cmd):
         mock_cmd.return_value = ("id-1", "stderr")
-        self.assertEqual("id-1", scan_sources._tagged_mosc_id("kc.conf", "4.2", "s390x", True))
+        self.assertEqual("id-1", scan_sources._tagged_rhcos_id("kc.conf", "cname", "4.2", "s390x", True))
         self.assertIn("--kubeconfig 'kc.conf'", mock_cmd.call_args_list[0][0][0])
         self.assertIn("--namespace 'ocp-s390x-priv'", mock_cmd.call_args_list[0][0][0])
         self.assertIn("istag '4.2-art-latest-s390x-priv", mock_cmd.call_args_list[0][0][0])
 
-    @patch("doozerlib.cli.scan_sources._tagged_mosc_id", autospec=True)
+    @patch("doozerlib.cli.scan_sources._tagged_rhcos_id", autospec=True)
     @patch("doozerlib.cli.scan_sources._latest_rhcos_build_id", autospec=True)
     def test_detect_rhcos_status(self, mock_latest, mock_tagged):
         mock_tagged.return_value = "id-1"
         mock_latest.return_value = "id-2"
-        runtime = MagicMock()
+        runtime = MagicMock(group_config=Model())
         runtime.get_minor_version.return_value = "4.2"
         runtime.arches = ['s390x']
 

--- a/tests/test_rhcos.py
+++ b/tests/test_rhcos.py
@@ -139,7 +139,7 @@ class TestRhcos(unittest.TestCase):
         self.assertIn("util-linux-2.32.1-24.el8.s390x", rhcos_build.get_rpm_nvras())
         self.assertIn("util-linux-2.32.1-24.el8", rhcos_build.get_rpm_nvrs())
         self.assertEqual(rhcos_build.get_package_build_objects()['dbus']['nvr'], 'dbus-1.12.8-12.el8_3')
-        self.assertEqual(rhcos_build.get_machine_os_content_digest(), 'sha256:d51ca4e301cfdbc98e16ace0bcbee02b143a8be9e454ce5fb196467981141f59')
+        self.assertEqual(rhcos_build.get_container_digest(), 'sha256:d51ca4e301cfdbc98e16ace0bcbee02b143a8be9e454ce5fb196467981141f59')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-3883

We will need to configurably inject multiple containers from an RHCOS build into the payload. Eventually `machine-os-content` may not be the reference container and may not be present at all. https://github.com/openshift/ocp-build-data/pull/1773/files shows how we might expect config to look for the first additional container. https://github.com/openshift/ocp-build-data-validator/pull/78 enables `rhel-coreos-8` in assembly definitions.

If the changes seem a bit much to review, it will likely be easier to review one commit at a time, as each represents a discrete change.