### PR TITLE
Remove command 'images:update-dockerfile'

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -183,7 +183,7 @@ class DistGitRepo(object):
                     if e.errno != errno.EEXIST:
                         raise
 
-                if fake_distgit and self.runtime.command in ['images:rebase', 'images:update-dockerfile']:
+                if fake_distgit and self.runtime.command == 'images:rebase':
                     cmd_list = ['mkdir', '-p', self.distgit_dir]
                     self.logger.info("Creating local build dir: {}".format(self.distgit_dir))
                     exectools.cmd_assert(cmd_list)

--- a/functional_tests/test_images.py
+++ b/functional_tests/test_images.py
@@ -95,20 +95,6 @@ class TestImages(unittest.TestCase):
         git_commit = ref.peel(pygit2.Commit)  # type: pygit2.Commit
         self.assertIn("test rebase", git_commit.message)
 
-    def test_images_update_dockerfile(self):
-        _, out, _ = run_doozer([
-            "--group=openshift-3.11",
-            "--images=aos3-installation",
-            "images:update-dockerfile",
-            "--message=test update dockerfile"
-        ])
-        working_dir = get_working_dir()
-        repo_path = os.path.join(working_dir, "distgits", "containers", "aos3-installation")
-        repo = pygit2.Repository(repo_path)
-        ref = repo.references["HEAD"].resolve()  # type: pygit2.Reference
-        git_commit = ref.peel(pygit2.Commit)  # type: pygit2.Commit
-        self.assertIn("test update dockerfile", git_commit.message)
-
     def test_images_revert(self):
         _, out, _ = run_doozer([
             "--group=openshift-3.11",


### PR DESCRIPTION
CLI command `images:update-dockerfile` is not used anywhere by automation and can be removed