### PR TITLE
[ART-4931] Rebase Dockerfiles according to release schedule

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1636,8 +1636,13 @@ class ImageDistGitRepo(DistGitRepo):
             return False
         elif self.runtime.group_config.canonical_builders_from_upstream == 'auto':
             # canonical_builders_from_upstream set to 'auto': rebase according to release schedule
-            feature_freeze_date = ReleaseSchedule(self.runtime).get_ff_date()
-            return datetime.now() < feature_freeze_date
+            try:
+                feature_freeze_date = ReleaseSchedule(self.runtime).get_ff_date()
+                return datetime.now() < feature_freeze_date
+            except ChildProcessError:
+                # Could not access Gitlab: display a warning and fallback to default
+                self.logger.error('Failed retrieving release schedule from Gitlab: fallback to using ART\'s config')
+                return False
         elif self.runtime.group_config.canonical_builders_from_upstream == 'on':
             return True
         elif self.runtime.group_config.canonical_builders_from_upstream == 'off':

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1643,6 +1643,10 @@ class ImageDistGitRepo(DistGitRepo):
                 # Could not access Gitlab: display a warning and fallback to default
                 self.logger.error('Failed retrieving release schedule from Gitlab: fallback to using ART\'s config')
                 return False
+            except ValueError as e:
+                # A GITLAB token env var was not provided: display a warning and fallback to default
+                self.logger.error(f'Fallback to default ART config: {e}')
+                return False
         elif self.runtime.group_config.canonical_builders_from_upstream == 'on':
             return True
         elif self.runtime.group_config.canonical_builders_from_upstream == 'off':

--- a/doozerlib/release_schedule.py
+++ b/doozerlib/release_schedule.py
@@ -23,7 +23,7 @@ class ReleaseSchedule:
     @classmethod
     def initialize(cls, runtime):
         if 'GITLAB_TOKEN' not in os.environ:
-            raise RuntimeError('A GITLAB_TOKEN env var must be defined')
+            raise ValueError('A GITLAB_TOKEN env var must be defined')
 
         # Clone ocp-release-schedule in doozer working dir
         git_data = gitdata.GitData(

--- a/doozerlib/release_schedule.py
+++ b/doozerlib/release_schedule.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+import os
+
+import yaml
+
+from doozerlib import gitdata
+
+
+class ReleaseSchedule:
+    """
+    This class is a Singleton. Only at first object construction, it will clone ocp-release-schedule repo inside Doozer
+    working directory, parse and store yaml data related to the current OCP version
+    """
+
+    _instance = None
+
+    def __new__(cls, runtime):
+        if cls._instance is None:
+            cls._instance = super(ReleaseSchedule, cls).__new__(cls)
+            cls.initialize(runtime)
+        return cls._instance
+
+    @classmethod
+    def initialize(cls, runtime):
+        if 'GITLAB_TOKEN' not in os.environ:
+            raise RuntimeError('A GITLAB_TOKEN env var must be defined')
+
+        # Clone ocp-release-schedule in doozer working dir
+        git_data = gitdata.GitData(
+            data_path=f'https://oauth2:{os.environ["GITLAB_TOKEN"]}@gitlab.cee.redhat.com/ocp-release-schedule/schedule.git',
+            clone_dir=runtime.working_dir
+        )
+
+        # Parse and store relevant yaml
+        major = runtime.group_config.vars['MAJOR']
+        minor = runtime.group_config.vars['MINOR']
+        config_file = f'{git_data.data_dir}/schedules/{major}.{minor}.yaml'
+        with open(config_file) as f:
+            cls._instance.schedule_data = yaml.safe_load(f.read())
+
+    def get_ff_date(self) -> datetime:
+        event = next(item for item in self.schedule_data['events'] if item["name"] == "feature-freeze")
+        return datetime.strptime(event['date'], '%Y-%m-%dT%H:00:00-00:00')


### PR DESCRIPTION
Ref. [ART-4931](https://issues.redhat.com/browse/ART-4931)

In https://github.com/openshift/doozer/pull/646, we introduced the `canonical_builders_from_upstream` flag that controls the way we rebase Dockerfiles. 

With this PR, the flag is turned into a parameter that can (and normally should) be set to 'auto': when this happens, Doozer will clone https://gitlab.cee.redhat.com/ocp-release-schedule/schedule/-/tree/master/ and check the feature freeze date for the relevant OCP version. If we are before feature freeze, it will try to match upstream; otherwise, it will override upstream builders according to ART configuration.

The ReleaseSchedule class is responsible for cloning and parsing the schedule repo. I've decided to make it a Singleton, since we do not want to clone the repo more times than needed (just once), and we currently just want to do it when running `doozer images:rebase` (hence not suitable for being initialized with the runtime). Using the Singleton pattern, we can safely type `ReleaseSchedule(runtime)` as many times as we want without worrying about checking if we already did clone.