### PR TITLE
[ART-4751] update valid-subscription in csv

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -254,7 +254,14 @@ class OLMBundle(object):
                 contents = self.find_and_replace_image_references_by_sha(f.read())
                 f.seek(0)
                 f.truncate()
-                f.write(contents)
+                if "clusterserviceversion.yaml" in file:
+                    if not self.valid_subscription_label:
+                        raise ValueError("missing valid-subscription-label in operator config")
+                    yml_content = yaml.safe_load(contents)
+                    yml_content['metadata']['annotations']['operators.openshift.io/valid-subscription'] = self.valid_subscription_label
+                    f.write(yaml.dump(yml_content))
+                else:
+                    f.write(contents)
 
     def generate_bundle_annotations(self):
         """Create an annotations YAML file for the bundle, using info extracted from operator's
@@ -570,9 +577,6 @@ class OLMBundle(object):
         if self.runtime.group_config.operator_channel_stable == 'default':
             override_default = stable_channel
 
-        if not self.valid_subscription_label:
-            raise ValueError("missing valid-subscription-label in operator config")
-
         return {
             'operators.operatorframework.io.bundle.channel.default.v1': override_default,
             'operators.operatorframework.io.bundle.channels.v1': override_channel,
@@ -580,7 +584,6 @@ class OLMBundle(object):
             'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
             'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
             'operators.operatorframework.io.bundle.package.v1': self.package,
-            'operators.openshift.io/valid-subscription': self.valid_subscription_label,
         }
 
     @property

--- a/tests/test_olm_bundle.py
+++ b/tests/test_olm_bundle.py
@@ -15,21 +15,3 @@ class TestOLMBundle(unittest.TestCase):
     def test_get_bundle_image_name_with_ose_prefix(self):
         obj = flexmock(OLMBundle(None, dry_run=False, brew_session=MagicMock()), bundle_name='ose-foo')
         self.assertEqual(obj.get_bundle_image_name(), 'openshift/ose-foo')
-
-    def test_valid_subscription_label_is_present(self):
-        expected_key = 'operators.openshift.io/valid-subscription'
-        expected_val = '["My", "Subscription", "Label"]'
-
-        # mocking
-        config = {'update-csv': {'valid-subscription-label': expected_val}}
-        runtime = flexmock(
-            group_config=flexmock(operator_channel_stable='default'),
-            image_map={'myimage': flexmock(config=config)}
-        )
-        obj = flexmock(OLMBundle(runtime, dry_run=False, brew_session=MagicMock()), operator_name='myimage')
-        obj.channel = '...'
-        obj.package = '...'
-
-        self.assertIn(expected_key, obj.operator_framework_tags.keys())
-        actual_val = obj.operator_framework_tags[expected_key]
-        self.assertEqual(expected_val, actual_val)


### PR DESCRIPTION
according to CVP [test result](http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-cluster-kube-descheduler-operator-metadata-container-v4.10.0.202208241855.p0.g866e811.assembly.stream-1/db1f386c-0802-4f87-89f2-1fd14a51377u/operator-valid-subscriptions-bundle-image-output.txt), valid-subscription should be set in csv file
https://issues.redhat.com/browse/CVP-3200