### PR TITLE
Fix flake8 issue

### DIFF
--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -608,7 +608,7 @@ class ArchiveImageInspector:
         self.brew_build_inspector = brew_build_inspector
 
         if self.brew_build_inspector:
-            assert(self.brew_build_inspector.get_brew_build_id() == self.get_brew_build_id())
+            assert (self.brew_build_inspector.get_brew_build_id() == self.get_brew_build_id())
 
     def image_arch(self) -> str:
         """

--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -287,7 +287,7 @@ class OLMBundle(object):
             **self.redhat_delivery_tags,
             **self.operator_framework_tags
         }
-        del(bundle_df.labels['release'])
+        del (bundle_df.labels['release'])
 
     def create_container_yaml(self):
         """Use container.yaml to disable unnecessary multiarch

--- a/doozerlib/rpm_utils.py
+++ b/doozerlib/rpm_utils.py
@@ -188,15 +188,15 @@ def _rpmvercmp(a: str, b: str):
         # leave one and two pointing to the start of the alpha or numeric
         # segment and walk str1 and str2 to end of segment
         if str1[p].isdigit():
-            while(str1[p] != "\0" and str1[p].isdigit()):
+            while (str1[p] != "\0" and str1[p].isdigit()):
                 p += 1
-            while(str2[q] != "\0" and str2[q].isdigit()):
+            while (str2[q] != "\0" and str2[q].isdigit()):
                 q += 1
             isnum = 1
         else:
-            while(str1[p] != "\0" and str1[p].isalpha()):
+            while (str1[p] != "\0" and str1[p].isalpha()):
                 p += 1
-            while(str2[q] != "\0" and str2[q].isalpha()):
+            while (str2[q] != "\0" and str2[q].isalpha()):
                 q += 1
             isnum = 0
 


### PR DESCRIPTION
The following errors were showing up in PR-merge build 
```
./doozerlib/image.py:611:19: E275 missing whitespace after keyword
./doozerlib/rpm_utils.py:191:18: E275 missing whitespace after keyword
./doozerlib/rpm_utils.py:193:18: E275 missing whitespace after keyword
./doozerlib/rpm_utils.py:197:18: E275 missing whitespace after keyword
./doozerlib/rpm_utils.py:199:18: E275 missing whitespace after keyword
./doozerlib/olm/bundle.py:290:12: E275 missing whitespace after keyword
ERROR: InvocationError for command /mnt/workspace/jenkins/working/art-tools_doozer_PR-628/.tox/py36/bin/flake8 (exited with code 1)
```
Added spaces to fix the above issues.