### PR TITLE
Remove hardcoded permits for stream assembly

### DIFF
--- a/doozerlib/assembly.py
+++ b/doozerlib/assembly.py
@@ -285,27 +285,11 @@ def assembly_permits(releases_config: Model, assembly: typing.Optional[str]) -> 
     """
     :param releases_config: The content of releases.yml in Model form.
     :param assembly: The name of the assembly to assess
-    Returns the a computed permits config model for a given assembly. If no
+    Returns computed permits config model for a given assembly. If no
     permits are defined ListModel([]) is returned.
     """
 
     defined_permits = _assembly_config_struct(releases_config, assembly, 'permits', [])
-
-    if not defined_permits and (assembly == 'stream' or not assembly):  # If assembly is None, this a group without assemblies enabled
-        # TODO: Address this formally with https://issues.redhat.com/browse/ART-3162 .
-        # In the short term, we need to allow certain inconsistencies for stream.
-        # We don't want common pre-GA issues to stop all nightlies.
-        default_stream_permits = [
-            {
-                'code': 'OUTDATED_RPMS_IN_STREAM_BUILD',
-                'component': '*'
-            },
-            {
-                'code': 'CONFLICTING_GROUP_RPM_INSTALLED',
-                'component': 'rhcos'
-            }
-        ]
-        return ListModel(list_to_model=default_stream_permits)
 
     # Do some basic validation here to fail fast
     if assembly_type(releases_config, assembly) == AssemblyTypes.STANDARD:


### PR DESCRIPTION
Right now we have hardcoded default permits for all stream
assemblies.This creates a situation for where it's easy to forget
default permits exist when defining any other permit in releases.yml example
when rhcos is broken - or at the time of branch cut. Including them explicitly 
in releases.yml will ensure that we are aware of them and they are defined 
in one place.

Context: https://coreos.slack.com/archives/C048BG69N8H/p1668031797575059

We will need follow up ocp-build-data PRs for all versions that we build
to include these explicitly (right now they are explicitly defined in 4.13-4.8)
4.7 - <>
4.6 - <>
