### PR TITLE
scan-sources: Detect member in from.builder

### DIFF
--- a/doozerlib/cli/scan_sources.py
+++ b/doozerlib/cli/scan_sources.py
@@ -130,6 +130,9 @@ def config_scan_source_changes(runtime: Runtime, ci_kubeconfig, as_yaml):
             base_image = image_meta.config["from"].member
             if base_image:
                 dependencies.add(base_image)
+            for builder in image_meta.config['from'].builder:
+                if builder.member:
+                    dependencies.add(builder.member)
             for dep_key in dependencies:
                 dep = runtime.image_map.get(dep_key)
                 if not dep:


### PR DESCRIPTION
`enterprise-console-builder` has this in their config:

```yaml
from:
  builder:
  - stream: golang
  - member: openshift-base-nodejs
  member: openshift-enterprise-base
```

The code so far did not look for `member` in `.from.builder`. This means that in the case of a rebuild of `openshift-base-nodejs` and `openshift-enterprise-console`, where nodejs succeeded but console failed, scans-sources will not discover that a rebuild is necessary.

With this patch, the following invocation says a rebuild is needed:
```sh
doozer -g openshift-4.12 --assembly stream -i openshift-enterprise-console -i ose-metallb -i openshift-base-nodejs config:scan-sources
```