### PR TITLE
config:print - fix bug in definition

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1653,7 +1653,7 @@ def config_mode(runtime, mode, push, message):
 
 
 @cli.command("config:print", short_help="View config for given images / rpms")
-@click.option("-n", "--name-only", default=[], is_flag=True,
+@click.option("-n", "--name-only", default=False, is_flag=True,
               help="Just print name of matched configs. Overrides --key")
 @click.option("--key", help="Specific key in config to print", default=None)
 @click.option("--yaml", "as_yaml", default=False, is_flag=True, help='Print results in a yaml block')


### PR DESCRIPTION
`config:print` broke. guess how i discovered it...
yes, while running the `rebuild` job for the first time in 3 months.