### PR TITLE
[ART-4753]: Complain when rhcos-es are from different openshift/os commits

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -22,6 +22,7 @@ class AssemblyIssueCode(Enum):
     INCONSISTENT_RHCOS_RPMS = 5
     MISSING_INHERITED_DEPENDENCY = 6
     MISSING_RHCOS_CONTAINER = 7
+    INCONSISTENT_OS_COMMIT = 8
 
 
 class AssemblyIssue:

--- a/tests/cli/test_gen_payload.py
+++ b/tests/cli/test_gen_payload.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, skip
+import unittest
 from unittest.mock import MagicMock, Mock, patch
 from flexmock import flexmock
 
@@ -15,7 +15,7 @@ from doozerlib.exceptions import DoozerFatalError
 from doozerlib import rhcos
 
 
-class TestGenPayloadCli(TestCase):
+class TestGenPayloadCli(unittest.TestCase):
 
     def test_find_rhcos_payload_entries(self):
         rhcos_build = MagicMock()
@@ -217,6 +217,7 @@ class TestGenPayloadCli(TestCase):
         gpcli.should_receive("detect_rhcos_issues").with_args(rhcosEntry, None).once()
         gpcli.should_receive("detect_rhcos_inconsistent_rpms").once().with_args(
             {False: ["rbi"], True: []})
+        gpcli.should_receive("detect_rhcos_inconsistent_os_commit").once()
 
         gpcli.detect_extend_payload_entry_issues(None)
         self.assertEqual(gpcli.assembly_issues, spamEntry.issues)
@@ -252,6 +253,14 @@ class TestGenPayloadCli(TestCase):
         pg_find_mock.side_effect = [[], ["dummy1", "dummy2"]]
         gpcli.detect_rhcos_inconsistent_rpms({False: ["rbi"], True: []})
         self.assertEqual(gpcli.assembly_issues[0].code, AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS)
+
+    @patch("doozerlib.cli.release_gen_payload.PayloadGenerator.find_rhcos_os_commit_inconsistencies")
+    def test_detect_rhcos_inconsistent_os_commit(self, pg_find_mock):
+        gpcli = rgp_cli.GenPayloadCli()
+        gpcli.privacy_modes = [True, False]
+        pg_find_mock.side_effect = [[], ["dummy1", "dummy2"]]
+        gpcli.detect_rhcos_inconsistent_os_commit({False: ["rbi"], True: []})
+        self.assertEqual(gpcli.assembly_issues[0].code, AssemblyIssueCode.INCONSISTENT_OS_COMMIT)
 
     def test_summarize_issue_permits(self):
         gpcli = rgp_cli.GenPayloadCli()
@@ -617,3 +626,7 @@ manifests:
         self.assertIn(dict(name="spam2"), istream_apiobj.model.spec.tags, "not pruned")
         self.assertEqual({"release.openshift.io/rewrite": "false"},
                          istream_apiobj.model.spec.tags[-1]["annotations"], "added")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
```
$ doozer --assembly=4.11.3 --group openshift-4.11 release:gen-payload --output-dir /tmp/doozer
assembly_issues:
  rhcos:
  - code: INCONSISTENT_OS_COMMIT
    msg: 'Found diiferent openshift/os commits in builds [RHCOSBuild:x86_64:411.86.202208291737-0,
      RHCOSBuild:ppc64le:411.86.202208291739-0, RHCOSBuild:s390x:411.86.202208311151-0,
      RHCOSBuild:aarch64:411.86.202208310958-0] (private=False): {''765d2beb337b80b7fdad356f79abe54d7fdfd5c3'':
      {''ppc64le'', ''x86_64''}, ''0f001449a6690beff3aede4aa775a7e8d09f302f'': {''s390x'',
      ''aarch64''}}'
```
and...
```
⫸  doozer --assembly=4.11.4 --group openshift-4.11 release:gen-payload --output-dir /tmp/doozer
assembly_issues: {}
```