### PR TITLE
Fix unit test warning

### DIFF
--- a/tests/test_pushd.py
+++ b/tests/test_pushd.py
@@ -37,13 +37,13 @@ class DirTestCase(unittest.TestCase):
         Execute the concurrency test for 10 threads
         """
         thread_count = 10
-        pool = Pool(thread_count)
-        results = [
-            pool.apply_async(lambda: self.test_getcwd(concurrent=True))
-            for _ in range(thread_count)
-        ]
-        for result in results:
-            result.get()
+        with Pool(thread_count) as pool:
+            results = [
+                pool.apply_async(lambda: self.test_getcwd(concurrent=True))
+                for _ in range(thread_count)
+            ]
+            for result in results:
+                result.get()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To prevent such a warning during unit test execution:
```
/usr/lib64/python3.8/multiprocessing/pool.py:265: ResourceWarning: unclosed running multiprocessing pool <multiprocessing.pool.ThreadPool state=RUN pool_size=10>
  _warn(f"unclosed running multiprocessing pool {self!r}",
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```