### PR TITLE
[ART-4861] rpms:rebase: Allow to use `~` in rpm version

### DIFF
--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -194,3 +194,34 @@ def validate_semver_major_minor_patch(ctx, param, version):
         raise click.BadParameter('Expected X, X.Y, or X.Y.Z (with optional "v" prefix)')
 
     return f'{vsplit[0]}.{minor_version}.{patch_version}'
+
+
+def validate_rpm_version(ctx, param, version: str):
+    """
+    For non-None, non-auto values, ensures that the incoming parameter meets the criteria vX.Y.Z[~prerelease] or X.Y.Z[~prerelease].
+    If minor or patch is not supplied, the value is modified to possess
+    minor.major to meet semver requirements.
+    :param ctx: Click context
+    :param param: The parameter specified on the command line
+    :param version: The version specified on the command line
+    :return:
+    """
+    if version == 'auto' or version is None:
+        return version
+
+    xyz, prerelease = version.rsplit("~", 1)
+    vsplit = xyz.split(".")
+    try:
+        int(vsplit[0].lstrip('v'))
+        minor_version = int('0' if len(vsplit) < 2 else vsplit[1])
+        patch_version = int('0' if len(vsplit) < 3 else vsplit[2])
+    except ValueError:
+        raise click.BadParameter(f'Invalid version string: {version}')
+
+    if len(vsplit) > 3:
+        raise click.BadParameter('Expected X, X.Y, or X.Y.Z (with optional "v" prefix)')
+
+    result = f'{vsplit[0]}.{minor_version}.{patch_version}'
+    if prerelease:
+        result += f"~{prerelease}"
+    return result

--- a/doozerlib/cli/rpms_build.py
+++ b/doozerlib/cli/rpms_build.py
@@ -6,7 +6,7 @@ import click
 
 from doozerlib import exectools
 from doozerlib.cli import (cli, click_coroutine, pass_runtime,
-                           validate_semver_major_minor_patch)
+                           validate_rpm_version)
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.rpm_builder import RPMBuilder
 from doozerlib.rpmcfg import RPMMetadata
@@ -14,7 +14,7 @@ from doozerlib.runtime import Runtime
 
 
 @cli.command("rpms:rebase-and-build", help="Rebase and build rpms in the group or given by --rpms.")
-@click.option("--version", metavar='VERSION', default=None, callback=validate_semver_major_minor_patch,
+@click.option("--version", metavar='VERSION', default=None, callback=validate_rpm_version,
               help="Version string to populate in specfile.", required=True)
 @click.option("--release", metavar='RELEASE', default=None,
               help="Release label to populate in specfile.", required=True)
@@ -75,7 +75,7 @@ async def _rpms_rebase_and_build(runtime: Runtime, version: str, release: str, e
 
 
 @cli.command("rpms:rebase", help="Rebase rpms in the group or given by --rpms.")
-@click.option("--version", metavar='VERSION', default=None, callback=validate_semver_major_minor_patch,
+@click.option("--version", metavar='VERSION', default=None, callback=validate_rpm_version,
               help="Version string to populate in specfile.", required=True)
 @click.option("--release", metavar='RELEASE', default=None,
               help="Release label to populate in specfile.", required=True)


### PR DESCRIPTION
So something like `4.12.0~rc.1` will become a valid rpm version.