### PR TITLE
fix get_maintainer_info is undefined error

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -2453,8 +2453,8 @@ class ImageDistGitRepo(DistGitRepo):
             owners = list(self.config.owners)
 
         # If upstream has not identified the BZ component, have the pipeline send them a nag note.
-        maintainer = self.metadata.get_maintainer_info()
-        if owners and not maintainer.get('component', None):
+        jira_project, jira_component = self.metadata.get_jira_info()
+        if jira_project == 'OCPBUGS' and jira_component == 'Unknown':
             week_number = date.today().isocalendar()[1]  # Determine current week number
             oit_path = dg_path.joinpath('.oit')
             util.mkdirs(oit_path)


### PR DESCRIPTION
This method has been removed by
https://github.com/openshift/doozer/pull/710/.

This PR changes it to the new method `get_jira_info`. Or we can completely remove the logic of notifying maintainers for missing component if this is not needed any more.