### PR TITLE
Expose jira information from components

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -25,6 +25,10 @@ group: openshift-4.0
 #Username for running rhpkg / brew / tito
 user: ahaile
 
+# URLs for internal systems
+hosts:
+  prodsec_git: ...
+
 #Global option overrides that can only be set from settings.yaml
 global_opts:
   # num of concurrent distgit pull/pushes

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1285,15 +1285,11 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
             public_url = None
         s = s.replace("{upstream_public}", public_url or 'None')
 
-        if '{bz_' in s:
-            mi = image.get_maintainer_info()
-            desc = ''
-            for k, v in mi.items():
-                desc += f'[{k}={v}] '
-            s = s.replace('{bz_info}', desc)
-            s = s.replace('{bz_product}', mi.get('product', 'Unknown'))
-            s = s.replace('{bz_component}', mi.get('component', 'Unknown'))
-            s = s.replace('{bz_subcomponent}', mi.get('subcomponent', 'N/A'))
+        if '{jira_' in s:
+            jira_project, jira_component = image.get_jira_info()
+            s = s.replace('{jira_info}', 'jira[project={jira_project} component={jira_component}]')
+            s = s.replace('{jira_project}', jira_project)
+            s = s.replace('{jira_component}', jira_component)
 
         if '{image}' in s:
             s = s.replace("{image}", get_dfp().labels["name"])

--- a/doozerlib/cli/cli_opts.py
+++ b/doozerlib/cli/cli_opts.py
@@ -18,6 +18,13 @@ def global_opt_default_string():
     return res
 
 
+def hosts_default_string():
+    res = '\n'
+    for k in ('prodsec_git',):
+        res += '  {}:\n'.format(k)
+    return res
+
+
 CLI_OPTS = {
     'data_path': {
         'env': 'DOOZER_DATA_PATH',
@@ -34,6 +41,10 @@ CLI_OPTS = {
     'user': {
         'env': 'DOOZER_USER',
         'help': 'Username for running rhpkg / brew'
+    },
+    'hosts': {
+        'help': 'Mappings of host aliases to their internal hostnames',
+        'default': hosts_default_string()
     },
     'global_opts': {
         'help': 'Global option overrides that can only be set from settings.yaml',

--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1838,10 +1838,9 @@ class ImageDistGitRepo(DistGitRepo):
             if "com.redhat.delivery.appregistry" in dfp.labels:
                 dfp.labels["com.redhat.delivery.appregistry"] = "False"
 
-            # For each bit of maintainer information we have, create a new label in the image
-            maintainer = self.metadata.get_maintainer_info()
-            for k, v in maintainer.items():
-                dfp.labels[f'io.openshift.maintainer.{k}'] = v
+            jira_project, jira_component = self.metadata.get_jira_info()
+            dfp.labels['io.openshift.maintainer.project'] = jira_project
+            dfp.labels['io.openshift.maintainer.component'] = jira_component
 
             if 'from' in self.config:
                 self._rebase_from_directives(dfp)

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -301,13 +301,8 @@ class RPMBuilder:
         """
         if not rpm.source_path:
             raise ValueError("Source is not cloned.")
-        maintainer = await exectools.to_thread(rpm.get_maintainer_info)
-        maintainer_string = ""
-        if maintainer:
-            flattened_info = ", ".join(f"{k}: {v}" for (k, v) in maintainer.items())
-            # The space before the [Maintainer] information is actual rpm spec formatting
-            # clue to preserve the line instead of assuming it is part of a paragraph.
-            maintainer_string = f"[Maintainer] {flattened_info}"
+        project, component = await exectools.to_thread(rpm.get_jira_info)
+        maintainer_string = f'[Maintainer] project: {project}, component: {component}'
 
         # otherwise, make changes similar to tito tagging
         rpm_spec_tags = {

--- a/tests/test_rpm_builder.py
+++ b/tests/test_rpm_builder.py
@@ -240,12 +240,7 @@ systemd-units
         version = "1.2.3"
         release = "202104070000.yuxzhu_test.p0"
         rpm.set_nvr(version, release)
-        maintainer_info = {
-            "product": "My Product",
-            "component": "My Component",
-            "subcomponent": "My Subcomponent",
-        }
-        rpm.get_maintainer_info = mock.MagicMock(return_value=maintainer_info)
+        rpm.get_jira_info = mock.MagicMock(return_value=("My Product", "My Component"))
         mocked_file = mocked_open.return_value.__aenter__.return_value
         mocked_file.readlines.return_value = """
 %global os_git_vars OS_GIT_VERSION='' OS_GIT_COMMIT='' OS_GIT_MAJOR='' OS_GIT_MINOR='' OS_GIT_TREE_STATE=''
@@ -272,7 +267,7 @@ Some description
         self.assertIn("Version:        1.2.3\n", specfile_content)
         self.assertIn("Release:        202104070000.yuxzhu_test.p0%{?dist}\n", specfile_content)
         self.assertIn("Source0:        foo-1.2.3.tar.gz\n", specfile_content)
-        self.assertIn("%description\n[Maintainer] product: My Product, component: My Component, subcomponent: My Subcomponent\n", specfile_content)
+        self.assertIn("%description\n[Maintainer] project: My Product, component: My Component\n", specfile_content)
         self.assertIn("%setup -q -n foo-1.2.3\n", specfile_content)
         self.assertIn("%autosetup -S git -n foo-1.2.3 -p1\n", specfile_content)
         self.assertIn("Version:        1.2.3\n", specfile_content)


### PR DESCRIPTION
- Migrate old bugzilla logic to be Jira based. 
- Consults prodsec database to determine component to Jira component mapping.
- Adds a new `hosts` section in doozer/settings.yaml to let us alias hostnames without checking them into git (avoid getting flagged by prodsec)