### PR TITLE
Migrate away from prodsec data for jira

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1097,10 +1097,9 @@ def images_print(runtime, short, show_non_release, show_base, output, label, pat
     {build} - Shorthand for {component}-{version}-{release} (e.g. container-engine-v3.6.173.0.25-1)
     {repository} - Shorthand for {image}:{version}-{release}
     {label} - The label you want to print from the Dockerfile (Empty string if n/a)
-    {bz_info} - All known BZ component information for the component
-    {bz_product} - The BZ product, if known
-    {bz_component} - The BZ component, if known
-    {bz_subcomponent} - The BZ subcomponent, if known
+    {jira_info} - All known BZ component information for the component
+    {jira_project} - The associated Jira project for bugs, if known
+    {jira_component} - The associated Jira project component, if known
     {upstream} - The upstream repository for the image
     {upstream_public} - The public upstream repository (if different) for the image
     {lf} - Line feed

--- a/doozerlib/cli/images_streams.py
+++ b/doozerlib/cli/images_streams.py
@@ -677,26 +677,29 @@ be reopened automatically.
         if potential_project != project or potential_component != component:
             description += f'''
 
-Important: Product Security has recorded in their ps_modules.json data that bugs
-for this component should be opened against Jira project "{potential_project}" and
+Important: ART has recorded in their product data that bugs for
+this component should be opened against Jira project "{potential_project}" and
 component "{potential_component}". This project or component does not exist. Jira
-should either be updated to include this component or an email should be sent to
-prodsec-openshift@redhat.com to have them update their data. Until this is done,
-ART issues against this component will be opened against OCPBUGS/Unknown --
-creating unnecessary work and delay.
+should either be updated to include this component or @release-artists should be
+notified of the proper mapping in the #aos-art Slack channel.
 
-Prodsec will need to know the product component name: {distgit_key} .
+Component name: {image_meta.get_component_name()} .
+Jira mapping: https://github.com/openshift/ocp-build-data/blob/main/product.yml
 '''
         elif potential_project == 'Unknown':
             description += f'''
 
-Important: Product Security maintains a mapping of OpenShift software components to
-Jira components in their ps_modules.json data for OpenShift. This component does not
-have a mapping in that data. Please email prodsec-openshift@redhat.com to ensure
-this component is registered. Until this is done, ART issues against
-this component will be opened against OCPBUGS/Unknown -- creating unnecessary work and delay.
+Important: ART maintains a mapping of OpenShift software components to
+Jira components. This component does not currently have an entry defined
+within that data.
+Contact @release-artists in the #aos-art Slack channel to inform them of
+the Jira project and component to use for this image.
 
-Prodsec will need to know the product component name: {distgit_key} .
+Until this is done, ART issues against this component will be opened
+against OCPBUGS/Unknown -- creating unnecessary processing work and delay.
+
+Component name: {image_meta.get_component_name()} .
+Jira mapping: https://github.com/openshift/ocp-build-data/blob/main/product.yml
 '''
 
         fields = {


### PR DESCRIPTION
Prodsec has requested they be dowstream of component Jira mapping data instead of the source of truth. The source of truth has historically been OWNERS files in component repos, but has now been established in https://github.com/openshift/ocp-build-data/blob/main/product.yml .