### PR TITLE
get-nightlies: honor --arches global option

### DIFF
--- a/tests/cli/test_get_nightlies.py
+++ b/tests/cli/test_get_nightlies.py
@@ -9,10 +9,13 @@ from doozerlib.model import Model
 
 class TestGetNightlies(TestCase):
     def setUp(self):
-        self.runtime = MagicMock(group_config=Model(dict(
-            arches=["x86_64", "s390x", "ppc64le", "aarch64"],
-            multi_arch=dict(enabled=True),
-        )))
+        self.runtime = MagicMock(
+            group_config=Model(dict(
+                arches=["x86_64", "s390x", "ppc64le", "aarch64"],
+                multi_arch=dict(enabled=True),
+            )),
+            arches=["x86_64", "s390x", "ppc64le", "aarch64"]
+        )
         subject.image_info_cache = {}
 
     def test_determine_arch_list(self):
@@ -22,7 +25,7 @@ class TestGetNightlies(TestCase):
             set(subject.determine_arch_list(self.runtime, ["s390x", "ppc64le"]))
         )
 
-        runtime = MagicMock(group_config=Model(dict(arches=["x86_64", "aarch64"])))
+        runtime = MagicMock(arches=["x86_64", "aarch64"])
         with self.assertRaises(ValueError, msg="should fail when specifying non-configured arch"):
             subject.determine_arch_list(runtime, ["bogus"])
         # with self.assertRaises(ValueError, msg="should fail when specifying multi if not configured"):


### PR DESCRIPTION
This is useful to get a consistent set of nightlies for microshift rebase because we only care about certain arches.

```sh
doozer --arches=x86_64,aarch64 --group=openshift-4.12 --assembly=stream get-nightlies --matching=4.12.0-0.nightly-2022-11-16-003434 --limit=2
```

Use `runtime.arches` to retrieve all enabled arches instead of reading group config.