### PR TITLE
Revert "[ART-5384] Async release gen payload"

### DIFF
--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime
 import hashlib
 import traceback
@@ -9,7 +8,6 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Dict, NamedTuple, Iterable, Set, Any, Callable
 from unittest.mock import MagicMock
 
-import aiofiles
 import click
 import yaml
 from doozerlib import rhcos
@@ -104,7 +102,7 @@ and in more detail in state.yaml. The release-controller, per ART-2195, will
 read and propagate/expose this annotation in its display of the release image.
     """
     runtime.initialize(mode="both", clone_distgits=False, clone_source=False, prevent_cloning=True)
-    pipeline = GenPayloadCli(
+    GenPayloadCli(
         runtime,
         is_name or assembly_imagestream_base_name(runtime),
         is_namespace or default_imagestream_namespace_base_name(),
@@ -113,9 +111,7 @@ read and propagate/expose this annotation in its display of the release image.
         exclude_arch,
         skip_gc_tagging, emergency_ignore_issues,
         apply, apply_multi_arch, moist_run
-    )
-
-    asyncio.get_event_loop().run_until_complete(pipeline.run())
+    ).run()
 
 
 def default_imagestream_base_name(version: str) -> str:
@@ -145,7 +141,7 @@ def payload_imagestream_namespace_and_name(base_namespace: str, base_imagestream
     return namespace, name
 
 
-async def modify_and_replace_api_object(api_obj: oc.APIObject, modifier_func: Callable[[oc.APIObject], Any], backup_file_path: Path, dry_run: bool):
+def modify_and_replace_api_object(api_obj: oc.APIObject, modifier_func: Callable[[oc.APIObject], Any], backup_file_path: Path, dry_run: bool):
     """
     Receives an APIObject, archives the current state of that object, runs a modifying method on it,
     archives the new state of the object, and then tries to replace the object on the
@@ -157,11 +153,8 @@ async def modify_and_replace_api_object(api_obj: oc.APIObject, modifier_func: Ca
                              states of the object before triggering the update.
     :param dry_run: Write archive files but do not actually update the imagestream.
     """
-
-    filepath = backup_file_path.joinpath(
-        f"replacing-{api_obj.kind()}.{api_obj.namespace()}.{api_obj.name()}.before-modify.json")
-    async with aiofiles.open(filepath, mode='w+') as backup_file:
-        await backup_file.write(api_obj.as_json(indent=4))
+    with backup_file_path.joinpath(f"replacing-{api_obj.kind()}.{api_obj.namespace()}.{api_obj.name()}.before-modify.json").open(mode="w+") as backup_file:
+        backup_file.write(api_obj.as_json(indent=4))
 
     modifier_func(api_obj)
     api_obj_model = api_obj.model
@@ -178,10 +171,8 @@ async def modify_and_replace_api_object(api_obj: oc.APIObject, modifier_func: Ca
 
     api_obj_model.pop("status")
 
-    filepath = backup_file_path.joinpath(
-        f"replacing-{api_obj.kind()}.{api_obj.namespace()}.{api_obj.name()}.after-modify.json")
-    async with aiofiles.open(filepath, mode="w+") as backup_file:
-        await backup_file.write(api_obj.as_json(indent=4))
+    with backup_file_path.joinpath(f"replacing-{api_obj.kind()}.{api_obj.namespace()}.{api_obj.name()}.after-modify.json").open(mode="w+") as backup_file:
+        backup_file.write(api_obj.as_json(indent=4))
 
     if not dry_run:
         api_obj.replace()
@@ -268,7 +259,7 @@ class GenPayloadCli:
         # do we proceed with this payload after weighing issues against permits?
         self.payload_permitted = False
 
-    async def run(self):
+    def run(self):
         """Main entry point once instantiated with CLI inputs."""
         self.validate_parameters()
 
@@ -277,14 +268,14 @@ class GenPayloadCli:
         assembly_inspector = AssemblyInspector(rt, rt.build_retrying_koji_client())
 
         self.payload_entries_for_arch = self.generate_payload_entries(assembly_inspector)
-        assembly_report: Dict = await self.generate_assembly_report(assembly_inspector)
+        assembly_report: Dict = self.generate_assembly_report(assembly_inspector)
 
         print(yaml.dump(assembly_report, default_flow_style=False, indent=2))
         with self.output_path.joinpath("assembly-report.yaml").open(mode="w") as report_file:
             yaml.dump(assembly_report, stream=report_file, default_flow_style=False, indent=2)
 
         self.assess_assembly_viability()
-        await self.sync_payloads()  # even when not permitted, produce what we _would have_ synced
+        self.sync_payloads()  # even when not permitted, produce what we _would have_ synced
 
         if self.payload_permitted:
             exit(0)
@@ -311,7 +302,7 @@ class GenPayloadCli:
                 "Cannot create a multi nightly without including the full set of images. "
                 "Either include all images/arches or omit --apply-multi-arch")
 
-    async def generate_assembly_report(self, assembly_inspector: AssemblyInspector) -> Dict:
+    def generate_assembly_report(self, assembly_inspector: AssemblyInspector) -> Dict:
         """Generate a status report of the search for inconsistencies across all payloads generated."""
         rt = self.runtime
         report = dict(
@@ -322,13 +313,13 @@ class GenPayloadCli:
                 if ii is None
             ],  # A list of metas where the assembly did not find a build
         )
-        report["viable"], report["assembly_issues"] = await self.generate_assembly_issues_report(assembly_inspector)
+        report["viable"], report["assembly_issues"] = self.generate_assembly_issues_report(assembly_inspector)
 
         self.payload_permitted = report["viable"]
 
         return report
 
-    async def generate_assembly_issues_report(self, assembly_inspector: AssemblyInspector) -> (bool, Dict[str, Dict]):
+    def generate_assembly_issues_report(self, assembly_inspector: AssemblyInspector) -> (bool, Dict[str, Dict]):
         """Populate self.assembly_issues and payload entries with inconsistencies found."""
         rt = self.runtime
         self.logger.info("Checking assembly content for inconsistencies.")
@@ -353,7 +344,7 @@ class GenPayloadCli:
         self.detect_extend_payload_entry_issues(assembly_inspector)
 
         # If the assembly claims to have reference nightlies, assert that our payload matches them exactly.
-        self.assembly_issues.extend(await PayloadGenerator.check_nightlies_consistency(assembly_inspector))
+        self.assembly_issues.extend(PayloadGenerator.check_nightlies_consistency(assembly_inspector))
 
         return self.summarize_issue_permits(assembly_inspector)
 
@@ -580,7 +571,7 @@ class GenPayloadCli:
                 self.apply = False
                 self.apply_multi_arch = False
 
-    async def sync_payloads(self):
+    def sync_payloads(self):
         """
         Use the payload entries that have been generated across the arches to mirror the images
         out to quay and create the imagestream definitions that will update the release-controller.
@@ -596,24 +587,20 @@ class GenPayloadCli:
             False: dict()
         }
 
-        tasks = []
         for arch, payload_entries in self.payload_entries_for_arch.items():
-            tasks.append(self.mirror_payload_content(arch, payload_entries))
+            self.mirror_payload_content(arch, payload_entries)
             for private_mode in self.privacy_modes:
                 self.logger.info(f"Building payload files for architecture: {arch}; private: {private_mode}")
-                tasks.append(
-                    self.generate_specific_payload_imagestreams(arch, private_mode, payload_entries, multi_specs))
-        await asyncio.gather(*tasks)
+                self.generate_specific_payload_imagestreams(arch, private_mode, payload_entries, multi_specs)
 
         if self.apply_multi_arch:
             if self.runtime.group_config.multi_arch.enabled:
-                await self.sync_heterogeneous_payloads(multi_specs)
+                self.sync_heterogeneous_payloads(multi_specs)
             else:
                 self.logger.info("--apply-multi-arch is enabled but the group config / assembly does "
                                  "not have group.multi_arch.enabled==true")
 
-    @exectools.limit_concurrency(500)
-    async def mirror_payload_content(self, arch: str, payload_entries: Dict[str, PayloadEntry]):
+    def mirror_payload_content(self, arch: str, payload_entries: Dict[str, PayloadEntry]):
         """Ensure an arch's payload entries are synced out for the public to access."""
         # Prevents writing the same destination twice (not supported by oc if in the same mirroring file):
         mirror_src_for_dest: Dict[str, str] = dict()
@@ -633,19 +620,15 @@ class GenPayloadCli:
         # it is what we update in the imagestreams that defines whether the image will be
         # part of a public vs private release.
         src_dest_path = self.output_path.joinpath(f"src_dest.{arch}")
-        async with aiofiles.open(src_dest_path, mode="w+", encoding="utf-8") as out_file:
+        with src_dest_path.open("w+", encoding="utf-8") as out_file:
             for dest_pullspec, src_pullspec in mirror_src_for_dest.items():
-                await out_file.write(f"{src_pullspec}={dest_pullspec}\n")
+                out_file.write(f"{src_pullspec}={dest_pullspec}\n")
 
         if self.apply or self.apply_multi_arch:
             self.logger.info(f"Mirroring images from {str(src_dest_path)}")
-            try:
-                await asyncio.wait_for(exectools.cmd_assert_async(
-                    f"oc image mirror --keep-manifest-list --filename={str(src_dest_path)}", retries=3), timeout=1800)
-            except asyncio.TimeoutError:
-                pass
+            exectools.cmd_assert(f"oc image mirror --keep-manifest-list --filename={str(src_dest_path)}", retries=3, timeout=1800)
 
-    async def generate_specific_payload_imagestreams(
+    def generate_specific_payload_imagestreams(
             self, arch: str, private_mode: bool,
             payload_entries: Dict[str, PayloadEntry],
             # Map [is_private] -> [tag_name] -> [arch] -> PayloadEntry
@@ -680,27 +663,26 @@ class GenPayloadCli:
         imagestream_namespace, imagestream_name = payload_imagestream_namespace_and_name(
             *self.base_imagestream, arch, private_mode)
 
-        await self.write_imagestream_artifact_file(imagestream_namespace, imagestream_name, istags, incomplete_payload_update)
+        self.write_imagestream_artifact_file(imagestream_namespace, imagestream_name, istags, incomplete_payload_update)
         if self.apply:
-            await self.apply_arch_imagestream(imagestream_namespace, imagestream_name, istags, incomplete_payload_update)
+            self.apply_arch_imagestream(imagestream_namespace, imagestream_name, istags, incomplete_payload_update)
 
-    async def write_imagestream_artifact_file(self, imagestream_namespace: str, imagestream_name: str, istags: List[Dict], incomplete_payload_update):
+    def write_imagestream_artifact_file(self, imagestream_namespace: str, imagestream_name: str, istags: List[Dict], incomplete_payload_update):
         """Write the yaml file for the imagestream."""
-        filename = f"updated-tags-for.{imagestream_namespace}.{imagestream_name}" \
-                   f"{'-partial' if incomplete_payload_update else ''}.yaml"
-        async with aiofiles.open(self.output_path.joinpath(filename), mode="w+", encoding="utf-8") as out_file:
+        filename = f"updated-tags-for.{imagestream_namespace}.{imagestream_name}{'-partial' if incomplete_payload_update else ''}.yaml"
+        with self.output_path.joinpath(filename).open("w+", encoding="utf-8") as out_file:
             istream_spec = PayloadGenerator.build_payload_imagestream(
                 self.runtime,
                 imagestream_name, imagestream_namespace,
                 istags, self.assembly_issues
             )
-            await out_file.write(yaml.safe_dump(istream_spec, indent=2, default_flow_style=False))
+            yaml.safe_dump(istream_spec, out_file, indent=2, default_flow_style=False)
 
-    async def apply_arch_imagestream(self, imagestream_namespace: str, imagestream_name: str, istags: List[Dict], incomplete_payload_update: bool):
+    def apply_arch_imagestream(self, imagestream_namespace: str, imagestream_name: str, istags: List[Dict], incomplete_payload_update: bool):
         """Orchestrate the update and tag removal for one arch imagestream in the OCP cluster."""
         with oc.project(imagestream_namespace):
             istream_apiobj = self.ensure_imagestream_apiobj(imagestream_name)
-            pruning_tags, adding_tags = await self.apply_imagestream_update(istream_apiobj, istags, incomplete_payload_update)
+            pruning_tags, adding_tags = self.apply_imagestream_update(istream_apiobj, istags, incomplete_payload_update)
 
             if pruning_tags:
                 self.logger.warning(f"The following tag names are no longer part of the release and will be pruned in {imagestream_namespace}:{imagestream_name}: {pruning_tags}")
@@ -735,7 +717,7 @@ class GenPayloadCli:
         })
         return oc.selector(f"imagestream/{imagestream_name}").object()
 
-    async def apply_imagestream_update(self, istream_apiobj, istags: List[Dict], incomplete_payload_update: bool) -> Tuple[Set[str], Set[str]]:
+    def apply_imagestream_update(self, istream_apiobj, istags: List[Dict], incomplete_payload_update: bool) -> Tuple[Set[str], Set[str]]:
         """Apply changes for one imagestream object to the OCP cluster."""
         # gather diffs between old and new, indicating removal or addition
         pruning_tags: Set[str] = set()
@@ -774,10 +756,10 @@ class GenPayloadCli:
 
             apiobj.model.spec.tags = new_istags
 
-        await modify_and_replace_api_object(istream_apiobj, update_single_arch_istags, self.output_path, self.moist_run)
+        modify_and_replace_api_object(istream_apiobj, update_single_arch_istags, self.output_path, self.moist_run)
         return pruning_tags, adding_tags
 
-    async def sync_heterogeneous_payloads(self, multi_specs: Dict[bool, Dict[str, Dict[str, PayloadEntry]]]):
+    def sync_heterogeneous_payloads(self, multi_specs: Dict[bool, Dict[str, Dict[str, PayloadEntry]]]):
         """
         We now generate the artifacts to create heterogeneous release payloads (suitable for
         clusters with multiple arches present). A heterogeneous or 'multi' release payload is a
@@ -824,10 +806,10 @@ class GenPayloadCli:
             multi_release_manifest_list_tag: str  # The quay.io tag to preserve the multi payload
             multi_release_istag, multi_release_manifest_list_tag = self.get_multi_release_names(private_mode)
 
-            tasks = []
-            for tag_name, arch_to_payload_entry in multi_specs[private_mode].items():
-                tasks.append(self.build_multi_istag(tag_name, arch_to_payload_entry, imagestream_namespace))
-            multi_istags: List[Dict] = await asyncio.gather(*tasks)
+            multi_istags: List[Dict] = list(
+                self.build_multi_istag(tag_name, arch_to_payload_entry, imagestream_namespace)
+                for tag_name, arch_to_payload_entry in multi_specs[private_mode].items()
+            )
 
             # now multi_istags contains istags which all point to component manifest lists. We must
             # run oc adm release new on this set of tags -- once for each arch - to create the arch
@@ -840,13 +822,13 @@ class GenPayloadCli:
             # We will then stitch those arch specific payload images together into a release payload
             # manifest list.
             multi_release_dest: str = f"quay.io/{'/'.join(self.release_repo)}:{multi_release_manifest_list_tag}"
-            final_multi_pullspec: str = await self.create_multi_release_image(
+            final_multi_pullspec: str = self.create_multi_release_image(
                 imagestream_name, multi_release_is, multi_release_dest, multi_release_istag,
                 multi_specs, private_mode)
             self.logger.info(f"The final pull_spec for the multi release payload is: {final_multi_pullspec}")
 
             with oc.project(imagestream_namespace):
-                await self.apply_multi_imagestream_update(final_multi_pullspec, imagestream_name, multi_release_istag)
+                self.apply_multi_imagestream_update(final_multi_pullspec, imagestream_name, multi_release_istag)
 
     def get_multi_release_names(self, private_mode: bool) -> Tuple[str, str]:
         """
@@ -875,7 +857,7 @@ class GenPayloadCli:
             multi_release_istag = multi_release_manifest_list_tag
         return multi_release_istag, multi_release_manifest_list_tag
 
-    async def build_multi_istag(self, tag_name: str, arch_to_payload_entry: Dict[str, PayloadEntry], imagestream_namespace: str) -> Dict:
+    def build_multi_istag(self, tag_name: str, arch_to_payload_entry: Dict[str, PayloadEntry], imagestream_namespace: str) -> Dict:
         """Build a single imagestream tag for a component in a multi-arch payload."""
         # There are two flows:
         # 1. The images for ALL arches were part of the same brew built manifest list. In this case,
@@ -894,8 +876,7 @@ class GenPayloadCli:
             self.logger.info(f"Reusing brew manifest-list {output_digest_pullspec} for component {tag_name}")
         else:
             # Flow 2: Build a new manifest list and push it to quay.
-            output_digest_pullspec = \
-                await self.create_multi_manifest_list(tag_name, arch_to_payload_entry, imagestream_namespace)
+            output_digest_pullspec = self.create_multi_manifest_list(tag_name, arch_to_payload_entry, imagestream_namespace)
 
         issues = list(issue  # collect issues from each payload entry.
                       for payload_entry in entries
@@ -906,7 +887,7 @@ class GenPayloadCli:
                 issues=issues,
             ))
 
-    async def create_multi_manifest_list(
+    def create_multi_manifest_list(
             self, tag_name: str,
             arch_to_payload_entry: Dict[str, PayloadEntry],
             imagestream_namespace: str) -> str:
@@ -939,15 +920,16 @@ class GenPayloadCli:
         output_pullspec: str = f"{self.full_component_repo()}:sha256-{manifest_list_hash.hexdigest()}"
 
         # write the manifest list to a file and push it to the registry.
-        async with aiofiles.open(component_manifest_path, mode="w+") as ml:
-            await ml.write(yaml.safe_dump(dict(image=output_pullspec, manifests=manifests), default_flow_style=False))
-        await exectools.cmd_assert_async(f"manifest-tool push from-spec {str(component_manifest_path)}", retries=3)
+        with component_manifest_path.open(mode="w+") as ml:
+            yaml.safe_dump(
+                dict(image=output_pullspec, manifests=manifests),
+                stream=ml, default_flow_style=False)
+        exectools.cmd_assert(f"manifest-tool push from-spec {str(component_manifest_path)}", retries=3)
 
         # we are pushing a new manifest list, so return its sha256 based pullspec
-        sha = await find_manifest_list_sha(output_pullspec)
-        return exchange_pullspec_tag_for_shasum(output_pullspec, sha)
+        return exchange_pullspec_tag_for_shasum(output_pullspec, find_manifest_list_sha(output_pullspec))
 
-    async def create_multi_release_image(
+    def create_multi_release_image(
             self, imagestream_name: str, multi_release_is: Dict, multi_release_dest: str,
             multi_release_name: str, multi_specs: Dict[bool, Dict[str, Dict[str, PayloadEntry]]],
             private_mode: bool) -> str:
@@ -960,32 +942,28 @@ class GenPayloadCli:
         # Write the imagestream to a file ("oc adm release new" can read from a file instead of
         # openshift cluster API)
         multi_release_is_path: Path = self.output_path.joinpath(f"{imagestream_name}-release-imagestream.yaml")
-        async with aiofiles.open(multi_release_is_path, mode="w+") as mf:
-            await mf.write(yaml.safe_dump(multi_release_is))
+        with multi_release_is_path.open(mode="w+") as mf:
+            yaml.safe_dump(multi_release_is, mf)
 
         arch_release_dests: Dict[str, str] = dict()  # This will map arch names to a release payload pullspec we create for that arch (i.e. based on the arch's CVO image)
-        tasks = []
         for arch, cvo_entry in multi_specs[private_mode]["cluster-version-operator"].items():
             arch_release_dests[arch] = f"{multi_release_dest}-{arch}"
             # Create the arch specific release payload containing tags pointing to manifest list
             # component images.
-            tasks.append(
-                exectools.cmd_assert_async([
-                    "oc", "adm", "release", "new",
-                    f"--name={multi_release_name}",
-                    "--reference-mode=source",
-                    "--keep-manifest-list",
-                    f"--from-image-stream-file={str(multi_release_is_path)}",
-                    f"--to-image-base={cvo_entry.dest_pullspec}",
-                    f"--to-image={arch_release_dests[arch]}",
-                    "--metadata", json.dumps({"release.openshift.io/architecture": "multi"})
-                ])
-            )
-        await asyncio.gather(*tasks)
+            exectools.cmd_assert([
+                "oc", "adm", "release", "new",
+                f"--name={multi_release_name}",
+                "--reference-mode=source",
+                "--keep-manifest-list",
+                f"--from-image-stream-file={str(multi_release_is_path)}",
+                f"--to-image-base={cvo_entry.dest_pullspec}",
+                f"--to-image={arch_release_dests[arch]}",
+                "--metadata", json.dumps({"release.openshift.io/architecture": "multi"})
+            ])
 
-        return await self.create_multi_release_manifest_list(arch_release_dests, imagestream_name, multi_release_dest)
+        return self.create_multi_release_manifest_list(arch_release_dests, imagestream_name, multi_release_dest)
 
-    async def create_multi_release_manifest_list(
+    def create_multi_release_manifest_list(
             self, arch_release_dests: Dict[str, str],
             imagestream_name: str, multi_release_dest: str) -> str:
         """
@@ -1006,16 +984,16 @@ class GenPayloadCli:
         }
 
         release_payload_ml_path = self.output_path.joinpath(f"{imagestream_name}.manifest-list.yaml")
-        async with aiofiles.open(release_payload_ml_path, mode="w+") as ml:
-            await ml.write(yaml.safe_dump(ml_dict, default_flow_style=False))
+        with release_payload_ml_path.open(mode="w+") as ml:
+            yaml.safe_dump(ml_dict, stream=ml, default_flow_style=False)
 
         # Construct the top level manifest list release payload
-        await exectools.cmd_assert_async(f"manifest-tool push from-spec {str(release_payload_ml_path)}", retries=3)
+        exectools.cmd_assert(f"manifest-tool push from-spec {str(release_payload_ml_path)}", retries=3)
         # if we are actually pushing a manifest list, then we should derive a sha256 based pullspec
-        sha = await find_manifest_list_sha(multi_release_dest)
-        return exchange_pullspec_tag_for_shasum(multi_release_dest, sha)
+        return exchange_pullspec_tag_for_shasum(
+            multi_release_dest, find_manifest_list_sha(multi_release_dest))
 
-    async def apply_multi_imagestream_update(self, final_multi_pullspec: str, imagestream_name: str, multi_release_istag: str):
+    def apply_multi_imagestream_update(self, final_multi_pullspec: str, imagestream_name: str, multi_release_istag: str):
         """
         If running with assembly==stream, updates release imagestream with a new imagestream tag for the nightly. Older
         nightlies are pruned from the release imagestream.
@@ -1073,8 +1051,7 @@ class GenPayloadCli:
             })
             return True
 
-        await modify_and_replace_api_object(
-            multi_art_latest_is, add_multi_nightly_release, self.output_path, self.moist_run)
+        modify_and_replace_api_object(multi_art_latest_is, add_multi_nightly_release, self.output_path, self.moist_run)
 
 
 class PayloadGenerator:
@@ -1383,7 +1360,7 @@ class PayloadGenerator:
         return members
 
     @staticmethod
-    async def _check_nightly_consistency(assembly_inspector: AssemblyInspector, nightly: str, arch: str) -> List[AssemblyIssue]:
+    def _check_nightly_consistency(assembly_inspector: AssemblyInspector, nightly: str, arch: str) -> List[AssemblyIssue]:
         runtime = assembly_inspector.runtime
 
         def terminal_issue(msg: str) -> List[AssemblyIssue]:
@@ -1403,7 +1380,7 @@ class PayloadGenerator:
         rc = -1
         pullspec = f"registry.ci.openshift.org/ocp{rc_suffix}/release{rc_suffix}:{nightly}"
         while retries > 0:
-            rc, release_json_str, err = await exectools.cmd_gather_async(f"oc adm release info {pullspec} -o=json")
+            rc, release_json_str, err = exectools.cmd_gather(f"oc adm release info {pullspec} -o=json")
             if rc == 0:
                 break
             runtime.logger.warn(f"Error accessing nightly release info for {pullspec}:  {err}")
@@ -1450,7 +1427,7 @@ class PayloadGenerator:
         return issues
 
     @staticmethod
-    async def check_nightlies_consistency(assembly_inspector: AssemblyInspector) -> List[AssemblyIssue]:
+    def check_nightlies_consistency(assembly_inspector: AssemblyInspector) -> List[AssemblyIssue]:
         """
         If this assembly has reference-releases, check whether the current images selected by the
         assembly are an exact match for the nightly contents.
@@ -1460,9 +1437,7 @@ class PayloadGenerator:
             return []
 
         issues: List[AssemblyIssue] = []
-        tasks = []
         for arch, nightly in basis.reference_releases.primitive().items():
-            tasks.append(PayloadGenerator._check_nightly_consistency(assembly_inspector, nightly, arch))
-        issues.extend(await asyncio.gather(*tasks))
+            issues.extend(PayloadGenerator._check_nightly_consistency(assembly_inspector, nightly, arch))
 
         return issues

--- a/doozerlib/util.py
+++ b/doozerlib/util.py
@@ -781,9 +781,9 @@ def get_release_calc_previous(version, arch,
     return sort_semver(list(upgrade_from))
 
 
-async def find_manifest_list_sha(pull_spec):
+def find_manifest_list_sha(pull_spec):
     cmd = 'oc image info --filter-by-os=linux/amd64 -o json {}'.format(pull_spec)
-    out, err = await exectools.cmd_assert_async(cmd, retries=3)
+    out, err = exectools.cmd_assert(cmd, retries=3)
     image_data = json.loads(out)
     if 'listDigest' not in image_data:
         raise ValueError('Specified image is not a manifest-list.')


### PR DESCRIPTION
Reverts openshift/doozer#697

Ran into an error:
```
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Fbuild-sync/art-tools/doozer/doozerlib/cli/release_gen_payload.py", line 564, in summarize_issue_permits
    assembly_issues_report.setdefault(ai.component, []).append(dict(
AttributeError: 'list' object has no attribute 'component'
```
in https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/28979/console.

Reverting to have time to resolve this.