### PR TITLE
dev.Dockerfile: install editable, update to f35

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:35
 
 # Trust the Red Hat IT Root CA and set up rcm-tools repo
 RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
@@ -51,11 +51,11 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
 COPY .devcontainer/krb5-redhat.conf /etc/krb5.conf.d/
 
 # Preinstall dependencies
-COPY ./ /tmp/doozer/
-RUN chown "$USERNAME" -R /tmp/doozer \
- && pushd /tmp/doozer \
- && sudo -u "$USERNAME" pip3 install --user -r ./requirements.txt -r requirements-dev.txt ./ \
- && popd && rm -rf /tmp/doozer
+COPY ./* /workspaces/doozer/
+RUN chown "$USERNAME" -R /workspaces/doozer \
+ && cd /workspaces/doozer \
+ && sudo -u "$USERNAME" pip3 install --user -r ./requirements.txt -r requirements-dev.txt \
+ && sudo -u "$USERNAME" pip3 install --user -e ./
 
 USER "$USER_UID"
 WORKDIR /workspaces/doozer


### PR DESCRIPTION
by installing doozer in `/workspaces/doozer` as editable, when i run the container with doozer mounted there i can run with my edits immediately without having to think about it.

i tried updating this to f36 but there was some problem i didn't feel like debugging... maybe py3.6 not enabled there, don't remember.