### PR TITLE
ART-4807: Add OSBS 2 builder

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,4 +1,7 @@
-FROM fedora:35
+FROM registry.fedoraproject.org/fedora:36
+LABEL name="doozer-dev" \
+  description="Doozer development container image" \
+  maintainer="OpenShift Automated Release Tooling (ART) Team <aos-team-art@redhat.com>"
 
 # Trust the Red Hat IT Root CA and set up rcm-tools repo
 RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
@@ -9,12 +12,12 @@ RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
 
 RUN dnf install -y \
     # runtime dependencies
-    krb5-workstation git tig rsync koji skopeo podman docker tito \
-    python3.8 python3-certifi python3-rpm python3-kobo-rpmlib \
-    # provides en_US.UTF-8 locale required by tito
+    krb5-workstation git tig rsync koji skopeo podman docker \
+    python3.8 python3-certifi \
+    # provides en_US.UTF-8 locale
     glibc-langpack-en \
     # development dependencies
-    gcc krb5-devel \
+    gcc gcc-c++ krb5-devel \
     python3-devel python3-pip python3-wheel \
     # other tools for development and troubleshooting
     bash-completion vim tmux procps-ng psmisc wget net-tools iproute socat \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,6 @@
 		// This will ignore your local shell user setting for Linux since shells like zsh are typically
 		// not in base container images. You can also update this to an specific shell to ensure VS Code
 		// uses the right one for terminals and tasks. For example, /bin/bash (or /bin/ash for Alpine).
-		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/usr/bin/python3",
 		"python.linting.pylintEnabled": false,
 		"python.linting.flake8Enabled": true,
@@ -29,16 +28,14 @@
 		],
 		"python.testing.pytestEnabled": false,
 		"python.testing.nosetestsEnabled": false,
-		"python.testing.unittestEnabled": true,
-		"python.jediEnabled": false,  // false to use Microsoft Python Language Server. This requires .NET Core 2.1+
-		"python.languageServer": "Pylance",
+		"python.testing.unittestEnabled": true
 	},
 
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
 	// Uncomment the next line to run commands after the container is created - for example installing git.
-	"postCreateCommand": "sudo chown -R dev: /workspaces/doozer-working-dir && pip3 install --user -r requirements-dev.txt -e .",
+	"postCreateCommand": "sudo chown -R dev: /workspaces/doozer-working-dir",
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [

--- a/.devcontainer/settings.yaml
+++ b/.devcontainer/settings.yaml
@@ -7,5 +7,5 @@ data_path: https://github.com/openshift/ocp-build-data.git
 #Sub-group directory or branch to pull build data
 # group: openshift-4.0
 
-#Username for running rhpkg / brew / tito
+#Username for running rhpkg / brew
 # user: dev

--- a/doozerlib/__init__.py
+++ b/doozerlib/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
-if sys.version_info < (3, 6):
-    sys.exit('Sorry, Python < 3.6 is not supported.')
+if sys.version_info < (3, 8):
+    sys.exit('Sorry, Python < 3.8 is not supported.')
 
 from setuptools_scm import get_version
 

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -2228,9 +2228,6 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
 
 def main():
     try:
-        if 'REQUESTS_CA_BUNDLE' not in os.environ:
-            os.environ['REQUESTS_CA_BUNDLE'] = '/etc/pki/tls/certs/ca-bundle.crt'
-
         cli(obj={})
     except DoozerFatalError as ex:
         # Allow capturing actual tool errors and print them

--- a/doozerlib/cli/cli_opts.py
+++ b/doozerlib/cli/cli_opts.py
@@ -33,7 +33,7 @@ CLI_OPTS = {
     },
     'user': {
         'env': 'DOOZER_USER',
-        'help': 'Username for running rhpkg / brew / tito'
+        'help': 'Username for running rhpkg / brew'
     },
     'global_opts': {
         'help': 'Global option overrides that can only be set from settings.yaml',

--- a/doozerlib/cli/rpms_build.py
+++ b/doozerlib/cli/rpms_build.py
@@ -13,7 +13,6 @@ from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.runtime import Runtime
 
 
-# This command reimplements `rpms:build` without tito. Rename it to `rpms:build` when getting to prod.
 @cli.command("rpms:rebase-and-build", help="Rebase and build rpms in the group or given by --rpms.")
 @click.option("--version", metavar='VERSION', default=None, callback=validate_semver_major_minor_patch,
               help="Version string to populate in specfile.", required=True)
@@ -165,7 +164,6 @@ async def _rebase_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata, v
     return record["status"]
 
 
-# This command reimplements `rpms:build` without tito. Rename it to `rpms:build` when getting to prod.
 @cli.command("rpms:build", help="Build rpms in the group or given by --rpms.")
 @click.option('--scratch', default=False, is_flag=True, help='Perform a scratch build.')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')

--- a/doozerlib/constants.py
+++ b/doozerlib/constants.py
@@ -8,6 +8,7 @@ GIT_NO_PROMPTS = {
 
 GITHUB_TOKEN = "GITHUB_TOKEN"
 BREWWEB_URL = "https://brewweb.engineering.redhat.com/brew"
+DISTGIT_GIT_URL = "git://pkgs.devel.redhat.com"
 
 # Environment variables that should be set for doozer interaction with db for storing and retrieving build records.
 # DB ENV VARS

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -15,23 +15,6 @@ from .metadata import Metadata
 from .model import Missing
 from .pushd import Dir
 
-RELEASERS_CONF = """
-[{target}]
-releaser = tito.release.DistGitReleaser
-branches = {branch}
-build_targets = {branch}:{brew_target}
-srpm_disttag = .el7aos
-builder.test = 1
-remote_git_name = {name}
-"""
-
-# note; appended to, does not replace existing props
-TITO_PROPS = """
-
-[{target}]
-remote_git_name = {name}
-"""
-
 
 class RPMMetadata(Metadata):
 

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -478,9 +478,11 @@ class Runtime(object):
         self.assembly_type = assembly_type(self.get_releases_config(), self.assembly)
 
         if not self.brew_event:
+            self.logger.info("Basis brew event is not set. Using the latest event....")
             with self.shared_koji_client_session() as koji_session:
                 # If brew event is not set as part of the assembly and not specified on the command line,
                 # lock in an event so that there are no race conditions.
+                self.logger.info("Getting the latest event....")
                 event_info = koji_session.getLastEvent()
                 self.brew_event = event_info['id']
 
@@ -741,6 +743,7 @@ class Runtime(object):
             if self._koji_client_session is None:
                 self._koji_client_session = self.build_retrying_koji_client()
                 if not self.disable_gssapi:
+                    self.logger.info("Authenticating to Brew...")
                     self._koji_client_session.gssapi_login()
             yield self._koji_client_session
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 import sys
-if sys.version_info < (3, 6):
-    sys.exit('Sorry, Python < 3.6 is not supported.')
+if sys.version_info < (3, 8):
+    sys.exit('Sorry, Python < 3.8 is not supported.')
 
 with open('./requirements.txt') as f:
     INSTALL_REQUIRES = f.read().splitlines()
@@ -28,14 +28,13 @@ setup(
     install_requires=INSTALL_REQUIRES,
     test_suite='tests',
     dependency_links=[],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Environment :: Console",
         "Operating System :: POSIX",
         "License :: OSI Approved :: Apache Software License",

--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -37,7 +37,7 @@ class TestAssert(unittest.TestCase):
         """
         Verify both positive and negative results for file test
         """
-        file_exists = "/etc/motd"
+        file_exists = "/etc/hosts"
         file_missing = "/tmp/doesnotexist"
         not_file = "/usr"
 

--- a/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -83,9 +83,29 @@ class TestImageDistGit(TestDistgit):
     def test_image_build_method_imagebuilder(self):
         get = lambda key, default: dict({"builder": "..."}) if key == "from" else default
 
-        metadata = flexmock(runtime=self.mock_runtime(group_config=flexmock(default_image_build_method="default-method")),
+        metadata = flexmock(runtime=self.mock_runtime(group_config=flexmock(default_image_build_method=distgit.Missing)),
                             config=flexmock(distgit=flexmock(branch=distgit.Missing),
                                             image_build_method=distgit.Missing,
+                                            get=get),
+                            name="_irrelevant_",
+                            logger="_irrelevant_")
+
+        repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
+        self.assertEqual("imagebuilder", repo.image_build_method)
+
+        metadata = flexmock(runtime=self.mock_runtime(group_config=flexmock(default_image_build_method="osbs2")),
+                            config=flexmock(distgit=flexmock(branch=distgit.Missing),
+                                            image_build_method=distgit.Missing,
+                                            get=get),
+                            name="_irrelevant_",
+                            logger="_irrelevant_")
+
+        repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
+        self.assertEqual("osbs2", repo.image_build_method)
+
+        metadata = flexmock(runtime=self.mock_runtime(group_config=flexmock(default_image_build_method="osbs2")),
+                            config=flexmock(distgit=flexmock(branch=distgit.Missing),
+                                            image_build_method="imagebuilder",
                                             get=get),
                             name="_irrelevant_",
                             logger="_irrelevant_")

--- a/tests/test_osbs2.py
+++ b/tests/test_osbs2.py
@@ -1,0 +1,105 @@
+import unittest
+from unittest.mock import ANY, MagicMock, patch
+
+from doozerlib import constants
+from doozerlib.distgit import ImageDistGitRepo
+from doozerlib.gitdata import DataObj
+from doozerlib.image import ImageMetadata
+from doozerlib.osbs2_builder import OSBS2Builder
+
+
+class TestOSBS2Builder(unittest.TestCase):
+
+    def _make_image_meta(self, runtime):
+        data_obj = DataObj("foo", "/path/to/ocp-build-data/images/foo.yml", {
+            "name": "foo",
+            "content": {
+                "source": {
+                    "git": {"url": "git@github.com:openshift-priv/foo.git", "branch": {"target": "release-4.8"}},
+                }
+            },
+            "targets": ["rhaos-4.12-rhel-8-containers-candidate"],
+        })
+        meta = ImageMetadata(runtime, data_obj, clone_source=False, prevent_cloning=True)
+        meta.branch = MagicMock(return_value="rhaos-4.12-rhel-8")
+        return meta
+
+    def test_construct_build_source_url(self):
+        runtime = MagicMock()
+        osbs2 = OSBS2Builder(runtime)
+        meta = self._make_image_meta(runtime)
+        dg = ImageDistGitRepo(meta, autoclone=False)
+
+        with self.assertRaises(ValueError):
+            dg.sha = None
+            actual = osbs2._construct_build_source_url(dg)
+
+        dg.sha = "deadbeef"
+        actual = osbs2._construct_build_source_url(dg)
+        self.assertEqual(actual, f"{constants.DISTGIT_GIT_URL}/containers/foo#deadbeef")
+
+    def test_start_build(self):
+        runtime = MagicMock()
+        osbs2 = OSBS2Builder(runtime)
+        meta = self._make_image_meta(runtime)
+        dg = ImageDistGitRepo(meta, autoclone=False)
+        dg.sha = "deadbeef"
+        dg.branch = "rhaos-4.12-rhel-8"
+        dg.cgit_file_available = MagicMock(return_value=(True, "http://cgit.example.com/foo.repo"))
+        profile = {
+            "signing_intent": "release",
+            "repo_type": "signed",
+            "repo_list": [],
+        }
+        koji_api = MagicMock(logged_in=False)
+        koji_api.buildContainer.return_value = 12345
+
+        task_id, task_url = osbs2._start_build(dg, "rhaos-4.12-rhel-8-containers-candidate", profile, koji_api)
+        dg.cgit_file_available.assert_called_once_with(".oit/signed.repo")
+        koji_api.gssapi_login.assert_called_once_with()
+        koji_api.buildContainer.assert_called_once_with(
+            f"{constants.DISTGIT_GIT_URL}/containers/foo#deadbeef",
+            "rhaos-4.12-rhel-8-containers-candidate",
+            opts={
+                'scratch': False,
+                'signing_intent': "release",
+                'yum_repourls': ["http://cgit.example.com/foo.repo"],
+                'git_branch': "rhaos-4.12-rhel-8",
+            },
+            channel="container-binary")
+        self.assertEqual(task_id, 12345)
+        self.assertEqual(task_url, f"{constants.BREWWEB_URL}/taskinfo?taskID=12345")
+
+    @patch("doozerlib.exectools.cmd_gather", return_value=(0, "", ""))
+    @patch("doozerlib.brew.watch_task", return_value=None)
+    @patch("doozerlib.osbs2_builder.OSBS2Builder._start_build", return_value=(12345, f"{constants.BREWWEB_URL}/taskinfo?taskID=12345"))
+    def test_build(self, _start_build: MagicMock, watch_task: MagicMock, cmd_gather: MagicMock):
+        koji_api = MagicMock(logged_in=False)
+        koji_api.getTaskResult = MagicMock(return_value={"koji_builds": [42]})
+        koji_api.getBuild = MagicMock(return_value={"id": 42, "nvr": "foo-v4.12.0-12345.p0.assembly.test"})
+        runtime = MagicMock()
+        runtime.build_retrying_koji_client = MagicMock(return_value=koji_api)
+        osbs2 = OSBS2Builder(runtime)
+        meta = self._make_image_meta(runtime)
+        dg = ImageDistGitRepo(meta, autoclone=False)
+        meta.distgit_repo = MagicMock(return_value=dg)
+        dg.sha = "deadbeef"
+        dg.branch = "rhaos-4.12-rhel-8"
+        dg.org_version = "v4.12.0"
+        dg.org_release = "12345.p0.assembly.test"
+        profile = {
+            "signing_intent": "release",
+            "repo_type": "signed",
+            "repo_list": [],
+        }
+
+        task_id, task_url, nvr = osbs2.build(meta, profile, retries=1)
+        self.assertEqual((task_id, task_url, nvr), (12345, f"{constants.BREWWEB_URL}/taskinfo?taskID=12345", "foo-v4.12.0-12345.p0.assembly.test"))
+        koji_api.gssapi_login.assert_called_once_with()
+        koji_api.getTaskResult.assert_called_once_with(12345)
+        koji_api.getBuild.assert_called_once_with(42)
+        koji_api.tagBuild.assert_called_once_with('rhaos-4.12-rhel-8-hotfix', "foo-v4.12.0-12345.p0.assembly.test")
+        runtime.build_retrying_koji_client.assert_called_once_with()
+        _start_build.assert_called_once_with(dg, 'rhaos-4.12-rhel-8-containers-candidate', {'signing_intent': 'release', 'repo_type': 'signed', 'repo_list': []}, koji_api)
+        watch_task.assert_called_once_with(koji_api, ANY, 12345, terminate_event=ANY)
+        cmd_gather.assert_called_once_with(['brew', 'download-logs', '--recurse', '-d', ANY, 12345])


### PR DESCRIPTION
- Add a builder to build container images using OSBS 2. Setting `default_image_build_method: osbs2` in group config to enable it.
- Remove some dead code.
- Remove hard-coded CA path for requests for better portability. It is not required on buildvm anymore.
- Bump base image of devcontainer to Fedora 36.