### PR TITLE
[ART-3324] Ignore disabled dependents

### DIFF
--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -27,7 +27,9 @@ class ImageMetadata(Metadata):
         self.dependencies: Set[str] = set()
         dependents = self.config.get('dependents', [])
         for d in dependents:
-            dependent: ImageMetadata = self.runtime.late_resolve_image(d, add=True)
+            dependent = self.runtime.late_resolve_image(d, add=True, required=False)
+            if not dependent:
+                continue
             dependent.dependencies.add(self.distgit_key)
             self.children.append(dependent)
         if clone_source:


### PR DESCRIPTION
Currently a disabled (or wip) image will be loaded anyway if it is listed as a dependent of an enabled image.

This PR changes the behavior to ignore disabled dependents unless `--load-disabled` or `--load-wip` option is specified.