### PR TITLE
Add timeouts to oc image mirror

### DIFF
--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -117,7 +117,7 @@ def images_streams_mirror(runtime, streams, only_if_missing, live_test_mode, dry
                 if dry_run:
                     print(f'For {upstream_entry_name}, would have run: {arm_cmd}')
                 else:
-                    exectools.cmd_assert(arm_cmd, retries=3, realtime=True)
+                    exectools.cmd_assert(arm_cmd, retries=3, realtime=True, timeout=1800)
 
 
 @images_streams.command('check-upstream', short_help='Dumps information about CI buildconfigs/mirrored images associated with this group.')

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -425,7 +425,7 @@ read and propagate/expose this annotation in its display of the release image.
 
         if apply or apply_multi_arch:
             logger.info(f'Mirroring images from {str(src_dest_path)}')
-            exectools.cmd_assert(f'oc image mirror --keep-manifest-list --filename={str(src_dest_path)}', retries=3)
+            exectools.cmd_assert(f'oc image mirror --keep-manifest-list --filename={str(src_dest_path)}', retries=3, timeout=1800)
 
         for private_mode in privacy_modes:
             logger.info(f'Building payload files for architecture: {arch}; private: {private_mode}')

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -852,7 +852,7 @@ class ImageDistGitRepo(DistGitRepo):
                     else:
                         for r in range(10):
                             self.logger.info("Mirroring image [retry={}]".format(r))
-                            rc, out, err = exectools.cmd_gather(mirror_cmd)
+                            rc, out, err = exectools.cmd_gather(mirror_cmd, timeout=1800)
                             if rc == 0:
                                 break
                             self.logger.info("Error mirroring image -- retrying in 60 seconds.\n{}".format(err))

--- a/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -501,7 +501,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
 
         (flexmock(distgit.exectools)
             .should_receive("cmd_gather")
-            .with_args(expected_cmd)
+            .with_args(expected_cmd, timeout=1800)
             .once()
             .and_return((0, "", "")))
 
@@ -547,7 +547,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
 
         (flexmock(distgit.exectools)
             .should_receive("cmd_gather")
-            .with_args(expected_cmd)
+            .with_args(expected_cmd, timeout=1800)
             .once()
             .and_return((0, "", "")))
 


### PR DESCRIPTION
We observed an issue that `oc image mirror` had stuck for 2 hours.

Add a timeout of 30 minutes to each `oc image mirror` invocation.

See https://coreos.slack.com/archives/GDBRP5YJH/p1659501833732749.