### PR TITLE
[ART-5088] Make ReleaseSchedule singleton class thread safe

### DIFF
--- a/doozerlib/release_schedule.py
+++ b/doozerlib/release_schedule.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import threading
 
 import yaml
 
@@ -13,11 +14,16 @@ class ReleaseSchedule:
     """
 
     _instance = None
+    _lock = threading.Lock()
 
     def __new__(cls, runtime):
         if cls._instance is None:
-            cls._instance = super(ReleaseSchedule, cls).__new__(cls)
-            cls.initialize(runtime)
+            with cls._lock:
+                # Another thread could have created the instance before the lock was acquired
+                # So check that the instance is still nonexistent.
+                if cls._instance is None:
+                    cls._instance = super(ReleaseSchedule, cls).__new__(cls)
+                    cls.initialize(runtime)
         return cls._instance
 
     @classmethod


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-5088

The best approach to this issue would be to eliminate concurrency by thread pool during rebase, and to adopt an async pattern. However, this is a lengthy task that involves a relevant refactoring. I propose to fix the error by making our code thread safe, and move the refactoring part in a dedicated ticket.