### PR TITLE
not match slash characters

### DIFF
--- a/doozerlib/olm/bundle.py
+++ b/doozerlib/olm/bundle.py
@@ -393,7 +393,7 @@ class OLMBundle(object):
             return image
 
         new_contents = re.sub(
-            r'{}\/([^:]+):([^\'"\s]+)'.format(self.operator_csv_config['registry']),
+            r'{}\/([^:]+):([^\'"\\\s]+)'.format(self.operator_csv_config['registry']),
             collect_replaced_image,
             contents,
             flags=re.MULTILINE


### PR DESCRIPTION
[olm](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Folm_bundle/8912/) job failed due to pullspec shows in [examples](https://pkgs.devel.redhat.com/cgit/containers/cluster-nfd-operator/tree/manifests/4.9/manifests/nfd.clusterserviceversion.yaml?h=rhaos-4.9-rhel-8#n12) and contains slash in suffix we need to exclude