### PR TITLE
[ART-4861] improve rpm modification scripts support

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -12,8 +12,10 @@ RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
 
 RUN dnf install -y \
     # runtime dependencies
-    krb5-workstation git tig rsync koji skopeo podman docker \
+    krb5-workstation git tig rsync koji skopeo podman docker rpmdevtools \
     python3.8 python3-certifi \
+    # required by microshift
+    yq jq golang \
     # provides en_US.UTF-8 locale
     glibc-langpack-en \
     # development dependencies

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -2522,8 +2522,6 @@ class RPMDistGitRepo(DistGitRepo):
     def __init__(self, metadata, autoclone=True):
         super(RPMDistGitRepo, self).__init__(metadata, autoclone)
         self.source = self.config.content.source
-        # if self.source.specfile is Missing:
-        #     raise ValueError('Must specify spec file name for RPMs.')
 
     async def resolve_specfile_async(self) -> Tuple[pathlib.Path, Tuple[str, str, str], str]:
         """ Returns the path, NVR, and commit hash of the spec file in distgit_dir

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -89,7 +89,7 @@ class TestRPMBuilder(unittest.TestCase):
         mocked_cmd_assert_async.assert_called_with(["spectool", "--", dg.dg_path / "foo.spec"], cwd=dg.dg_path)
         mocked_copy.assert_any_call(Path(rpm.source_path) / "a.diff", dg.dg_path / "a.diff", follow_symlinks=False)
         mocked_copy.assert_any_call(Path(rpm.source_path) / "b/c.diff", dg.dg_path / "b/c.diff", follow_symlinks=False)
-        rpm._run_modifications.assert_called_once_with(dg.dg_path / "foo.spec", dg.dg_path)
+        rpm._run_modifications.assert_called_once_with(f"{rpm.source_path}/foo.spec", rpm.source_path)
         dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].",
                                           commit_attributes={
                                               'version': '1.2.3',
@@ -129,7 +129,7 @@ class TestRPMBuilder(unittest.TestCase):
         mocked_cmd_assert_async.assert_called_with(["spectool", "--", dg.dg_path / "foo.spec"], cwd=dg.dg_path)
         mocked_copy.assert_any_call(Path(rpm.source_path) / "a.diff", dg.dg_path / "a.diff", follow_symlinks=False)
         mocked_copy.assert_any_call(Path(rpm.source_path) / "b/c.diff", dg.dg_path / "b/c.diff", follow_symlinks=False)
-        rpm._run_modifications.assert_called_once_with(dg.dg_path / "foo.spec", dg.dg_path)
+        rpm._run_modifications.assert_called_once_with(f'{rpm.source_path}/foo.spec', rpm.source_path)
         dg.commit.assert_called_once_with(f"Automatic commit of package [{rpm.config.name}] release [{rpm.version}-{rpm.release}].",
                                           commit_attributes={
                                               'version': '1.2.3',


### PR DESCRIPTION
A few changes need to be made to support running microshift rebase script:

- The modification script should be run inside of the upstream source directory instead of distgit directory. This is because distgit repos for rpms only contain specfile, tarball source, and patch files, which is not much useful. Though this is a breaking change, no rpms in supported OCP versions use this feature so it is ok to make this breaking change.
- Enhance `command` modification to pass environment variables to the script. We need this ability to pass the pullspecs of release images to microshift rebase script. Example config:
 
```yaml 
    modifications:
    - action: command
      command: microshift-rebase
      env:
        RELEASE_NAME: "{release_name}"
```

With this enhancement, we can rebase and build 4.11 microshift rpm (https://github.com/openshift/ocp-build-data/pull/1998) by explicitly invoking doozer with `doozer --group openshift-4.11 --assembly=4.11.6 --rpms=microshift rpms:rebase-and-build --version 4.11.6 --release $release.p?`