### PR TITLE
[OCPBUGS-6066] Add skips versions to CSV during rebase

### DIFF
--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -459,7 +459,7 @@ class Metadata(object):
                                              **list_builds_kwargs)
 
                 # Ensure the suffix ends the string OR at least terminated by a '.' .
-                # This latter check ensures that 'assembly.how' doesn't not match a build from
+                # This latter check ensures that 'assembly.how' doesn't match a build from
                 # "assembly.howdy'.
                 refined = [b for b in builds if b['nvr'].endswith(pattern_suffix) or f'{pattern_suffix}.' in b['nvr']]
 
@@ -502,7 +502,7 @@ class Metadata(object):
                     if not is_nvr:
                         return default_return()
                 else:
-                    # The image metadata (or, more likely, the currently assembly) has the image
+                    # The image metadata (or, more likely, the current assembly) has the image
                     # pinned. Return only the pinned NVR. When a child image is being rebased,
                     # it uses get_latest_build to find the parent NVR to use (if it is not
                     # included in the "-i" doozer argument). We need it to find the pinned NVR


### PR DESCRIPTION
Relevant change from `./doozer --working-dir with_skips --ignore-missing-base --group openshift-4.10 -i cluster-nfd-operator images:rebase --version v4.10.0 --release 999.p? --no-push --message 'test'`

```diff
--- a/manifests/4.10/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/4.10/manifests/nfd.clusterserviceversion.yaml
@@ -929,4 +929,46 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/cluster-nfd-operator
-  version: 4.10.0-202212061900
+  version: 4.10.0-999
+  skips:
+  - nfd.4.10.0-202112230034
+  - nfd.4.10.0-202208241855
+  - nfd.4.10.0-202111150453
+  - nfd.4.10.0-202201210948
+  - nfd.4.10.0-202211100520
+  - nfd.4.10.0-202203271029
+  - nfd.4.10.0-202201280546
+  - nfd.4.10.0-202206271723
+  - nfd.4.10.0-202205181948
+  - nfd.4.10.0-202212061900
+  - nfd.4.10.0-202211041323
+  - nfd.4.10.0-202111292203
+  - nfd.4.10.0-202206010607
+  - nfd.4.10.0-202206291026
+  - nfd.4.10.0-202204010807
+  - nfd.4.10.0-202202081751
+  - nfd.4.10.0-202210211005
+  - nfd.4.10.0-202202160023
+  - nfd.4.10.0-202211280957
+  - nfd.4.10.0-202207291908
+  - nfd.4.10.0-202202241648
+  - nfd.4.10.0-202204251358
+  - nfd.4.10.0-202203040217
+  - nfd.4.10.0-202211031007
+  - nfd.4.10.0-202201261535
+  - nfd.4.10.0-202111170619
+  - nfd.4.10.0-202206280938
+  - nfd.4.10.0-202203081809
+  - nfd.4.10.0-202210061808
+  - nfd.4.10.0-202205120735
+  - nfd.4.10.0-202202172102
+  - nfd.4.10.0-202203111548
+  - nfd.4.10.0-202201121612
+  - nfd.4.10.0-202208150436
+  - nfd.4.10.0-202209280142
+  - nfd.4.10.0-202210180818
+  - nfd.4.10.0-202202101606
+  - nfd.4.10.0-202202012317
+  - nfd.4.10.0-202204090935
+  - nfd.4.10.0-202207192148
+  - nfd.4.10.0-202201310820
\ No newline at end of file
```