### PR TITLE
gen-payload: remove old tags from multi imagestream for non-stream as…

### DIFF
--- a/tests/cli/test_gen_payload.py
+++ b/tests/cli/test_gen_payload.py
@@ -593,7 +593,7 @@ manifests:
 
     @patch("doozerlib.cli.release_gen_payload.modify_and_replace_api_object")
     def test_apply_multi_imagestream_update(self, mar_mock):
-        gpcli = flexmock(rgp_cli.GenPayloadCli(output_dir="/tmp"))
+        gpcli = flexmock(rgp_cli.GenPayloadCli(output_dir="/tmp", runtime=MagicMock(assembly_type=AssemblyTypes.STREAM)))
 
         # make MAR method do basically what it would, without writing all the files
         mar_mock.side_effect = lambda apiobj, func, *_: func(apiobj)


### PR DESCRIPTION
…sembly

We only need to keep 5 old imagestreamtags for stream assembly. Non-stream assemblies should contain one single tag.

For more info, see https://coreos.slack.com/archives/GDBRP5YJH/p1661329456656149