### PR TITLE
rpms:build: Fix hotfix tagging for multiple targets

### DIFF
--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -268,6 +268,12 @@ class Metadata(object):
     def candidate_brew_tags(self):
         return [self.candidate_brew_tag()]
 
+    def hotfix_brew_tags(self):
+        """ Returns "hotfix" Brew tags for this component.
+        "Hotfix" tags are used to prevent garbage collection.
+        """
+        return [self.hotfix_brew_tag()]
+
     def get_arches(self):
         """
         :return: Returns the list of architecture this image/rpm should build for. This is an intersection

--- a/doozerlib/rpm_builder.py
+++ b/doozerlib/rpm_builder.py
@@ -256,10 +256,11 @@ class RPMBuilder:
                     nvrs = [task.result[0]["nvr"] for task in multicall_tasks]
                     if self._runtime.hotfix:
                         # Tag rpms so they don't get garbage collected.
-                        self._runtime.logger.info(f'Tagging build(s) {nvrs} with {rpm.hotfix_brew_tag()} to prevent garbage collection')
+                        hotfix_tags = rpm.hotfix_brew_tags()
+                        self._runtime.logger.info(f'Tagging build(s) {nvrs} info {hotfix_tags} to prevent garbage collection')
                         with koji_api.multicall(strict=True) as m:
-                            for nvr in nvrs:
-                                m.tagBuild(rpm.hotfix_brew_tag(), nvr)
+                            for nvr, hotfix_tag in zip(nvrs, hotfix_tags):
+                                m.tagBuild(hotfix_tag, nvr)
 
                 logger.info("Successfully built rpm: %s", rpm.rpm_name)
                 rpm.build_status = True

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -233,6 +233,13 @@ class RPMMetadata(Metadata):
     def candidate_brew_tags(self):
         return self.targets.copy()
 
+    def hotfix_brew_tags(self):
+        hotfix_tags = []
+        for target in self.targets:
+            base_tag = target[:-len("-candidate")] if target.endswith("-candidate") else target
+            hotfix_tags.append(f"{base_tag}-hotfix")
+        return hotfix_tags
+
     def _default_brew_target(self):
         """ Returns derived brew target name from the distgit branch name
         """


### PR DESCRIPTION
Some packages, like `microshift`, has 2 targets (one for rhel 8 and another for rhel 9). For non-stream build, we need to tag the resulting builds into `rhaos-4.y-rhel-z-hotfix` to prevent gabbage collection, however Brew no longer allows us to use a single `-hotfix` tag.

With this PR, builds will be tagged into target-specific hotfix tags, e.g. `rhaos-4.13-rhel-9-hotfix` and `rhaos-4.13-rhel-8-hotfix` in order to work around this limitation.