### PR TITLE
Ensure project/component exists

### DIFF
--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -739,7 +739,7 @@ class Runtime(object):
         if major == 4 and minor < 6:
             raise ValueError("ocp-build-data/bug.yml is not expected to be available for 4.X versions < 4.6")
         bug_config = Model(self.gitdata.load_data(key='bug').data)
-        server = bug_config.jira_config.server or 'issues.redhat.com'
+        server = bug_config.jira_config.server or 'https://issues.redhat.com'
 
         token_auth = os.environ.get("JIRA_TOKEN")
         if not token_auth:


### PR DESCRIPTION
If a Jira project or component identified by prodsec data, open against OCPBUGS and warn, in the ticket, that the prodsec data should be updated.

Examples: 
- https://issues.redhat.com/browse/OCPBUGS-6100
- https://issues.redhat.com/browse/OCPBUGS-6103
