### PR TITLE
Fix Unexpected value type error

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -227,7 +227,8 @@ def _assembly_config_struct(releases_config: Model, assembly: typing.Optional[st
         parent_config_struct = _assembly_config_struct(releases_config, target_assembly.basis.assembly, key, default)
         if key in target_assembly:
             key_struct = target_assembly[key]
-
+            if hasattr(key_struct, "primitive"):
+                key_struct = key_struct.primitive()
             key_struct = merger(key_struct, parent_config_struct.primitive() if hasattr(parent_config_struct, "primitive") else parent_config_struct)
         else:
             key_struct = parent_config_struct

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -180,6 +180,7 @@ releases:
         self.assertEqual(merger('4', '5'), '4')
         self.assertEqual(merger(None, '5'), None)
         self.assertEqual(merger(True, None), True)
+        self.assertEqual(merger([1, 2], [2, 3]), [1, 2, 3])
 
         # Dicts are additive
         self.assertEqual(
@@ -451,7 +452,8 @@ releases:
                         "foo": {
                             "a": 1,
                             "b": 2
-                        }
+                        },
+                        "bar": [1, 2, 3]
                     }
                 },
                 "parent": {
@@ -459,7 +461,8 @@ releases:
                         "foo": {
                             "b": 3,
                             "c": 4,
-                        }
+                        },
+                        "bar": [0, 2, 4]
                     }
                 },
             }
@@ -470,3 +473,5 @@ releases:
             "b": 2,
             "c": 4,
         })
+        actual = _assembly_config_struct(Model(release_configs), "child", "bar", [])
+        self.assertEqual(actual, [0, 1, 2, 3, 4])


### PR DESCRIPTION
`assembly._assembly_config_struct` raises the following error when
merging 2 lists:

```
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly@2/pyartcd/pyartcd/util.py", line 89, in get_assembly_promotion_permits
    return assembly._assembly_config_struct(model.Model(releases_config), assembly_name, 'promotion_permits', [])
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly@2/art-tools/doozer/doozerlib/assembly.py", line 231, in _assembly_config_struct
    key_struct = merger(key_struct, parent_config_struct.primitive() if hasattr(parent_config_struct, "primitive") else parent_config_struct)
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly@2/art-tools/doozer/doozerlib/assembly.py", line 102, in merger
    raise TypeError(f'Unexpected value type: {type(a)}: {a}')
TypeError: Unexpected value type: <class 'doozerlib.model.ListModel'>: [{'code': 'ATTACHED_BUGS', 'why': 'CVE tracker validation does not yet understand links from jira to bugzilla, this has been humanly validated this time'}]
```

ListModel needs to be converted to its primitive type `list` before calling `merger`.