### PR TITLE
Define `release_name` when initing Runtime

### DIFF
--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -113,6 +113,7 @@ class RPMMetadata(Metadata):
             "content": new_specfile_data,
             "set_env": {"PATH": path},
             "runtime_assembly": self.runtime.assembly,
+            "release_name": "",
         }
 
         if self.runtime.assembly_type in [AssemblyTypes.STANDARD, AssemblyTypes.CANDIDATE, AssemblyTypes.PREVIEW]:

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -800,7 +800,7 @@ def isolate_major_minor_in_group(group_name: str) -> Tuple[int, int]:
     return int(match[1]), int(match[2])
 
 
-def get_release_name(assembly_type: str, group_name: str, assembly_name: str, release_offset: Optional[int]):
+def get_release_name(assembly_type: assembly.AssemblyTypes, group_name: str, assembly_name: str, release_offset: Optional[int]):
     major, minor = isolate_major_minor_in_group(group_name)
     if major is None or minor is None:
         raise ValueError(f"Invalid group name: {group_name}")


### PR DESCRIPTION
This will avoid template key not defined error to allow to rebasing
microshift against nightlies.

This also refactors a little bit to reduce duplicate code.