### PR TITLE
[ART-6053] rhcos: ignore RPMs missing from brew

### DIFF
--- a/doozerlib/rhcos.py
+++ b/doozerlib/rhcos.py
@@ -358,6 +358,7 @@ class RHCOSBuildInspector:
                     rpm_def = koji_api.getRPM(nvra, strict=True)
                 except koji.GenericError as e:
                     if self.runtime.group_config.rhcos.allow_missing_brew_rpms and "No such rpm" in str(e):
+                        self.logger.warning("Failed to find RPM %s in Brew", nvra, exc_info=True)
                         continue  # if conigured, just skip RPMs brew doesn't know about
                     raise Exception(f"Failed to find RPM {nvra} in brew: {e}")
 

--- a/doozerlib/rhcos.py
+++ b/doozerlib/rhcos.py
@@ -357,7 +357,7 @@ class RHCOSBuildInspector:
                 try:
                     rpm_def = koji_api.getRPM(nvra, strict=True)
                 except koji.GenericError as e:
-                    if self.runtime.group_config.rhcos.allow_missing_brew_rpms:
+                    if self.runtime.group_config.rhcos.allow_missing_brew_rpms and "No such rpm" in str(e):
                         continue  # if conigured, just skip RPMs brew doesn't know about
                     raise Exception(f"Failed to find RPM {nvra} in brew: {e}")
 


### PR DESCRIPTION
[test run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/31280/console)
enables https://github.com/openshift/ocp-build-data/pull/2619