### PR TITLE
[ART-6149] Comment on pr from job feature

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -35,6 +35,7 @@ from doozerlib.cli.rpms_build import rpms_build
 from doozerlib.cli.config_plashet import config_plashet
 from doozerlib.cli.release_calc_upgrade_tests import release_calc_upgrade_tests
 from doozerlib.cli.inspect_stream import inspect_stream
+from doozerlib.cli.job_pr_build_info import comment_from_job
 
 from doozerlib import coverity
 from doozerlib.exceptions import DoozerFatalError

--- a/doozerlib/cli/job_pr_build_info.py
+++ b/doozerlib/cli/job_pr_build_info.py
@@ -1,0 +1,27 @@
+import sys
+import click
+import yaml
+from doozerlib.cli import cli
+from doozerlib.comment_on_pr import CommentOnPr
+
+
+@cli.command("comment-on-pr:from-job",
+             short_help="Lists the PRs that need to be commented from the job id.")
+@click.option("-j", "--job", required=True, metavar='JOB',
+              help="Name of the job. Eg: ocp4/123")
+def comment_from_job(job: str):
+    """
+    Comment on PRs of images built from the job.
+
+    Steps:
+    - Gets the list of images built from the job, from art-dashboard-server API endpoint.
+    - Finds the PR number from the merge commit.
+    - Checks to see if the PR has already been commented by the bot. If it hasn't, send back the list of PRs to update.
+    """
+    job_name, job_id = job.split("/")
+    if job_name != "ocp4":
+        print("Can only process OCP4 jobs for now")
+        sys.exit(1)
+
+    result = CommentOnPr(job_id=job_id).run()
+    print(yaml.dump(result))

--- a/doozerlib/cli/job_pr_build_info.py
+++ b/doozerlib/cli/job_pr_build_info.py
@@ -3,6 +3,9 @@ import click
 import yaml
 from doozerlib.cli import cli
 from doozerlib.comment_on_pr import CommentOnPr
+from doozerlib.logutil import getLogger
+
+logger = getLogger(__name__)
 
 
 @cli.command("comment-on-pr:from-job",
@@ -20,7 +23,7 @@ def comment_from_job(job: str):
     """
     job_name, job_id = job.split("/")
     if job_name != "ocp4":
-        print("Can only process OCP4 jobs for now")
+        logger.error("Can only process OCP4 jobs for now")
         sys.exit(1)
 
     result = CommentOnPr(job_id=job_id).run()

--- a/doozerlib/comment_on_pr.py
+++ b/doozerlib/comment_on_pr.py
@@ -1,0 +1,136 @@
+import pprint
+import sys
+import requests
+import re
+import logging
+
+
+class CommentOnPr:
+    """
+    Comment on origin PR about the status of build, nightly, releases.
+    """
+
+    def __init__(self, job_id: int, logger=None):
+        self.art_dash_api_endpoint = "http://art-dash-server-aos-art-web.apps.ocp4.prod.psi.redhat.com/api/v1"
+        self.github_api_base_url_openshift = "https://api.github.com/repos/openshift"
+        self.job_id = job_id
+
+        self.logger = logger
+        if logger is None:
+            logging.basicConfig(level=logging.INFO)
+            self.logger = logging.getLogger()
+
+    def _pr_of_builds_from_job(self):
+        """
+        Get the PR urls of the build details of an images that are successfully built.
+
+        job_no: The jenkins job number
+        """
+        url = f"{self.art_dash_api_endpoint}/builds?jenkins_build_url__icontains=ocp4/{self.job_id}"
+        self.logger.debug(f"Querying ART Dash server with url: {url}")
+
+        response = requests.get(url)
+        if response.status_code != 200:
+            self.logger.error(f"ART DASH Server error. Status code: {response.status_code}")
+            sys.exit(1)
+
+        data = response.json()
+        self.logger.debug(f"Response: {pprint.pformat(data)}")
+
+        if data["count"] > 0:
+            pull_request_urls = []
+            results = data["results"]
+
+            for build in results:
+                if build["brew_task_state"] != "success":
+                    # Do not check for unsuccessful builds
+                    continue
+
+                build_commit_url = build["label_io_openshift_build_commit_url"]
+                build_id = build["build_0_id"]
+                distgit_name = build["dg_name"]
+
+                regex = r"^https:\/\/github\.com\/(?P<org>[a-z]+)\/(?P<repo_name>[a-z-]+)\/commit\/(?P<sha>\w+)$"
+                match = re.match(regex, build_commit_url)
+                self.logger.debug(f"regex matches: {pprint.pformat(match.groupdict())}")
+
+                _, self.repo_name, sha = match.groupdict().values()
+
+                github_api_url = f"{self.github_api_base_url_openshift}/{self.repo_name}/commits/{sha}/pulls"
+                self.logger.debug(f"Querying GitHub API with url: {github_api_url}")
+
+                pulls = requests.get(github_api_url)
+                if pulls.status_code != 200:
+                    self.logger.error(f"GitHub API error. Status code: {pulls.status_code}")
+                    sys.exit(1)
+
+                pulls = pulls.json()
+                self.logger.debug(f"Pull requests: {pprint.pformat(pulls)}")
+
+                if len(pulls) == 1:
+                    pull_url = pulls[0]["html_url"]
+                    pull_request_urls.append({"repo_name": self.repo_name, "pr": pull_url, "build_id": build_id,
+                                              "distgit_name": distgit_name})
+                else:
+                    self.logger.error("More than one PRs were found for a merge commit")
+            return pull_request_urls
+        else:
+            self.logger.info(f"No builds were found for job no: {self.job_id} ")
+
+    def _get_comments_from_pr(self, repo_name: str, pr_no: int):
+        """
+        Get the comments from a given pull request
+        """
+        github_api_url = f"{self.github_api_base_url_openshift}/{repo_name}/issues/{pr_no}/comments"
+        self.logger.debug(f"Querying GitHub API with url: {github_api_url}")
+
+        response = requests.get(github_api_url)
+        if response.status_code != 200:
+            self.logger.error(f"GitHub API error. Status code: {response.status_code}")
+            sys.exit(1)
+
+        comments = response.json()
+        self.logger.debug(f"Comments from PR: {pprint.pformat(comments)}")
+
+        return comments
+
+    def _check_if_pr_needs_reporting(self, repo_name: str, pr_no: int, type_: str):
+        """
+        Check the comments to see if the bot has already reported so as not to prevent spamming
+
+        repo_name: Name of the repository. Eg: console
+        pr_no: The Pull request ID/No
+        type_: The type of notification. PR | NIGHTLY | RELEASE
+        """
+
+        comments = self._get_comments_from_pr(repo_name, pr_no)
+
+        for comment in comments:
+            body = comment["body"]
+            self.logger.debug(f"Comment body: {body}")
+
+            if f"[ART PR {type_} NOTIFIER]" not in body:
+                return True
+        return False
+
+    def _check_builds(self):
+        """
+        Returns a list of repo PRs that needs reporting to.
+        """
+        data = self._pr_of_builds_from_job()
+        results = []
+        for dict_ in data:
+            repo_name, pull_request, build_id, distgit_name = dict_.values()
+            pr_no = pull_request.split("/")[-1]
+            self.logger.debug(f"repo_name: {repo_name}\n"
+                              f"pull_request: {pull_request}\n"
+                              f"build_id: {build_id}\n"
+                              f"pr_no: {pr_no}")
+
+            if self._check_if_pr_needs_reporting(repo_name, pr_no, "BUILD"):
+                results.append({"repo_name": repo_name, "pr_no": pr_no, "build_id": build_id,
+                                "distgit_name": distgit_name})
+        return results
+
+    def run(self):
+        return {"from_builds": self._check_builds()}

--- a/doozerlib/comment_on_pr.py
+++ b/doozerlib/comment_on_pr.py
@@ -2,7 +2,10 @@ import pprint
 import sys
 import requests
 import re
-import logging
+from doozerlib.logutil import getLogger
+
+ART_DASH_API_ENDPOINT = "http://art-dash-server-aos-art-web.apps.ocp4.prod.psi.redhat.com/api/v1"
+GITHUB_API_URL_REPOS = "https://api.github.com/repos"
 
 
 class CommentOnPr:
@@ -11,14 +14,8 @@ class CommentOnPr:
     """
 
     def __init__(self, job_id: int, logger=None):
-        self.art_dash_api_endpoint = "http://art-dash-server-aos-art-web.apps.ocp4.prod.psi.redhat.com/api/v1"
-        self.github_api_base_url_openshift = "https://api.github.com/repos/openshift"
         self.job_id = job_id
-
-        self.logger = logger
-        if logger is None:
-            logging.basicConfig(level=logging.INFO)
-            self.logger = logging.getLogger()
+        self.logger = logger if logger else getLogger(__name__)
 
     def _pr_of_builds_from_job(self):
         """
@@ -26,7 +23,7 @@ class CommentOnPr:
 
         job_no: The jenkins job number
         """
-        url = f"{self.art_dash_api_endpoint}/builds?jenkins_build_url__icontains=ocp4/{self.job_id}"
+        url = f"{ART_DASH_API_ENDPOINT}/builds?jenkins_build_url__icontains=ocp4/{self.job_id}"
         self.logger.debug(f"Querying ART Dash server with url: {url}")
 
         response = requests.get(url)
@@ -49,15 +46,16 @@ class CommentOnPr:
                 build_commit_url = build["label_io_openshift_build_commit_url"]
                 build_id = build["build_0_id"]
                 distgit_name = build["dg_name"]
+                nvr = build["build_0_nvr"]
 
-                regex = r"^https:\/\/github\.com\/(?P<org>[a-z]+)\/(?P<repo_name>[a-z-]+)\/commit\/(?P<sha>\w+)$"
+                regex = r"^https:\/\/github\.com\/(?P<org>[a-z-]+)\/(?P<repo_name>[a-z-]+)\/commit\/(?P<sha>\w+)$"
                 match = re.match(regex, build_commit_url)
                 self.logger.debug(f"regex matches: {pprint.pformat(match.groupdict())}")
 
-                _, self.repo_name, sha = match.groupdict().values()
+                org, repo_name, sha = match.groupdict().values()
 
-                github_api_url = f"{self.github_api_base_url_openshift}/{self.repo_name}/commits/{sha}/pulls"
-                self.logger.debug(f"Querying GitHub API with url: {github_api_url}")
+                github_api_url = f"{GITHUB_API_URL_REPOS}/{org}/{repo_name}/commits/{sha}/pulls"
+                self.logger.info(f"Querying GitHub API with url: {github_api_url}")
 
                 pulls = requests.get(github_api_url)
                 if pulls.status_code != 200:
@@ -65,24 +63,24 @@ class CommentOnPr:
                     sys.exit(1)
 
                 pulls = pulls.json()
-                self.logger.debug(f"Pull requests: {pprint.pformat(pulls)}")
+                self.logger.info(f"Pull requests: {pprint.pformat(pulls)}")
 
                 if len(pulls) == 1:
                     pull_url = pulls[0]["html_url"]
-                    pull_request_urls.append({"repo_name": self.repo_name, "pr": pull_url, "build_id": build_id,
-                                              "distgit_name": distgit_name})
+                    pull_request_urls.append({"org": org, "repo_name": repo_name, "pr": pull_url, "build_id": build_id,
+                                              "distgit_name": distgit_name, "nvr": nvr})
                 else:
                     self.logger.error("More than one PRs were found for a merge commit")
             return pull_request_urls
         else:
             self.logger.info(f"No builds were found for job no: {self.job_id} ")
 
-    def _get_comments_from_pr(self, repo_name: str, pr_no: int):
+    def _get_comments_from_pr(self, org: str, repo_name: str, pr_no: int):
         """
         Get the comments from a given pull request
         """
-        github_api_url = f"{self.github_api_base_url_openshift}/{repo_name}/issues/{pr_no}/comments"
-        self.logger.debug(f"Querying GitHub API with url: {github_api_url}")
+        github_api_url = f"{GITHUB_API_URL_REPOS}/{org}/{repo_name}/issues/{pr_no}/comments"
+        self.logger.info(f"Querying GitHub API with url: {github_api_url}")
 
         response = requests.get(github_api_url)
         if response.status_code != 200:
@@ -94,7 +92,7 @@ class CommentOnPr:
 
         return comments
 
-    def _check_if_pr_needs_reporting(self, repo_name: str, pr_no: int, type_: str):
+    def _check_if_pr_needs_reporting(self, org: str, repo_name: str, pr_no: int, type_: str):
         """
         Check the comments to see if the bot has already reported so as not to prevent spamming
 
@@ -103,15 +101,15 @@ class CommentOnPr:
         type_: The type of notification. PR | NIGHTLY | RELEASE
         """
 
-        comments = self._get_comments_from_pr(repo_name, pr_no)
+        comments = self._get_comments_from_pr(org, repo_name, pr_no)
 
         for comment in comments:
             body = comment["body"]
             self.logger.debug(f"Comment body: {body}")
 
-            if f"[ART PR {type_} NOTIFIER]" not in body:
-                return True
-        return False
+            if f"[ART PR {type_} NOTIFIER]" in body:
+                return False
+        return True
 
     def _check_builds(self):
         """
@@ -120,16 +118,19 @@ class CommentOnPr:
         data = self._pr_of_builds_from_job()
         results = []
         for dict_ in data:
-            repo_name, pull_request, build_id, distgit_name = dict_.values()
+            org, repo_name, pull_request, build_id, distgit_name, nvr = dict_.values()
             pr_no = pull_request.split("/")[-1]
-            self.logger.debug(f"repo_name: {repo_name}\n"
-                              f"pull_request: {pull_request}\n"
-                              f"build_id: {build_id}\n"
-                              f"pr_no: {pr_no}")
+            self.logger.info(f"repo_name: {repo_name}\n"
+                             f"org: {org}\n"
+                             f"pull_request: {pull_request}\n"
+                             f"build_id: {build_id}\n"
+                             f"pr_no: {pr_no}\n"
+                             f"distgit_name: {distgit_name}\n"
+                             f"nvr: {nvr}")
 
-            if self._check_if_pr_needs_reporting(repo_name, pr_no, "BUILD"):
-                results.append({"repo_name": repo_name, "pr_no": pr_no, "build_id": build_id,
-                                "distgit_name": distgit_name})
+            if self._check_if_pr_needs_reporting(org, repo_name, pr_no, "BUILD"):
+                results.append({"org": org, "repo_name": repo_name, "pr_no": pr_no, "pr_url": pull_request,
+                                "build_id": build_id, "distgit_name": distgit_name, "nvr": nvr})
         return results
 
     def run(self):


### PR DESCRIPTION
Comment on PRs of images built from the job.

Steps:
- Gets the list of images built from the job, from art-dashboard-server API endpoint.
- Finds the PR number from the merge commit.
- Checks to see if the PR has already been commented by the bot. If it hasn't, send back the list of PRs to update.

Eg:
`./doozer comment-on-pr:from-job --job ocp4/40183
`
Prints:
`{'from_builds': [{'repo_name': 'network-tools', 'pr_no': '61'}, {'repo_name': 'ovn-kubernetes', 'pr_no': '1543'}]}
`

For https://github.com/openshift/aos-cd-jobs/pull/3538