### PR TITLE
get-nightlies: revamp for deeper comparison

### DIFF
--- a/doozerlib/cli/get_nightlies.py
+++ b/doozerlib/cli/get_nightlies.py
@@ -1,97 +1,186 @@
+from typing import List, Dict, Optional, Set, Tuple
+import asyncio
 import click
+import hashlib
 import json
 import sys
 from urllib import request
-from doozerlib.cli import cli
-from doozerlib import constants, util, exectools
-from doozerlib.rhcos import get_primary_container_name
+from doozerlib.cli import cli, click_coroutine
+from doozerlib.model import Model
+from doozerlib import constants, util, exectools, logutil
+from doozerlib.rhcos import RHCOSBuildInspector
+
+logger = logutil.getLogger(__name__)
 
 
-@cli.command("get-nightlies", short_help="Get sets of Accepted nightlies. A set contains nightly for each arch, "
-                                         "determined by closest timestamps")
-@click.option("--limit", default=1, metavar='NUM', help="Number of sets of passing nightlies to print")
+@cli.command("get-nightlies", short_help="Determine set(s) of accepted nightlies with matching contents for all architectures")
+@click.option("--matching", metavar="NIGHTLY_NAME", multiple=True, help="Only report nightlies with the same content as named nightly")
+@click.option("--allow-pending", is_flag=True, help="Include nightlies that have not completed tests")
+@click.option("--allow-rejected", is_flag=True, help="Include nightlies that have failed tests")
+@click.option("--exclude-arch", metavar="ARCH", multiple=True, help="Exclude arch(es) normally included in this version (multi,aarch64,...)")
+@click.option("--limit", default=1, metavar='NUM', help="Number of sets of nightlies to print")
 @click.option("--rhcos", is_flag=True, help="Print rhcos build id with nightlies")
-@click.option("--latest", is_flag=True, help="Just get the latest nightlies for all arches (Accepted or not)")
+@click.option("--latest", is_flag=True, help="Just get the latest nightlies for all arches (accepted or not)")
 @click.pass_obj
-def get_nightlies(runtime, limit, rhcos, latest):
+@click_coroutine
+async def get_nightlies(runtime, matching: List[str], exclude_arch: List[str], allow_pending: bool, allow_rejected: bool, limit: str, rhcos: bool, latest: bool):
+    """
+    Find one or more sets of nightlies (including all arches) that have
+    matching content according to source commits and NVRs (or in the case of
+    RHCOS containers, RPM content).
+
+    By default:
+
+    * only one set of nightlies (the most recent) is displayed (see --limit)
+
+    * only accepted nightlies will be examined (see --allow-pending / --allow-rejected)
+
+    * all arches configured for the group will be included (see --exclude-arch)
+
+    You may also specify a desired nightly or nightlies (see --matching), in
+    which case those will be the only nightlies examined in their respective
+    arches.
+
+    If results do not include a nightly that you expect to see, check the
+    doozer debug.log where details about equivalence failures are logged.
+    Matching is performed in two phases:
+
+    * The first uses only info from the nightly release images for quick
+      comparison in order to construct candidate equivalent sets of nightlies.
+
+    * The second retrieves image info for all payload content in order to
+      compare group image NVRs and RHCOS RPM content.
+    """
+    # parameter validation/processing
+    limit = int(limit)
     if latest and limit > 1:
-        print("Don't use --latest and --limit > 1", file=sys.stderr)
+        raise ValueError("Don't use --latest and --limit > 1")
+    if limit < 1:
+        raise ValueError("--limit must be a positive integer")
+    if latest:
+        allow_pending = True
+        allow_rejected = True
+    runtime.initialize(clone_distgits=False)
+    include_arches: Set[str] = determine_arch_list(runtime, set(exclude_arch))
+
+    # make lists of nightly objects per arch
+    try:
+        nightlies_for_arch: Dict[str, List[Dict]] = find_rc_nightlies(runtime, include_arches, allow_pending, allow_rejected, matching)
+    except NoMatchingNightlyException as ex:
+        util.red_print(ex)
         exit(1)
 
-    limit = int(limit)
-    runtime.initialize(clone_distgits=False)
-    major = runtime.group_config.vars.MAJOR
-    minor = runtime.group_config.vars.MINOR
+    # retrieve release info for each nightly image (with concurrency)
+    await asyncio.gather(*[
+        populate_nightly_release_data(nightly)
+        for arch, nightlies in nightlies_for_arch.items()
+        for nightly in nightlies
+    ])
 
-    not_arm = major == 4 and minor < 9
-    nightlies_with_phase = {}
+    # find sets of nightlies where all arches have equivalent content
+    eq_sets = []
+    for eq_set in generate_equivalence_sets(nightlies_for_arch):
+        # check for deeper equivalence
+        await eq_set.populate_deeper_equivalence(runtime)
+        if eq_set.deeper_equivalence():
+            eq_sets.append(eq_set)
+            util.green_print(eq_set)
+            if len(eq_sets) >= limit:
+                break  # don't spend time looking for more than were requested
 
-    def ignore_arch(arch):
-        return (arch == 'arm64' and not_arm) or arch == 'multi'
-
-    for arch in util.go_arches:
-        if ignore_arch(arch):
-            continue
-        phase = 'Accepted'
-        if latest:
-            phase = ''
-        nightlies_with_phase[arch] = all_nightlies_in_phase(major, minor, arch, phase)
-
-    primary_coreos_tag = get_primary_container_name(runtime)
-
-    i = 0
-    for x64_nightly, x64_phase in nightlies_with_phase["amd64"]:
-        if i >= limit:
-            break
-        nightly_set = []
-        for arch in util.go_arches:
-            if ignore_arch(arch):
-                continue
-            if latest:
-                nightly, phase = nightlies_with_phase[arch][i]
-            else:
-                nightly, phase = get_closest_nightly(nightlies_with_phase[arch], x64_nightly)
-            nightly_set.append(nightly)
-            nightly_str = f'{nightly} {phase}'
-            if rhcos:
-                if phase != 'Pending':
-                    rhcos = get_coreos_build_from_payload(get_nightly_pullspec(nightly, arch), primary_coreos_tag)
-                    nightly_str += f' {rhcos}'
-            print(nightly_str)
-        print(",".join(nightly_set))
-        i += 1
+    if not eq_sets:
+        util.red_print("No sets of equivalent nightlies found for given parameters.")
+        exit(1)
 
 
-def get_nightly_pullspec(release, arch):
-    suffix = util.go_suffix_for_arch(arch)
-    return f'registry.ci.openshift.org/ocp{suffix}/release{suffix}:{release}'
+def determine_arch_list(runtime, exclude_arches: Set[str]) -> Set[str]:
+    """
+    Validate exclude_arches and return group-configured arches without them
+    """
+    available_arches: Set[str] = set(runtime.group_config.arches or [])
+    # TODO: managing multi requires an oc new enough to understand
+    # manifest-listed release images, and possibly other complications - tackle
+    # this when we get closer to releasing multi.
+    #
+    # if runtime.group_config.multi_arch.enabled:
+    #     available_arches.add("multi")
+
+    try:
+        exclude_arches = set(util.brew_arch_for_go_arch(arch) for arch in exclude_arches)
+    except Exception as ex:
+        raise ValueError(f"invalid --exclude-arch: {ex}")
+
+    for arch in exclude_arches:
+        if arch not in available_arches:
+            raise ValueError(f"arch {arch} is not among the available arches for this version: {available_arches}")
+
+    return available_arches - exclude_arches
 
 
-def get_coreos_build_from_payload(payload_pullspec, primary_coreos_tag):
-    """Retrieve the build version of RHCOS (e.g. 411.86.202206131434-0)"""
-    out, err = exectools.cmd_assert(["oc", "adm", "release", "info", "--image-for", primary_coreos_tag, "--", payload_pullspec])
-    if err:
-        raise Exception(f"Error running oc adm: {err}")
-    rhcos_pullspec = out.split('\n')[0]
-    out, err = exectools.cmd_assert(["oc", "image", "info", "-o", "json", rhcos_pullspec])
-    if err:
-        raise Exception(f"Error running oc adm: {err}")
-    image_info = json.loads(out)
-    build_id = image_info["config"]["config"]["Labels"]["version"]
-    return build_id
+class NoMatchingNightlyException(Exception):
+    """Indicates one or more nightlies that were requested to match were not found"""
+    pass
 
 
-def get_closest_nightly(nightly_with_phase_list, nightly):
-    target_ts = util.get_release_tag_datetime(nightly)
-    min_delta, min_nightly = None, None
-    for nightly, phase in nightly_with_phase_list:
-        nightly_ts = util.get_release_tag_datetime(nightly)
-        delta = target_ts - nightly_ts
-        local_delta = abs(delta.total_seconds())
-        if min_delta is None or local_delta < min_delta:
-            min_delta = local_delta
-            min_nightly = (nightly, phase)
-    return min_nightly
+class EmptyArchException(Exception):
+    """Indicates there are no (accepted) nightlies for an arch"""
+    pass
+
+
+def find_rc_nightlies(runtime, arches: Set[str], allow_pending: bool, allow_rejected: bool, matching: Optional[List[str]] = []) -> Dict[str, List[Dict]]:
+    """
+    Find all current nightlies for each arch, in order RC gives them (most
+    recent to oldest). Filter to Accepted unless allow_rejected is true.
+    ref.  https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.12.0-0.nightly/tags
+    Each nightly looks like:
+    {
+      "name": "4.12.0-0.nightly-2022-07-15-132344",
+      "phase": "Ready",
+      "pullSpec": "registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-07-15-132344",
+      "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.12.0-0.nightly-2022-07-15-132344"
+    }
+    """
+    found_matching: Dict[str, bool] = {name: False for name in matching}
+    nightlies_for_arch: Dict[str, List[Dict]] = {}
+    allowed_phases = {"Accepted"}
+    if allow_pending:
+        allowed_phases.add("Ready")
+    if allow_rejected:
+        allowed_phases.add("Rejected")
+
+    tag_base: str = f"{runtime.group_config.vars.MAJOR}.{runtime.group_config.vars.MINOR}.0-0.nightly"
+    for arch in arches:
+        # retrieve the list of nightlies from the release-controller
+        rc_url: str = f"{rc_api_url(tag_base, arch)}/tags"
+        logger.info(f"Reading nightlies from {rc_url}")
+        with request.urlopen(rc_url) as req:
+            data = json.loads(req.read().decode())
+
+        # filter them per parameters
+        nightlies: List[Dict] = [
+            nightly for nightly in (data.get("tags") or [])
+            if nightly["phase"] in allowed_phases
+        ]
+        matched_nightlies: List[Dict] = [
+            nightly for nightly in nightlies
+            if nightly["name"] in matching
+        ]
+        if matched_nightlies:
+            nightlies = matched_nightlies  # no need to look at others in this arch
+            for nightly in matched_nightlies:
+                found_matching[nightly["name"]] = True
+
+        if not nightlies:
+            # must be nightlies to succeed; user must adjust parameters
+            raise EmptyArchException(f"No nightlies for {tag_base} {arch} are in state {allowed_phases}")
+        nightlies_for_arch[arch] = nightlies
+
+    # make sure we found every match we expected
+    unmatched: Set[str] = {name for name, found in found_matching.items() if not found}
+    if matching and unmatched:
+        raise NoMatchingNightlyException(f"Found no nightlies in state {allowed_phases} matching {unmatched}")
+
+    return nightlies_for_arch
 
 
 def rc_api_url(tag, arch):
@@ -107,16 +196,269 @@ def rc_api_url(tag, arch):
     return f"{constants.RC_BASE_URL.format(arch=arch)}/api/v1/releasestream/{tag}{arch_suffix}"
 
 
-def all_nightlies_in_phase(major, minor, arch, phase):
-    # returns the build id string or None (or raise exception), one for each arch
-    # (may want to return "schema-version" also if this ever gets more complex)
-    tag = f'{major}.{minor}.0-0.nightly'
-    rc_url = f"{rc_api_url(tag, arch)}/tags"
-    if phase:
-        rc_url += f'?phase={phase}'
-    with request.urlopen(rc_url) as req:
-        data = json.loads(req.read().decode())
-    if not data["tags"]:
-        return None
-    nightlies = [(tag["name"], tag["phase"]) for tag in data["tags"]]
-    return nightlies
+async def populate_nightly_release_data(nightly: Dict[str, str]):
+    """
+    update the nightly record with new fields from the release image:
+    releaseInfo: output from `oc adm release info -o json` for the nightly pullspec
+    equivalence: an EquivalenceBase object for comparing to other nightlies
+    """
+    release_json_str, _ = await exectools.cmd_assert_async(f"oc adm release info {nightly['pullSpec']} -o=json", retries=3)
+    info = nightly["releaseInfo"] = json.loads(release_json_str)
+    nightly["equivalence"] = EquivalenceBase(info)
+
+
+# only look up the same container info once and store it here
+image_info_cache: Dict[str, Dict] = {}
+
+
+class EquivalenceBase:
+    """
+    Class to enable an initial comparison of two nightlies, just checking that
+    they have the same source commits. RHCOS containers have no source commit
+    annotation so are compared based on image labels (only after other
+    comparisons succeed).
+
+    If the initial comparison succeeds, then a deeper comparison can be
+    performed using image info from pullspecs and RHCOS build records.
+    """
+
+    def __init__(self, release_info: Dict):
+        self.release_info = release_info
+        self.commit_for_tag = {}
+        self.pullspec_for_tag = {}
+        self.rhcos_tag_names = set()
+        self.rhcos_tag_digests = {}
+        self.nvr_for_tag = {}
+        self.rhcos_inspector = None  # filled by populate_deeper_equivalence
+        for tag in release_info["references"]["spec"]["tags"]:
+            name = tag["name"]
+            commit = tag["annotations"]["io.openshift.build.commit.id"]
+            self.pullspec_for_tag[name] = tag["from"]["name"]
+            self.commit_for_tag[name] = commit or None
+            if not commit:  # assume RHCOS
+                self.rhcos_tag_names.add(name)
+
+        self.tag_names = set(self.commit_for_tag.keys())
+
+        # remove entries that are just stand-ins
+        pod_commit = self.commit_for_tag["pod"]  # NOTE: hardcoded required "stand-in" member
+        self.commit_for_tag = {
+            tag: commit
+            for tag, commit in self.commit_for_tag.items()
+            if tag == "pod" or commit != pod_commit
+        }
+
+    def __eq__(self, other):
+        """
+        Determine whether self and other are superficially equivalent.
+        We do not check that all of the same tags are present in both, because
+        it turns out there are situations where differences between arches in
+        the tag set are normal.
+        We do check that if both have a tag, they have the same source commit
+        (for group images) or the same set of RPM labels (for RHCOS images).
+        """
+
+        for tag, commit in self.commit_for_tag.items():
+            other_commit = other.commit_for_tag.get(tag)
+            if commit and other_commit and commit != other_commit:
+                logger.debug(f"different because {tag}@{commit} != {tag}@{other_commit}")
+                return False
+            # ^^ missing entries automatically match
+
+        for tag in self.rhcos_tag_names:
+            if self.retrieve_rhcos_tag_digest(tag) != other.retrieve_rhcos_tag_digest(tag):
+                logger.debug("different because rhcos digests don't match")
+                return False
+
+        return True
+
+    def retrieve_rhcos_tag_digest(self, tag):
+        """
+        From the RHCOS container info extract distingushing characteristics and
+        generate a digest of them.
+
+        For now the characteristics are just labels for RPMs in the container.
+        """
+        if tag in self.rhcos_tag_digests:
+            logger.debug(f"digest {self.rhcos_tag_digests[tag]} for {tag}")
+            return self.rhcos_tag_digests[tag]
+
+        labels = {
+            key: val.rsplit(".", 1)[0]  # remove arch suffix from rpm
+            for key, val in self.retrieve_image_info(self.pullspec_for_tag[tag]).config.config.Labels.items()
+            if key.startswith("com.coreos.rpm.") and "kernel-rt" not in key
+        }
+        self.rhcos_tag_digests[tag] = hashlib.sha256(json.dumps(labels, sort_keys=True).encode("utf-8")).hexdigest()
+        logger.debug(f"digest {self.rhcos_tag_digests[tag]} for {labels} from {tag}")
+        return self.rhcos_tag_digests[tag]
+
+    def __repr__(self):
+        return f"{self.commit_for_tag}/{self.rhcos_tag_digests}"
+
+    def retrieve_image_info(self, pullspec):
+        """pull and cache json info for a container pullspec"""
+        if pullspec not in image_info_cache:
+            image_json_str, _ = exectools.cmd_assert(
+                f"oc image info {pullspec} -o=json --filter-by-os=amd64",
+                retries=3
+            )
+            image_info_cache[pullspec] = Model(json.loads(image_json_str))
+        return image_info_cache[pullspec]
+
+    async def retrieve_image_info_async(self, pullspec):
+        """pull and cache json info for a container pullspec (enable concurrency)"""
+        if pullspec not in image_info_cache:
+            image_json_str, _ = await exectools.cmd_assert_async(
+                f"oc image info {pullspec} -o=json --filter-by-os=amd64",
+                retries=3
+            )
+            image_info_cache[pullspec] = Model(json.loads(image_json_str))
+        return image_info_cache[pullspec]
+
+    async def populate_deeper_equivalence(self, runtime, arch):
+        """Retrieve image NVRs and RHCOS build data concurrently for deeper comparison"""
+        await asyncio.gather(*(
+            self.retrieve_image_info_async(self.pullspec_for_tag[tag])
+            for tag in self.commit_for_tag
+        ))
+        if not self.rhcos_inspector:
+            ps4tag = {tag: self.pullspec_for_tag[tag] for tag in self.rhcos_tag_names}
+            self.rhcos_inspector = RHCOSBuildInspector(runtime, ps4tag, arch)
+
+    def retrieve_nvr_for_tag(self, tag: str):
+        """Retrieve group image NVR according to the image info at the tag pullspec"""
+        if tag not in self.nvr_for_tag:
+            labels = self.retrieve_image_info(self.pullspec_for_tag[tag]).config.config.Labels
+            labels = tuple(labels[k] for k in ("com.redhat.component", "version", "release"))
+            self.nvr_for_tag[tag] = labels if all(labels) else None
+        return self.nvr_for_tag[tag]
+
+    def deeper_equivalence(self, other):
+        """
+        Do a deeper (more expensive) equivalence check that requires
+        populate_deeper_equivalence having been called beforehand. This checks
+        that group images NVRs and RHCOS RPM content are the same for both
+        nightlies.
+        """
+        # check that group images in the release all have the same nvr
+        for tag, commit in self.commit_for_tag.items():
+            other_commit = other.commit_for_tag.get(tag)
+            if not commit or not other_commit:
+                continue  # ignore missing or non-group entries
+            self_nvr = self.retrieve_nvr_for_tag(tag)
+            other_nvr = other.retrieve_nvr_for_tag(tag)
+            if self_nvr != other_nvr:
+                if self_nvr[0] != other_nvr[0]:
+                    # give alt images (where components differ for the same tag) a pass.
+                    # most of the time they'll have the same VR but that's not absolutely
+                    # guaranteed (one build could flake then succeed with later R).
+                    # so just rely on source commit equivalence (already verified)
+                    # and ignore the slim possibility that the RPMs installed differ.
+                    continue
+                logger.debug(f"different because {tag} NVR {self_nvr} != {other_nvr}")
+                return False
+
+        return self.deeper_equivalence_rhcos(other)
+
+    def deeper_equivalence_rhcos(self, other):
+        """Check that the two have the same RHCOS contents according to build records"""
+        for eq_base in (self, other):
+            if not eq_base.rhcos_inspector:
+                raise Exception(f"No rhcos_inspector for eq_base {eq_base}, should have called populate_deeper_equivalence first")
+            eq_base._rhcos_rpms = {
+                nevra[0]: (nevra[2], nevra[3])
+                for nevra in eq_base.rhcos_inspector.get_os_metadata_rpm_list()
+            }
+
+        logger.debug(f"comparing {self.rhcos_inspector} and {other.rhcos_inspector}")
+        for rpm_name, vr in self._rhcos_rpms.items():
+            if rpm_name in other._rhcos_rpms and vr != other._rhcos_rpms[rpm_name]:
+                logger.debug(f"different '{rpm_name}' version-release {vr} != {other._rhcos_rpms[rpm_name]}")
+                return False
+
+        return True
+
+
+class EqSetDuplicateArchException(Exception):
+    """Indicates a bug where code tried to add a nightly with an arch that's already represented in the eq set"""
+
+
+class EquivalenceSet:
+    """
+    Class to represent a set of nightlies from each arch that are equivalent
+    according to their EquivalenceBase. They can be sorted by creation date
+    (latest timestamp of nightlies in the set)
+    """
+
+    def __init__(self, nightly_for_arch: Dict[str, Dict]):
+        self.nightly_for_arch = nightly_for_arch
+        self.timestamp = max(nightly["releaseInfo"]["config"]["created"] for nightly in nightly_for_arch.values())
+
+    def augment(self, arch: str, nightly: Dict):
+        """
+        If the nightly being added is equivalent to all existing members, spawn
+        a new set that includes it and return that. Otherwise return None.
+        """
+        if arch in self.nightly_for_arch:
+            raise EqSetDuplicateArchException(f"Cannot add arch {arch} when already present in {self}")
+
+        nightly_for_arch = {arch: nightly}
+        for arch, existing in self.nightly_for_arch.items():
+            logger.debug(f"comparing {nightly['name']} and {existing['name']}")
+            if nightly["equivalence"] != existing["equivalence"]:
+                return None  # not equivalent
+            nightly_for_arch[arch] = existing
+
+        return EquivalenceSet(nightly_for_arch)
+
+    def __repr__(self):
+        return " ".join(nightly['name'] for nightly in self.nightly_for_arch.values())
+
+    async def populate_deeper_equivalence(self, runtime):
+        """Prepare EquivalenceBases for deeper (more expensive) comparison"""
+        await asyncio.gather(*(
+            nightly["equivalence"].populate_deeper_equivalence(runtime, arch)
+            for arch, nightly in self.nightly_for_arch.items()
+        ))
+
+    def deeper_equivalence(self):
+        """Check that all EquivalenceBases have deeper equivalency"""
+        nightlies = list(self.nightly_for_arch.values())
+        while len(nightlies) > 1:
+            this = nightlies.pop()
+            for other in nightlies:
+                logger.debug(f"comparing {this['name']} and {other['name']}")
+                if not this["equivalence"].deeper_equivalence(other["equivalence"]):
+                    logger.debug(f"deeper equivalence failed for {self}")
+                    return False
+
+        return True
+
+
+def generate_equivalence_sets(nightlies_for_arch: Dict[str, List[Dict]]) -> List[EquivalenceSet]:
+    """
+    Build all-arch sets of equivalent (according to EquivalenceBase.__eq__) nightlies.
+    We initialize sets with the arch with the fewest nightlies, then extend
+    them with all equivalent nightlies from one arch at a time.
+    """
+    eq_sets: List[EquivalenceSet] = []
+
+    # process arches from shortest list to longest to maximize elimination
+    for arch, nightlies in sorted(nightlies_for_arch.items(), key=lambda it: len(it[1])):
+        if not eq_sets:
+            # seed with the first arch
+            eq_sets = [EquivalenceSet({arch: nightly}) for nightly in nightlies]
+            continue
+        # try to combine everything in this arch with existing sets
+        new_sets: List[EquivalenceSet] = []
+        for eq_set in eq_sets:
+            for nightly in nightlies:
+                new_set = eq_set.augment(arch, nightly)
+                if new_set:
+                    new_sets.append(new_set)
+
+        if not new_sets:
+            return new_sets  # no sets left to augment
+        eq_sets = new_sets
+
+    return sorted(eq_sets, reverse=True, key=lambda eq_set: eq_set.timestamp)

--- a/tests/cli/test_get_nightlies.py
+++ b/tests/cli/test_get_nightlies.py
@@ -348,15 +348,15 @@ class TestGetNightlies(TestCase):
             },
         ]
         eqset = subject.EquivalenceSet({"x86_64": nightlies[0]})
-        self.assertIsNone(eqset.augment("s390x", nightlies[1]))
+        self.assertFalse(eqset.generate_equivalents_with("s390x", [nightlies[1]]))
 
-        set1 = eqset.augment("aarch64", nightlies[2])
+        set1 = eqset.generate_equivalents_with("aarch64", [nightlies[2]])[0]
         self.assertIsInstance(set1, subject.EquivalenceSet)
         self.assertEqual(set1.timestamp, "2022-07-18")  # greater of first and third
 
-        self.assertIsNone(set1.augment("s390x", nightlies[1]))
+        self.assertFalse(set1.generate_equivalents_with("s390x", [nightlies[1]]))
         with self.assertRaises(subject.EqSetDuplicateArchException):
-            eqset.augment("x86_64", nightlies[0])
+            eqset.generate_equivalents_with("x86_64", nightlies[0])
 
     def test_generate_equivalence_sets(self):
         nightlies_for_arch = {

--- a/tests/cli/test_get_nightlies.py
+++ b/tests/cli/test_get_nightlies.py
@@ -73,10 +73,25 @@ class TestGetNightlies(TestCase):
         with self.assertRaises(subject.EmptyArchException):
             subject.find_rc_nightlies(self.runtime, {"x86_64"}, True, True)
 
-    def test_populate_nightly_release_data(self):
-        pass
+    @staticmethod
+    def vanilla_nightly(release_image_info=None, name=None):
+        # just give me an instance to test (default supplies "pod" entry)
+        nightly = subject.Nightly(
+            release_image_info=release_image_info or {
+                "references": {"spec": {"tags": [
+                    {
+                        "name": "pod",
+                        "annotations": {"io.openshift.build.commit.id": "pod-commit"},
+                        "from": {"name": "pod-pullspec"},
+                    }
+                ]}}
+            },
+            name=name or "name", phase="Accepted", pullspec="nightly-pullspec",
+        )
+        nightly._process_nightly_release_data()
+        return nightly
 
-    def test_equivalence_base(self):
+    def test_nightly_eq(self):
         test_json = """
             {
                 "two-tags": {
@@ -150,184 +165,85 @@ class TestGetNightlies(TestCase):
                 }}}
             }
         """
-        release_info: Dict[str, Dict] = json.loads(test_json)
-        two_tags = subject.EquivalenceBase(release_info["two-tags"])
-        extra_tag = subject.EquivalenceBase(release_info["extra-tag"])
-        cvo_replaced = subject.EquivalenceBase(release_info["cvo-tag-replaced-by-pod"])
-        diff_pod = subject.EquivalenceBase(release_info["two-tag-different-pod"])
+        rii: Dict[str, Dict] = json.loads(test_json)
 
-        self.assertEqual(two_tags, extra_tag)
-        self.assertEqual(two_tags, cvo_replaced)
-        self.assertNotEqual(two_tags, diff_pod)
+        def make_nightly(ri_name):
+            nightly = self.vanilla_nightly(release_image_info=rii[ri_name])
+            return nightly
 
-    @patch('doozerlib.cli.get_nightlies.EquivalenceBase.retrieve_rhcos_tag_digest')
-    def test_equivalence_base_rhcos(self, mock_digest):
-        test_data = json.loads("""
-            {
-                "references": {
-                  "spec": {
-                    "tags": [
-                        {
-                          "name": "some-rhcos-tag",
-                          "annotations": { "io.openshift.build.commit.id": "" },
-                          "from": { "name": "mocked-out" }
-                        },
-                        {
-                          "name": "pod",
-                          "annotations": { "io.openshift.build.commit.id": "pod-commit" },
-                          "from": { "name": "ignored" }
-                        }
-                    ]
-                }}
-            }
-        """)
-        rhcos1 = subject.EquivalenceBase(test_data)
-        rhcos2 = subject.EquivalenceBase(test_data)
-        mock_digest.side_effect = ["digest1", "digest1"]
-        self.assertEqual(rhcos1, rhcos2)
+        n: Dict[str, subject.Nightly] = {name: make_nightly(name) for name in rii}
+        self.assertEqual(n["two-tags"], n["extra-tag"])
+        self.assertEqual(n["two-tags"], n["cvo-tag-replaced-by-pod"])
+        self.assertNotEqual(n["two-tags"], n["two-tag-different-pod"])
 
-        rhcos1 = subject.EquivalenceBase(test_data)
-        rhcos2 = subject.EquivalenceBase(test_data)
-        mock_digest.side_effect = ["digest1", "digest2"]
-        self.assertNotEqual(rhcos1, rhcos2)
-
-    @staticmethod
-    def vanilla_eq_base():
-        # just give me an instance to test (supplies "pod" entry)
-        return subject.EquivalenceBase({
-            "references": {"spec": {"tags": [
-                {
-                    "name": "pod",
-                    "annotations": {"io.openshift.build.commit.id": "pod-commit"},
-                    "from": {"name": "pod-pullspec"},
-                }
-            ]}}})
-
-    @patch('doozerlib.cli.get_nightlies.EquivalenceBase.retrieve_image_info')
+    @patch('doozerlib.cli.get_nightlies.Nightly.retrieve_image_info')
     def test_retrieve_nvr_for_tag(self, mock_rii):
-        eq = self.vanilla_eq_base()
         mock_rii.return_value = Model(dict(config=dict(config=dict(Labels={
             "com.redhat.component": "spam",
             "version": "1.0",
             "release": "1.el8",
         }))))
-        self.assertEqual(("spam", "1.0", "1.el8"), eq.retrieve_nvr_for_tag("pod"))
+        nightly = self.vanilla_nightly()
+        self.assertEqual(("spam", "1.0", "1.el8"), nightly.retrieve_nvr_for_tag("pod"))
 
         mock_rii.return_value = Exception()  # should be cached from last call
-        self.assertEqual(("spam", "1.0", "1.el8"), eq.retrieve_nvr_for_tag("pod"))
+        self.assertEqual(("spam", "1.0", "1.el8"), nightly.retrieve_nvr_for_tag("pod"))
 
         mock_rii.return_value = Model()  # no labels provided
-        eq.pullspec_for_tag["rhcos"] = "rhcos_ps"
-        self.assertIsNone(eq.retrieve_nvr_for_tag("rhcos"))
+        nightly.pullspec_for_tag["rhcos"] = "rhcos_ps"
+        self.assertIsNone(nightly.retrieve_nvr_for_tag("rhcos"))
 
-    def test_deeper_equivalence(self):
-        eq1 = self.vanilla_eq_base()
-        eq2 = self.vanilla_eq_base()
-        eq1.rhcos_inspector = eq2.rhcos_inspector = MagicMock()  # always match
-        eq1.commit_for_tag["pod"] = eq2.commit_for_tag["pod"] = "commit1"
-        eq1.nvr_for_tag["pod"] = eq2.nvr_for_tag["pod"] = ("nvr", "1", "1")
-        self.assertTrue(eq1.deeper_equivalence(eq2))
+    def test_deeper_nightly(self):
+        n1 = self.vanilla_nightly()
+        n2 = self.vanilla_nightly()
+        n1.rhcos_inspector = n2.rhcos_inspector = MagicMock()  # always match
+        n1.commit_for_tag["pod"] = n2.commit_for_tag["pod"] = "commit1"
+        n1.nvr_for_tag["pod"] = n2.nvr_for_tag["pod"] = ("nvr", "1", "1")
+        self.assertTrue(n1.deeper_equivalence(n2))
 
         # works with missing entries too
-        eq1.commit_for_tag["missing1"] = eq2.commit_for_tag["missing2"] = "mcommit"
-        self.assertTrue(eq1.deeper_equivalence(eq2), "un-shared tags are ignored")
-        self.assertTrue(eq2.deeper_equivalence(eq1), "... in both directions")
+        n1.commit_for_tag["missing1"] = n2.commit_for_tag["missing2"] = "mcommit"
+        self.assertTrue(n1.deeper_equivalence(n2), "un-shared tags are ignored")
+        self.assertTrue(n2.deeper_equivalence(n1), "... in both directions")
 
         # get a failure
-        eq2.nvr_for_tag["pod"] = ("nvr", "2", "2")
-        self.assertFalse(eq1.deeper_equivalence(eq2))
+        n2.nvr_for_tag["pod"] = ("nvr", "2", "2")
+        self.assertFalse(n1.deeper_equivalence(n2))
 
         # give alt images (where components differ for the same tag) a pass.
         # most of the time they'll have the same VR but that's not absolutely
         # guaranteed (one build could flake then succeed with later R).
         # so just rely on source commit equivalence (already verified)
         # and ignore the slim possibility that the RPMs installed differ.
-        eq2.nvr_for_tag["pod"] = ("nvr-alt", "1", "1")
-        self.assertTrue(eq1.deeper_equivalence(eq2), "alt images allowed to differ")
+        n2.nvr_for_tag["pod"] = ("nvr-alt", "1", "1")
+        self.assertTrue(n1.deeper_equivalence(n2), "alt images allowed to differ")
 
-    def test_deeper_equivalence_rhcos(self):
-        eq1 = self.vanilla_eq_base()
-        eq2 = self.vanilla_eq_base()
-        ri1 = eq1.rhcos_inspector = MagicMock()
-        ri2 = eq2.rhcos_inspector = MagicMock()
-        for eq in (eq1, eq2):
-            eq.rhcos_inspector.get_os_metadata_rpm_list.return_value = [("spam", 0, 1, 1, "noarch")]
+    def test_deeper_nightly_rhcos(self):
+        n1 = self.vanilla_nightly()
+        n2 = self.vanilla_nightly()
+        ri1 = n1.rhcos_inspector = MagicMock()
+        ri2 = n2.rhcos_inspector = MagicMock()
+        for n in (n1, n2):
+            n.rhcos_inspector.get_os_metadata_rpm_list.return_value = [("spam", 0, 1, 1, "noarch")]
 
-        self.assertTrue(eq1.deeper_equivalence_rhcos(eq2), "same RPM content")
+        self.assertTrue(n1.deeper_nightly_rhcos(n2), "same RPM content")
 
         ri2.get_os_metadata_rpm_list.return_value = [("eggs", 0, 2, 3, "noarch")]
-        self.assertTrue(eq1.deeper_equivalence_rhcos(eq2), "unchecked RPM content")
-        self.assertTrue(eq2.deeper_equivalence_rhcos(eq1), "unmatched RPM content")
+        self.assertTrue(n1.deeper_nightly_rhcos(n2), "unchecked RPM content")
+        self.assertTrue(n2.deeper_nightly_rhcos(n1), "unmatched RPM content")
 
         ri1.get_os_metadata_rpm_list.return_value = [("sausage", 0, 1, 1, "noarch")]
         ri2.get_os_metadata_rpm_list.return_value = [("sausage", 0, 2, 3, "noarch")]
-        self.assertFalse(eq1.deeper_equivalence_rhcos(eq2), "mismatched RPM content")
+        self.assertFalse(n1.deeper_nightly_rhcos(n2), "mismatched RPM content")
 
-    @patch('doozerlib.exectools.cmd_assert')
-    def test_retrieve_rhcos_tag_digest(self, mock_image_info):
-        test_data = json.loads("""
-            {
-                "references": {
-                  "spec": {
-                    "tags": [
-                        {
-                          "name": "some-rhcos-tag",
-                          "annotations": { "io.openshift.build.commit.id": "" },
-                          "from": { "name": "mocked-out" }
-                        },
-                        {
-                          "name": "other-rhcos-tag",
-                          "annotations": { "io.openshift.build.commit.id": "" },
-                          "from": { "name": "mocked-out-2" }
-                        },
-                        {
-                          "name": "ya-rhcos-tag",
-                          "annotations": { "io.openshift.build.commit.id": "" },
-                          "from": { "name": "mocked-out-3" }
-                        },
-                        {
-                          "name": "pod",
-                          "annotations": { "io.openshift.build.commit.id": "pod-commit" },
-                          "from": { "name": "ignored" }
-                        }
-                    ]
-                }}
-            }
-        """)
-        test_image_info1 = json.dumps(dict(config=dict(config=dict(Labels={"com.coreos.rpm.foo": "foo-1.0"}))))
-        test_image_info2 = json.dumps(dict(config=dict(config=dict(Labels={"com.coreos.rpm.foo": "foo-2.0"}))))
-        test_image_info3 = json.dumps(dict(config=dict(config=dict(Labels={"com.coreos.rpm.foo": "foo-1.0", "com.coreos.rpm.kernel-rt": "kernel-1.0"}))))
-
-        rhcos = subject.EquivalenceBase(test_data)
-        mock_image_info.side_effect = [(test_image_info1, None), (test_image_info2, None)]
-        self.assertNotEqual(
-            rhcos.retrieve_rhcos_tag_digest("some-rhcos-tag"),
-            rhcos.retrieve_rhcos_tag_digest("other-rhcos-tag")
-        )
-
-        mock_image_info.side_effect = [(test_image_info1, None), (test_image_info3, None)]
-        self.assertEqual(
-            rhcos.retrieve_rhcos_tag_digest("some-rhcos-tag"),
-            rhcos.retrieve_rhcos_tag_digest("ya-rhcos-tag")
-        )
-
-        rhcos = subject.EquivalenceBase(test_data)
-        # these will be retrieved from cache
-        mock_image_info.side_effect = Exception("should not get here")
-        self.assertNotEqual(
-            rhcos.retrieve_rhcos_tag_digest("other-rhcos-tag"),
-            rhcos.retrieve_rhcos_tag_digest("ya-rhcos-tag"),
-            "image infos should be cached"
-        )
-
-    def test_equivalence_set(self):
+    def test_nightly_set(self):
         nightlies = [
             {
                 "name": "4.12.0-0.nightly-2022-07-15-132344",
                 "phase": "Ready",
                 "pullSpec": "registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-07-15-132344",
                 "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.12.0-0.nightly-2022-07-15-132344",
-                "equivalence": "digest1",  # represents the EquivalenceBase determined for this nightly
+                "equivalence": "digest1",  # represents the Nightly determined for this nightly
                 "releaseInfo": {"config": {"created": "2022-07-16"}},
             },
             {
@@ -347,50 +263,62 @@ class TestGetNightlies(TestCase):
                 "releaseInfo": {"config": {"created": "2022-07-18"}},
             },
         ]
-        eqset = subject.EquivalenceSet({"x86_64": nightlies[0]})
-        self.assertFalse(eqset.generate_equivalents_with("s390x", [nightlies[1]]))
 
-        set1 = eqset.generate_equivalents_with("aarch64", [nightlies[2]])[0]
-        self.assertIsInstance(set1, subject.EquivalenceSet)
+        def make(ndict):
+            nightly = subject.Nightly(release_image_info=ndict["releaseInfo"], nightly_info=ndict)
+            nightly.commit_for_tag["pod"] = ndict["equivalence"]  # set up comparison
+            return nightly
+
+        nset = subject.NightlySet({"x86_64": make(nightlies[0])})
+        self.assertFalse(nset.generate_equivalents_with("s390x", [make(nightlies[1])]))
+
+        set1 = nset.generate_equivalents_with("aarch64", [make(nightlies[2])])[0]
+        self.assertIsInstance(set1, subject.NightlySet)
         self.assertEqual(set1.timestamp, "2022-07-18")  # greater of first and third
 
-        self.assertFalse(set1.generate_equivalents_with("s390x", [nightlies[1]]))
-        with self.assertRaises(subject.EqSetDuplicateArchException):
-            eqset.generate_equivalents_with("x86_64", nightlies[0])
+        self.assertFalse(set1.generate_equivalents_with("s390x", [make(nightlies[1])]))
+        with self.assertRaises(subject.NightlySetDuplicateArchException):
+            nset.generate_equivalents_with("x86_64", make(nightlies[0]))
 
-    def test_generate_equivalence_sets(self):
+    def test_generate_nightly_sets(self):
+
+        def make(ndict):
+            nightly = subject.Nightly(release_image_info=ndict["releaseInfo"], nightly_info=ndict, phase="Accepted", pullspec="ignore")
+            nightly.commit_for_tag["pod"] = ndict["equivalence"]  # set up comparison
+            return nightly
+
         nightlies_for_arch = {
             "x86_64": [
-                {
+                make({
                     "name": "nightly1",
-                    "equivalence": "digest1",  # represents the EquivalenceBase for this nightly
+                    "equivalence": "digest1",  # represents the matching for this nightly
                     "releaseInfo": {"config": {"created": "2022-07-17"}},
-                },
-                {
+                }),
+                make({
                     "name": "nightly2",
                     "equivalence": "digest1",
                     "releaseInfo": {"config": {"created": "2022-07-18"}},
-                },
-                {
+                }),
+                make({
                     "name": "nightly3",
                     "equivalence": "digest2",
                     "releaseInfo": {"config": {"created": "2022-07-16"}},
-                },
+                }),
             ],
             "s390x": [
-                {
+                make({
                     "name": "nightly4",
                     "equivalence": "digest1",  # matches two
                     "releaseInfo": {"config": {"created": "2022-07-17"}},
-                },
-                {
+                }),
+                make({
                     "name": "nightly5",
                     "equivalence": "digest2",  # matches one
                     "releaseInfo": {"config": {"created": "2022-07-15"}},
-                },
+                }),
             ],
         }
-        sets = subject.generate_equivalence_sets(nightlies_for_arch)
+        sets = subject.generate_nightly_sets(nightlies_for_arch)
         self.assertEqual(3, len(sets))
         # also check that they sort by timestamp desc
         self.assertEqual("2022-07-18", sets[0].timestamp)
@@ -398,10 +326,10 @@ class TestGetNightlies(TestCase):
 
         # check that an incompatible nightly torpedoes set creation
         nightlies_for_arch["ppc64le"] = [
-            {
+            make({
                 "name": "nightly6",
                 "equivalence": "digest3",  # incompatible with all
                 "releaseInfo": {"config": {"created": "2022-07-17"}},
-            },
+            }),
         ]
-        self.assertEqual(0, len(subject.generate_equivalence_sets(nightlies_for_arch)))
+        self.assertEqual(0, len(subject.generate_nightly_sets(nightlies_for_arch)))

--- a/tests/cli/test_get_nightlies.py
+++ b/tests/cli/test_get_nightlies.py
@@ -1,0 +1,407 @@
+from typing import List, Dict, Optional, Set, Tuple
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+import json
+
+from doozerlib.cli import get_nightlies as subject
+from doozerlib.model import Model
+
+
+class TestGetNightlies(TestCase):
+    def setUp(self):
+        self.runtime = MagicMock(group_config=Model(dict(
+            arches=["x86_64", "s390x", "ppc64le", "aarch64"],
+            multi_arch=dict(enabled=True),
+        )))
+        subject.image_info_cache = {}
+
+    def test_determine_arch_list(self):
+        self.assertEqual(
+            # {"aarch64", "x86_64", "multi"},  # no multi yet
+            {"aarch64", "x86_64"},
+            set(subject.determine_arch_list(self.runtime, ["s390x", "ppc64le"]))
+        )
+
+        runtime = MagicMock(group_config=Model(dict(arches=["x86_64", "aarch64"])))
+        with self.assertRaises(ValueError, msg="should fail when specifying non-configured arch"):
+            subject.determine_arch_list(runtime, ["bogus"])
+        # with self.assertRaises(ValueError, msg="should fail when specifying multi if not configured"):
+        #     subject.determine_arch_list(runtime, ["multi"])  # no multi yet
+
+        self.assertEqual({"aarch64"}, subject.determine_arch_list(runtime, {"x86_64"}))
+        self.assertEqual({"x86_64", "aarch64"}, subject.determine_arch_list(runtime, set()))
+
+    @patch('urllib.request.urlopen')
+    def test_find_rc_nightlies(self, urlopen_mock):
+        data = """
+        {
+          "name": "4.12.0-0.nightly",
+          "tags": [
+            {
+              "name": "4.12.0-0.nightly-2022-07-15-132344",
+              "phase": "Ready",
+              "pullSpec": "registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-07-15-132344",
+              "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.12.0-0.nightly-2022-07-15-132344"
+            },
+            {
+              "name": "4.12.0-0.nightly-2022-07-15-065851",
+              "phase": "Rejected",
+              "pullSpec": "registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-07-15-065851",
+              "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.12.0-0.nightly-2022-07-15-065851"
+            },
+            {
+              "name": "4.12.0-0.nightly-2022-07-15-024227",
+              "phase": "Accepted",
+              "pullSpec": "registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-07-15-024227",
+              "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.12.0-0.nightly-2022-07-15-024227"
+            }
+        ]}
+        """
+        cm = MagicMock(getcode=200)
+        cm.read.return_value = bytes(data, encoding="utf-8")
+        cm.__enter__.return_value = cm
+        urlopen_mock.return_value = cm
+
+        self.assertEqual(1, len(subject.find_rc_nightlies(self.runtime, {"x86_64"}, False, False)["x86_64"]))
+        self.assertEqual(3, len(subject.find_rc_nightlies(self.runtime, {"x86_64"}, True, True)["x86_64"]))
+        self.assertEqual(1, len(subject.find_rc_nightlies(self.runtime, {"x86_64"}, True, True, ["4.12.0-0.nightly-2022-07-15-132344"])["x86_64"]))
+
+        with self.assertRaises(subject.NoMatchingNightlyException):
+            subject.find_rc_nightlies(self.runtime, {"x86_64"}, True, True, ["not-found-name"])
+
+        cm.read.return_value = b"{}"
+        with self.assertRaises(subject.EmptyArchException):
+            subject.find_rc_nightlies(self.runtime, {"x86_64"}, True, True)
+
+    def test_populate_nightly_release_data(self):
+        pass
+
+    def test_equivalence_base(self):
+        test_json = """
+            {
+                "two-tags": {
+                    "references": {
+                      "spec": {
+                        "tags": [
+                            {
+                              "name": "cluster-version-operator",
+                              "annotations": { "io.openshift.build.commit.id": "cvo-commit" },
+                              "from": { "name": "ignore" }
+                            },
+                            {
+                              "name": "pod",
+                              "annotations": { "io.openshift.build.commit.id": "pod-commit" },
+                              "from": { "name": "ignore" }
+                            }
+                        ]
+                }}},
+                "extra-tag": {
+                    "references": {
+                      "spec": {
+                        "tags": [
+                            {
+                              "name": "cluster-version-operator",
+                              "annotations": { "io.openshift.build.commit.id": "cvo-commit" },
+                              "from": { "name": "ignore" }
+                            },
+                            {
+                              "name": "pod",
+                              "annotations": { "io.openshift.build.commit.id": "pod-commit" },
+                              "from": { "name": "ignore" }
+                            },
+                            {
+                              "name": "unique to this nightly",
+                              "annotations": { "io.openshift.build.commit.id": "b5932d451e2514e932be49a95b3c46b2a74b5b0c" },
+                              "from": { "name": "ignore" }
+                            }
+                        ]
+                }}},
+                "cvo-tag-replaced-by-pod": {
+                    "references": {
+                      "spec": {
+                        "tags": [
+                            {
+                              "name": "cluster-version-operator",
+                              "annotations": { "io.openshift.build.commit.id": "pod-commit" },
+                              "from": { "name": "ignore" }
+                            },
+                            {
+                              "name": "pod",
+                              "annotations": { "io.openshift.build.commit.id": "pod-commit" },
+                              "from": { "name": "ignore" }
+                            }
+                        ]
+                }}},
+                "two-tag-different-pod": {
+                    "references": {
+                      "spec": {
+                        "tags": [
+                            {
+                              "name": "cluster-version-operator",
+                              "annotations": { "io.openshift.build.commit.id": "cvo-commit" },
+                              "from": { "name": "ignore" }
+                            },
+                            {
+                              "name": "pod",
+                              "annotations": { "io.openshift.build.commit.id": "different-pod-commit" },
+                              "from": { "name": "ignore" }
+                            }
+                        ]
+                }}}
+            }
+        """
+        release_info: Dict[str, Dict] = json.loads(test_json)
+        two_tags = subject.EquivalenceBase(release_info["two-tags"])
+        extra_tag = subject.EquivalenceBase(release_info["extra-tag"])
+        cvo_replaced = subject.EquivalenceBase(release_info["cvo-tag-replaced-by-pod"])
+        diff_pod = subject.EquivalenceBase(release_info["two-tag-different-pod"])
+
+        self.assertEqual(two_tags, extra_tag)
+        self.assertEqual(two_tags, cvo_replaced)
+        self.assertNotEqual(two_tags, diff_pod)
+
+    @patch('doozerlib.cli.get_nightlies.EquivalenceBase.retrieve_rhcos_tag_digest')
+    def test_equivalence_base_rhcos(self, mock_digest):
+        test_data = json.loads("""
+            {
+                "references": {
+                  "spec": {
+                    "tags": [
+                        {
+                          "name": "some-rhcos-tag",
+                          "annotations": { "io.openshift.build.commit.id": "" },
+                          "from": { "name": "mocked-out" }
+                        },
+                        {
+                          "name": "pod",
+                          "annotations": { "io.openshift.build.commit.id": "pod-commit" },
+                          "from": { "name": "ignored" }
+                        }
+                    ]
+                }}
+            }
+        """)
+        rhcos1 = subject.EquivalenceBase(test_data)
+        rhcos2 = subject.EquivalenceBase(test_data)
+        mock_digest.side_effect = ["digest1", "digest1"]
+        self.assertEqual(rhcos1, rhcos2)
+
+        rhcos1 = subject.EquivalenceBase(test_data)
+        rhcos2 = subject.EquivalenceBase(test_data)
+        mock_digest.side_effect = ["digest1", "digest2"]
+        self.assertNotEqual(rhcos1, rhcos2)
+
+    @staticmethod
+    def vanilla_eq_base():
+        # just give me an instance to test (supplies "pod" entry)
+        return subject.EquivalenceBase({
+            "references": {"spec": {"tags": [
+                {
+                    "name": "pod",
+                    "annotations": {"io.openshift.build.commit.id": "pod-commit"},
+                    "from": {"name": "pod-pullspec"},
+                }
+            ]}}})
+
+    @patch('doozerlib.cli.get_nightlies.EquivalenceBase.retrieve_image_info')
+    def test_retrieve_nvr_for_tag(self, mock_rii):
+        eq = self.vanilla_eq_base()
+        mock_rii.return_value = Model(dict(config=dict(config=dict(Labels={
+            "com.redhat.component": "spam",
+            "version": "1.0",
+            "release": "1.el8",
+        }))))
+        self.assertEqual(("spam", "1.0", "1.el8"), eq.retrieve_nvr_for_tag("pod"))
+
+        mock_rii.return_value = Exception()  # should be cached from last call
+        self.assertEqual(("spam", "1.0", "1.el8"), eq.retrieve_nvr_for_tag("pod"))
+
+        mock_rii.return_value = Model()  # no labels provided
+        eq.pullspec_for_tag["rhcos"] = "rhcos_ps"
+        self.assertIsNone(eq.retrieve_nvr_for_tag("rhcos"))
+
+    def test_deeper_equivalence(self):
+        eq1 = self.vanilla_eq_base()
+        eq2 = self.vanilla_eq_base()
+        eq1.rhcos_inspector = eq2.rhcos_inspector = MagicMock()  # always match
+        eq1.commit_for_tag["pod"] = eq2.commit_for_tag["pod"] = "commit1"
+        eq1.nvr_for_tag["pod"] = eq2.nvr_for_tag["pod"] = ("nvr", "1", "1")
+        self.assertTrue(eq1.deeper_equivalence(eq2))
+
+        # works with missing entries too
+        eq1.commit_for_tag["missing1"] = eq2.commit_for_tag["missing2"] = "mcommit"
+        self.assertTrue(eq1.deeper_equivalence(eq2), "un-shared tags are ignored")
+        self.assertTrue(eq2.deeper_equivalence(eq1), "... in both directions")
+
+        # get a failure
+        eq2.nvr_for_tag["pod"] = ("nvr", "2", "2")
+        self.assertFalse(eq1.deeper_equivalence(eq2))
+
+        # give alt images (where components differ for the same tag) a pass.
+        # most of the time they'll have the same VR but that's not absolutely
+        # guaranteed (one build could flake then succeed with later R).
+        # so just rely on source commit equivalence (already verified)
+        # and ignore the slim possibility that the RPMs installed differ.
+        eq2.nvr_for_tag["pod"] = ("nvr-alt", "1", "1")
+        self.assertTrue(eq1.deeper_equivalence(eq2), "alt images allowed to differ")
+
+    def test_deeper_equivalence_rhcos(self):
+        eq1 = self.vanilla_eq_base()
+        eq2 = self.vanilla_eq_base()
+        ri1 = eq1.rhcos_inspector = MagicMock()
+        ri2 = eq2.rhcos_inspector = MagicMock()
+        for eq in (eq1, eq2):
+            eq.rhcos_inspector.get_os_metadata_rpm_list.return_value = [("spam", 0, 1, 1, "noarch")]
+
+        self.assertTrue(eq1.deeper_equivalence_rhcos(eq2), "same RPM content")
+
+        ri2.get_os_metadata_rpm_list.return_value = [("eggs", 0, 2, 3, "noarch")]
+        self.assertTrue(eq1.deeper_equivalence_rhcos(eq2), "unchecked RPM content")
+        self.assertTrue(eq2.deeper_equivalence_rhcos(eq1), "unmatched RPM content")
+
+        ri1.get_os_metadata_rpm_list.return_value = [("sausage", 0, 1, 1, "noarch")]
+        ri2.get_os_metadata_rpm_list.return_value = [("sausage", 0, 2, 3, "noarch")]
+        self.assertFalse(eq1.deeper_equivalence_rhcos(eq2), "mismatched RPM content")
+
+    @patch('doozerlib.exectools.cmd_assert')
+    def test_retrieve_rhcos_tag_digest(self, mock_image_info):
+        test_data = json.loads("""
+            {
+                "references": {
+                  "spec": {
+                    "tags": [
+                        {
+                          "name": "some-rhcos-tag",
+                          "annotations": { "io.openshift.build.commit.id": "" },
+                          "from": { "name": "mocked-out" }
+                        },
+                        {
+                          "name": "other-rhcos-tag",
+                          "annotations": { "io.openshift.build.commit.id": "" },
+                          "from": { "name": "mocked-out-2" }
+                        },
+                        {
+                          "name": "ya-rhcos-tag",
+                          "annotations": { "io.openshift.build.commit.id": "" },
+                          "from": { "name": "mocked-out-3" }
+                        },
+                        {
+                          "name": "pod",
+                          "annotations": { "io.openshift.build.commit.id": "pod-commit" },
+                          "from": { "name": "ignored" }
+                        }
+                    ]
+                }}
+            }
+        """)
+        test_image_info1 = json.dumps(dict(config=dict(config=dict(Labels={"com.coreos.rpm.foo": "foo-1.0"}))))
+        test_image_info2 = json.dumps(dict(config=dict(config=dict(Labels={"com.coreos.rpm.foo": "foo-2.0"}))))
+        test_image_info3 = json.dumps(dict(config=dict(config=dict(Labels={"com.coreos.rpm.foo": "foo-1.0", "com.coreos.rpm.kernel-rt": "kernel-1.0"}))))
+
+        rhcos = subject.EquivalenceBase(test_data)
+        mock_image_info.side_effect = [(test_image_info1, None), (test_image_info2, None)]
+        self.assertNotEqual(
+            rhcos.retrieve_rhcos_tag_digest("some-rhcos-tag"),
+            rhcos.retrieve_rhcos_tag_digest("other-rhcos-tag")
+        )
+
+        mock_image_info.side_effect = [(test_image_info1, None), (test_image_info3, None)]
+        self.assertEqual(
+            rhcos.retrieve_rhcos_tag_digest("some-rhcos-tag"),
+            rhcos.retrieve_rhcos_tag_digest("ya-rhcos-tag")
+        )
+
+        rhcos = subject.EquivalenceBase(test_data)
+        # these will be retrieved from cache
+        mock_image_info.side_effect = Exception("should not get here")
+        self.assertNotEqual(
+            rhcos.retrieve_rhcos_tag_digest("other-rhcos-tag"),
+            rhcos.retrieve_rhcos_tag_digest("ya-rhcos-tag"),
+            "image infos should be cached"
+        )
+
+    def test_equivalence_set(self):
+        nightlies = [
+            {
+                "name": "4.12.0-0.nightly-2022-07-15-132344",
+                "phase": "Ready",
+                "pullSpec": "registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-07-15-132344",
+                "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.12.0-0.nightly-2022-07-15-132344",
+                "equivalence": "digest1",  # represents the EquivalenceBase determined for this nightly
+                "releaseInfo": {"config": {"created": "2022-07-16"}},
+            },
+            {
+                "name": "4.12.0-0.nightly-s390x-2022-07-15-065851",
+                "phase": "Rejected",
+                "pullSpec": "registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-07-15-065851",
+                "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.12.0-0.nightly-2022-07-15-065851",
+                "equivalence": "digest2",
+                "releaseInfo": {"config": {"created": "2022-07-17"}},
+            },
+            {
+                "name": "4.12.0-0.nightly-arm64-2022-07-15-024227",
+                "phase": "Accepted",
+                "pullSpec": "registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-07-15-024227",
+                "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.12.0-0.nightly-2022-07-15-024227",
+                "equivalence": "digest1",
+                "releaseInfo": {"config": {"created": "2022-07-18"}},
+            },
+        ]
+        eqset = subject.EquivalenceSet({"x86_64": nightlies[0]})
+        self.assertIsNone(eqset.augment("s390x", nightlies[1]))
+
+        set1 = eqset.augment("aarch64", nightlies[2])
+        self.assertIsInstance(set1, subject.EquivalenceSet)
+        self.assertEqual(set1.timestamp, "2022-07-18")  # greater of first and third
+
+        self.assertIsNone(set1.augment("s390x", nightlies[1]))
+        with self.assertRaises(subject.EqSetDuplicateArchException):
+            eqset.augment("x86_64", nightlies[0])
+
+    def test_generate_equivalence_sets(self):
+        nightlies_for_arch = {
+            "x86_64": [
+                {
+                    "name": "nightly1",
+                    "equivalence": "digest1",  # represents the EquivalenceBase for this nightly
+                    "releaseInfo": {"config": {"created": "2022-07-17"}},
+                },
+                {
+                    "name": "nightly2",
+                    "equivalence": "digest1",
+                    "releaseInfo": {"config": {"created": "2022-07-18"}},
+                },
+                {
+                    "name": "nightly3",
+                    "equivalence": "digest2",
+                    "releaseInfo": {"config": {"created": "2022-07-16"}},
+                },
+            ],
+            "s390x": [
+                {
+                    "name": "nightly4",
+                    "equivalence": "digest1",  # matches two
+                    "releaseInfo": {"config": {"created": "2022-07-17"}},
+                },
+                {
+                    "name": "nightly5",
+                    "equivalence": "digest2",  # matches one
+                    "releaseInfo": {"config": {"created": "2022-07-15"}},
+                },
+            ],
+        }
+        sets = subject.generate_equivalence_sets(nightlies_for_arch)
+        self.assertEqual(3, len(sets))
+        # also check that they sort by timestamp desc
+        self.assertEqual("2022-07-18", sets[0].timestamp)
+        self.assertEqual("2022-07-16", sets[2].timestamp)
+
+        # check that an incompatible nightly torpedoes set creation
+        nightlies_for_arch["ppc64le"] = [
+            {
+                "name": "nightly6",
+                "equivalence": "digest3",  # incompatible with all
+                "releaseInfo": {"config": {"created": "2022-07-17"}},
+            },
+        ]
+        self.assertEqual(0, len(subject.generate_equivalence_sets(nightlies_for_arch)))


### PR DESCRIPTION
Comparing timestamps on nightlies can only go so far.
For a more reliable indicator that all the nightlies selected are "the same thing" get-nightlies now compares contents quite deeply.
This should be reliable enough to feed into gen-assembly or to use in jobs checking that nightlies are available for upcoming releases.

It also allows specifying a nightly you'd like in the set and other improvements.

```
$ time doozer -q -g openshift-4.10 get-nightlies
4.10.0-0.nightly-ppc64le-2022-07-18-094300 4.10.0-0.nightly-s390x-2022-07-16-173211 4.10.0-0.nightly-arm64-2022-07-16-173300 4.10.0-0.nightly-2022-07-18-094217

real	0m30.512s
user	1m7.026s
sys	0m16.111s

$ time doozer -q -g openshift-4.10 get-nightlies --matching 4.10.0-0.nightly-2022-07-18-094217
4.10.0-0.nightly-ppc64le-2022-07-18-094300 4.10.0-0.nightly-s390x-2022-07-16-173211 4.10.0-0.nightly-arm64-2022-07-16-173300 4.10.0-0.nightly-2022-07-18-094217

real	0m16.225s
user	1m3.965s
sys	0m15.145s

```
